### PR TITLE
Dion2 with shard-independent update route added

### DIFF
--- a/configs/debug.yaml
+++ b/configs/debug.yaml
@@ -1,0 +1,42 @@
+
+# — Model —
+model_dim: 768
+n_layer: 12
+n_head: 6
+sequence_length: 128 
+
+# — Batching & Training — 
+num_iterations: 3000
+batch_size: 1024
+device_batch_size: 256
+
+# — Learning‐rate schedule —
+warmup_ratio: 0.0
+warmdown_ratio: 0.2
+
+# — Validation & Checkpointing —
+val_loss_every: 125
+val_tokens: 10485760 
+
+# — Weights & Biases logging —
+wandb_project_name: debug
+wandb_job_name: null
+no_wandb: false
+
+# — Miscellaneous flags —
+debug: false
+no_compile: false
+
+# — Distributed training — 
+fs_size: 4     # FSDP size 
+
+# — Optimizer & Hyperparameters —
+optimizer: dion2
+scalar_opt: lion
+mu: 0.95
+weight_decay: 0.01
+ortho_fraction: 0.25
+lr: 0.02 
+  
+shard_independent: true
+no_validation: false

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -587,14 +587,16 @@ def normuon_normalization(
     """
     V_dtype = V[0].dtype
     U = [u.to(dtype=V_dtype) for u in U]
-    
+
     norm_U = [
         u.norm(p=2, dim=(-2, -1), keepdim=True) for u in U
     ]  # list of ||u||_F, shape [*, 1, 1]
 
     U_sq = torch._foreach_mul(U, U)  # list of u*u, same shapes as U
-    neuron_norms = [u_sq.mean(dim=-1, keepdim=True) for u_sq in U_sq]  # Shape: [*, rows, 1]
-    
+    neuron_norms = [
+        u_sq.mean(dim=-1, keepdim=True) for u_sq in U_sq
+    ]  # Shape: [*, rows, 1]
+
     torch._foreach_lerp_(
         V, neuron_norms, 1 - muon_beta2
     )  # Update variance neuron buffer
@@ -606,17 +608,17 @@ def normuon_normalization(
     norm_U_new = [
         nu.norm(p=2, dim=(-2, -1), keepdim=True) for nu in normalized_U
     ]  # list of ||normalized_u||_F, shape [*, 1, 1]
-    
+
     # Protect against division by zero when norm_U_new is zero.
     # This can happen when U is all zeros (e.g., zero gradients from zero-initialized weights).
     # In this case, norm_U is also zero, so after clamping norm_U_new to ε the ratio becomes 0/ε ≈ 0,
     # and normalized_U * ratio correctly remains zero, preserving the zero state.
     norm_U_new_safe = [nu.clamp(min=1e-8) for nu in norm_U_new]
-    
+
     ratio = torch._foreach_div(
         norm_U, norm_U_new_safe
     )  # list of ||u||_F / ||normalized_u||_F, shape [*, 1, 1]
-    
+
     torch._foreach_mul_(normalized_U, ratio)  # normalized_u[i] *= ratio
 
     return normalized_U


### PR DESCRIPTION
This PR adds a shard_independent argument to the Dion2 optimizer, giving users control over how top-K row selection interacts with FSDP sharding.

##  1. Sharding-independent row selection for FSDP
Dion2 selects a subset of rows (top-K by L1 norm) for orthogonalization at each step. When parameters are sharded across devices, there's a design choice: should selection happen on local shards or on the full matrix?

### Options

- `shard_independent=False` (default)
  - Behavior: Each shard independently selects its top-K rows based on local momentum
  - Pros: Only communicates selected submatrices → reduced communication cost
  - Cons: Selection depends on sharding configuration.
  - **Note: Empirically, this dependency doesn't appear to affect training outcomes**

- `shard_independent=True`
  - Behavior: All-to-all gathers the full matrix, then selects top-K rows "globally" on each matrix
  - Pros: Algorithm behavior is identical regardless of sharding configuration
  - Cons: Requires communicating full matrices (communication cost of this path matches that of Muon)
  
## 2. Row-wise Selection Only

We now restrict Dion2's selection to row-wise selection (i.e., `select_dim=-2`). This ensures the selection semantics match "neuron-wise" selection, since linear layers have shape (output, input) — each row corresponds to one output neuron.
Previously, the code would choose between row or column selection based on matrix shape or sharding configuration. This change makes the behavior more interpretable and consistent.