### PR TITLE
Group all same-shape parameters into a single AsyncTask per shape group

### DIFF
--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -308,33 +308,23 @@ class NorMuon(Optimizer):
                     self._get_shard_info(params[0], group)
                 )
 
-                # 3D tensors sharded along batch dim: can't mega-batch, process individually
+                megabatch_args = normuon_update_args
                 if is_batch_sharded and not is_matrix_sharded:
-                    for x, g, m, v in zip(
-                        params, gradients, momentums, variances_neuron
-                    ):
-                        yield AsyncTask(
-                            normuon_update_batch_async(
-                                X=[x],
-                                G=[g],
-                                M=[m],
-                                V=[v],
-                                shard_dim=None,
-                                **normuon_update_args,
-                            )
-                        )
-                # Mega-batch: all same-shape params in ONE task
-                else:
-                    yield AsyncTask(
-                        normuon_update_megabatch_async(
-                            X=params,
-                            G=gradients,
-                            M=momentums,
-                            V=variances_neuron,
-                            shard_dim=sharded_tensor_dim,
-                            **normuon_update_args,
-                        )
+                    # Batch-sharded 3D tensors already contain whole local matrices,
+                    # so we can stack them and run the local megabatch path without
+                    # cross-rank communication.
+                    megabatch_args = {**normuon_update_args, "process_group": None}
+
+                yield AsyncTask(
+                    normuon_update_megabatch_async(
+                        X=params,
+                        G=gradients,
+                        M=momentums,
+                        V=variances_neuron,
+                        shard_dim=sharded_tensor_dim,
+                        **megabatch_args,
                     )
+                )
 
     def _create_lion_tasks(
         self,


### PR DESCRIPTION
When profiling NorMuon with FSDP2 on a 12-layer/768-hidden model across 2 GPUs, I noticed that optimizer.step was dominated by GPU idle time between dozens of small, sequential communication rounds. Each world_size-sized batch of same-shape parameters triggered its own pair of all-to-all calls and Newton-Schulz iteration, resulting in ~36 separate rounds per step with visible gaps on the Chrome trace between each one.

This PR collapses all same-shape parameters into a single "mega-batch" per shape group, bringing that down to ~3 rounds (one per unique weight shape in a standard transformer).

**What changed**
Mega-batched communication (normuon_update_megabatch_async)
Instead of processing world_size matrices at a time through all-to-all → Newton-Schulz → all-to-all, we now:

**Stack all N same-shape local shards into 3D tensors**
Do one all-to-all to redistribute the full stack
Run Newton-Schulz on a [N/world_size, rows, cols] batch (already supported by the existing NS implementations since they use dim=(-2,-1) norms and @ broadcasting)
Do one all-to-all back
The non-sharded (DDP-style) path gets the same treatment with all-gather, and single-GPU also benefits from batched NS.

**Stacked normalization kernel (normuon_normalization_stacked)**
The original normuon_normalization operated on a List[Tensor] using torch._foreach_* ops. With 48 attention weight matrices, that's 48-element foreach calls — each one launching separate kernels per tensor. The new version stacks everything into a single [N, rows, cols] tensor and does plain tensor ops, which torch.compile fuses into far fewer kernels.

Refactored _create_normuon_tasks
Extracted _get_shard_info as a helper method (was duplicated inline for every batch). The task creation now groups parameters by (shape, sharding, dtype) and yields one AsyncTask per group rather than per world_size-chunk.

**Backward compatibility**
The old normuon_update_batch_async and normuon_normalization are still present and used for the batch-sharded 3D tensor edge case
The async yield points are preserved at the same communication boundaries, so the AsyncRuntime overlap behavior is unchanged
All existing tests pass
Expected impact
For a typical transformer with 3 distinct weight shapes:

Communication rounds: O(num_params / world_size) → O(num_shapes), e.g. 36 → 3
Kernel launches: foreach over N-element lists → single stacked tensor ops
Newton-Schulz: N separate 2D calls → one batched 3D call with better occupancy
The actual speedup will depend on model size and world_size — larger models with more layers benefit more since there are more same-shape matrices to batch together.
**BEOFRE**
<img width="1154" height="729" alt="Screenshot 2026-02-23 at 21 13 34" src="https://github.com/user-attachments/assets/878b92a2-f3b0-4a9d-9f4c-bbd62a37e398" />
**AFTER**
<img width="971" height="725" alt="Screenshot 2026-02-23 at 21 09 59" src="https://github.com/user-attachments/assets/2d9c01ec-da1c-4cce-babf-88b30d95817f" />


Also the loss curve matches perfectly.