### PR TITLE
Refactor Dion2 and NorMuon to share a megabatch base class

### DIFF
--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -42,8 +42,6 @@ class Dion2(DistributedOrthoBase):
     Dion2 optimizer by Ahn et al.: TBD
     """
 
-    _algo_name = "dion2"
-
     def __init__(
         self,
         params: ParamsT,
@@ -88,7 +86,7 @@ class Dion2(DistributedOrthoBase):
             step=0,
         )
         super().__init__(
-            params, distributed_mesh, defaults,
+            params, distributed_mesh, "dion2", defaults,
             use_triton=use_triton, newton_schulz_func=newton_schulz_func,
         )
         self.verbose = verbose

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -20,20 +20,20 @@ class DistributedOrthoBase(Optimizer):
     Handles distributed setup, Newton-Schulz config, step orchestration,
     shard detection, and scalar optimizer tasks (Lion, AdamW).
 
-    Subclasses must set ``_algo_name`` and implement ``_create_ortho_tasks()``.
+    Subclasses must implement ``_create_ortho_tasks()``.
     """
-
-    _algo_name: str
 
     def __init__(
         self,
         params: ParamsT,
         distributed_mesh: Optional[Union[DeviceMesh, ProcessGroup]],
+        algo_name: str,
         defaults: dict,
         use_triton: bool = False,
         newton_schulz_func: Optional[Callable] = None,
     ):
         super().__init__(params, defaults)
+        self._algo_name = algo_name
 
         # Distributed configuration
         if isinstance(distributed_mesh, DeviceMesh):
@@ -240,10 +240,11 @@ def megabatch_orthogonalize_async(
     """
     Shared megabatch communication + Newton-Schulz orthogonalization.
 
-    Yields at async communication points for use with AsyncRuntime.
-    Returns the orthogonalized list of tensors.
-
-    Use via ``result = yield from megabatch_orthogonalize_async(...)``.
+    This is a generator that yields at async communication points and uses
+    ``return value`` to pass the result back to the caller. In Python, ``return``
+    inside a generator raises ``StopIteration(value)``, and the caller recovers
+    the value via ``result = yield from megabatch_orthogonalize_async(...)``.
+    The ``yield from`` transparently forwards intermediate yields to AsyncRuntime.
 
     Args:
         U: List of tensors to orthogonalize (all same shape).
@@ -258,13 +259,17 @@ def megabatch_orthogonalize_async(
     """
     N = len(U)
 
-    if comm_dim is not None and process_group is not None:
-        # --- Mega-batched sharded FSDP2 path ---
+    # Pad to divisible by world_size (needed by both distributed paths)
+    if process_group is not None and N > 1:
         pad_n = (world_size - N % world_size) % world_size
         U_work = U + [torch.zeros_like(U[0])] * pad_n if pad_n > 0 else U
         N_total = len(U_work)
         per_rank = N_total // world_size
+    else:
+        U_work = U
 
+    if comm_dim is not None and process_group is not None:
+        # --- Mega-batched sharded FSDP2 path ---
         input_chunks = [
             torch.stack(U_work[r * per_rank : (r + 1) * per_rank])
             for r in range(world_size)
@@ -303,11 +308,6 @@ def megabatch_orthogonalize_async(
 
     elif N > 1 and process_group is not None:
         # --- Mega-batched non-sharded path ---
-        pad_n = (world_size - N % world_size) % world_size
-        U_work = U + [torch.zeros_like(U[0])] * pad_n if pad_n > 0 else U
-        N_total = len(U_work)
-        per_rank = N_total // world_size
-
         start = device_rank * per_rank
         my_matrices = torch.stack(U_work[start : start + per_rank])
         my_matrices = muon_update_newton_schulz(

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -49,8 +49,6 @@ class NorMuon(DistributedOrthoBase):
     NorMuon optimizer: https://arxiv.org/abs/2510.05491
     """
 
-    _algo_name = "normuon"
-
     def __init__(
         self,
         params: ParamsT,
@@ -97,7 +95,7 @@ class NorMuon(DistributedOrthoBase):
             adjust_lr=adjust_lr,
         )
         super().__init__(
-            params, distributed_mesh, defaults,
+            params, distributed_mesh, "normuon", defaults,
             use_triton=use_triton, newton_schulz_func=newton_schulz_func,
         )
 


### PR DESCRIPTION
## Summary
- Extracts duplicated infrastructure between NorMuon and Dion2 into `MegabatchMuonBase`: distributed setup, Newton-Schulz config, step orchestration, shard detection, Lion/AdamW tasks
- Extracts the duplicated megabatch communication pattern into a shared `megabatch_orthogonalize_async` generator that both optimizers delegate to via `yield from`
- Each optimizer retains only its unique algorithmic logic:
  - **NorMuon**: pre-orthogonalize (momentum), neuron-wise normalization, post-orthogonalize
  - **Dion2**: submatrix selection, error feedback, indexed weight updates
- Dion2 now uses megabatching (groups all same-shape params into a single AsyncTask), reducing communication rounds from O(N/world_size) to O(1) per shape group
- **normuon.py + dion2.py**: 1,677 → 1,022 lines (655 fewer, ~39% reduction)

## Test plan
- [ ] Verify single-GPU Dion2 training matches pre-refactor
- [ ] Verify single-GPU NorMuon training matches pre-refactor
- [ ] Test multi-GPU DDP path (non-sharded all-gather)
- [ ] Test multi-GPU FSDP2 path (sharded all-to-all)
- [ ] Test batch-sharded 3D tensors (local-only path)
- [ ] Test with mixed parameter shapes (multiple shape groups)