### PR TITLE
Migrate Muon to DistributedOrthoBase with megabatching

### DIFF
--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -7,9 +7,13 @@ from torch.distributed.tensor import DeviceMesh, DTensor
 from torch.optim.optimizer import ParamsT
 from typing import Callable, Generator, List, Optional, Tuple, Union
 
-from .megabatch_base import DistributedOrthoBase, megabatch_orthogonalize_async
+from .megabatch_base import (
+    DistributedOrthoBase,
+    megabatch_orthogonalize_async,
+    adjust_lr_spectral_norm,
+    adjust_lr_rms_norm,
+)
 from .opt_utils import AsyncTask, to_local
-from .muon import adjust_lr_spectral_norm, adjust_lr_rms_norm
 
 
 class Dion2(DistributedOrthoBase):

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -1,3 +1,4 @@
+import math
 import torch
 import torch.distributed as dist
 from collections import defaultdict
@@ -15,7 +16,6 @@ from .newton_schulz_triton import (
 )
 from .opt_utils import AsyncRuntime, AsyncTask, to_local
 from .scalar_opts import adamw_update_foreach_async, lion_update_foreach_async
-from .muon import muon_update_newton_schulz, adjust_lr_spectral_norm, adjust_lr_rms_norm
 
 
 class DistributedOrthoBase(Optimizer):
@@ -64,7 +64,7 @@ class DistributedOrthoBase(Optimizer):
             )
         self._distributed_mesh = distributed_mesh
 
-        # Newton-Schulz configuration
+        # Orthogonalization function configuration
         if newton_schulz_func is not None:
             if not callable(newton_schulz_func):
                 raise TypeError(
@@ -269,7 +269,7 @@ def megabatch_orthogonalize_async(
     N = len(U)
 
     # Pad to divisible by world_size (needed by both distributed paths)
-    if process_group is not None and N > 1:
+    if process_group is not None and (N > 1 or comm_dim is not None):
         pad_n = (world_size - N % world_size) % world_size
         U_work = U + [torch.zeros_like(U[0])] * pad_n if pad_n > 0 else U
         N_total = len(U_work)
@@ -356,3 +356,42 @@ def megabatch_orthogonalize_async(
             epsilon=epsilon,
         )
         return [stacked[i] for i in range(N)]
+
+
+def muon_update_newton_schulz(
+    X: Tensor,
+    newton_schulz_func: Callable,
+    flatten: bool,
+    epsilon: Tensor,
+) -> Tensor:
+    """
+    Flatten the input tensor if needed and call the Newton-Schulz function.
+    """
+    original_shape = X.shape
+    if flatten and X.ndim >= 3:
+        X = X.flatten(start_dim=1)
+    elif X.ndim >= 4:
+        X = X.flatten(end_dim=-3)
+
+    return newton_schulz_func(X, epsilon=epsilon).reshape(original_shape)
+
+
+def adjust_lr_rms_norm(lr, param_shape, flatten):
+    """Adjust learning rate for constant element-wise RMS norm."""
+    if flatten:
+        fan_out = param_shape[0]
+        fan_in = math.prod(param_shape[1:])
+    else:
+        fan_out, fan_in = param_shape[-2:]
+    adjusted_ratio = 0.2 * math.sqrt(max(fan_out, fan_in))
+    return lr * adjusted_ratio
+
+
+def adjust_lr_spectral_norm(lr, param_shape, flatten):
+    """Adjust from spectral norm 1 to RMS operator norm 1."""
+    if flatten:
+        fan_out = param_shape[0]
+        fan_in = math.prod(param_shape[1:])
+    else:
+        fan_out, fan_in = param_shape[-2:]
+    return lr * math.sqrt(fan_out / fan_in)

--- a/dion/muon.py
+++ b/dion/muon.py
@@ -1,29 +1,22 @@
-import math
 import torch
-import torch.distributed as dist
-from itertools import chain
+from collections import defaultdict
 from torch import Tensor
 from torch.distributed import ProcessGroup
 from torch.distributed.tensor import DeviceMesh, DTensor
-from torch.optim.optimizer import Optimizer, ParamsT
+from torch.optim.optimizer import ParamsT
 from typing import Callable, Generator, List, Optional, Tuple, Union
 
-from .newton_schulz_triton import (
-    TRITON_AVAILABLE,
-    newton_schulz_triton,
-    zeropower_via_newtonschulz5,
+from .megabatch_base import (
+    DistributedOrthoBase,
+    megabatch_orthogonalize_async,
+    muon_update_newton_schulz,
+    adjust_lr_spectral_norm,
+    adjust_lr_rms_norm,
 )
-from .opt_utils import (
-    AsyncRuntime,
-    AsyncTask,
-    create_param_batches,
-    pad_batch,
-    to_local,
-)
-from .scalar_opts import adamw_update_foreach_async, lion_update_foreach_async
+from .opt_utils import AsyncTask, to_local
 
 
-class Muon(Optimizer):
+class Muon(DistributedOrthoBase):
     """
     Distributed Muon optimizer for PyTorch FSDP2. Also compatible with DDP.
 
@@ -48,7 +41,7 @@ class Muon(Optimizer):
             False: Tensors are not flattened. 3D+ tensors are treated as batches of 2D matrices.
         use_triton: Whether to use Triton kernel for Newton-Schulz. Ignored if custom function is provided.
         newton_schulz_func: Use a custom Newton-Schulz function for orthogonalization.
-            Signature is `func(input: Tensor, epsilon: float) -> Tensor`.
+            Signature is ``func(input: Tensor, epsilon: float) -> Tensor``.
 
     Muon optimizer algorithm by Keller Jordan: https://kellerjordan.github.io/posts/muon/
     FSDP2 Muon uses all-to-all communications: https://www.essential.ai/blog/infra
@@ -70,7 +63,6 @@ class Muon(Optimizer):
         use_triton: bool = False,
         newton_schulz_func: Optional[Callable] = None,
     ):
-        # Check hyperparameters
         if lr < 0.0:
             raise ValueError(f"Invalid learning rate: {lr}")
         if mu < 0.0:
@@ -82,7 +74,6 @@ class Muon(Optimizer):
                 f"Invalid adjust_lr value: {adjust_lr}. Must be 'spectral_norm', 'rms_norm', or None."
             )
 
-        # Default arguments for each param group
         defaults = dict(
             lr=lr,
             mu=mu,
@@ -97,111 +88,20 @@ class Muon(Optimizer):
             flatten=flatten,
             adjust_lr=adjust_lr,
         )
-        super().__init__(params, defaults)
+        super().__init__(
+            params, distributed_mesh, "muon", defaults,
+            use_triton=use_triton, newton_schulz_func=newton_schulz_func,
+        )
 
-        # Distributed configuration
-        if isinstance(distributed_mesh, DeviceMesh):
-            if distributed_mesh.ndim != 1:
-                raise ValueError(
-                    f"Only 1D DeviceMesh is supported, but got {distributed_mesh.ndim}D. For HSDP, provide the 1D sharded sub-mesh."
-                )
-            self._device_rank = distributed_mesh.get_local_rank()
-            self._world_size = distributed_mesh.size()
-            self._process_group = distributed_mesh.get_group()
-        elif isinstance(distributed_mesh, ProcessGroup):
-            self._device_rank = dist.get_rank(distributed_mesh)
-            self._world_size = dist.get_world_size(distributed_mesh)
-            self._process_group = distributed_mesh
-        elif distributed_mesh is None:
-            self._device_rank = 0
-            self._world_size = 1
-            self._process_group = None
-        else:
-            raise TypeError(
-                f"Invalid distributed_mesh type: {type(distributed_mesh)}. Expected DeviceMesh or ProcessGroup."
-            )
-        self._distributed_mesh = distributed_mesh
-
-        # Newton-Schulz configuration
-        if newton_schulz_func is not None:
-            if not callable(newton_schulz_func):
-                raise TypeError(
-                    f"newton_schulz_func must be a callable function, got {type(newton_schulz_func)}"
-                )
-            self._newton_schulz_func = newton_schulz_func
-        elif use_triton:
-            if not TRITON_AVAILABLE:
-                raise ImportError(
-                    "use_triton=True requires the 'triton' package, which is not installed. "
-                    "Install it with: pip install dion[triton]  (or: pip install triton)"
-                )
-            self._newton_schulz_func = newton_schulz_triton
-        else:
-            self._newton_schulz_func = zeropower_via_newtonschulz5
-
-    @torch.no_grad()
-    def step(self, closure=None):
-        """
-        Perform a single optimization step.
-        """
-        loss = None
-        if closure is not None:
-            with torch.enable_grad():
-                loss = closure()
-
-        muon_groups = []
-        lion_groups = []
-        adamw_groups = []
-
-        for group in self.param_groups:
-            # Increment step
-            group["step"] += 1
-
-            # Split parameter groups by algorithm
-            algo = group["algorithm"]
-            if algo == "muon":
-                muon_groups.append(group)
-            elif algo == "lion":
-                lion_groups.append(group)
-            elif algo == "adamw":
-                adamw_groups.append(group)
-            else:
-                raise ValueError(f"Unknown algorithm: {algo}")
-
-        # Create async tasks for each algorithm
-        muon_tasks = self._create_muon_tasks(muon_groups)
-        lion_tasks = self._create_lion_tasks(lion_groups)
-        adamw_tasks = self._create_adamw_tasks(adamw_groups)
-
-        all_tasks = chain(muon_tasks, lion_tasks, adamw_tasks)
-        runtime = AsyncRuntime(all_tasks, max_concurrent_tasks=3)
-        runtime.run()
-
-        return loss
-
-    def _get_or_initialize_state(self, param: Tensor, algo: str) -> dict:
-        """
-        Get optimizer state for the given parameter tensor,
-        or lazy-initialize it if it doesn't exist.
-        """
-        state = self.state[param]
-        if not state:
-            state["momentum"] = torch.zeros_like(param)
-            if algo == "adamw":
-                state["variance"] = torch.zeros_like(param)
-        return state
-
-    def _create_muon_tasks(
-        self,
-        param_groups: List[dict],
-        algo_name: str = "muon",
+    def _create_ortho_tasks(
+        self, param_groups: List[dict]
     ) -> Generator["AsyncTask", None, None]:
         """
-        Helper function to create batches of Muon matrices and generate
-        AsyncTask objects so we can process multiple batches concurrently.
+        Mega-batched Muon task creation: groups ALL same-shape parameters
+        into a single task to minimize communication rounds and kernel launches.
         """
         for group in param_groups:
-            assert group["algorithm"] == algo_name
+            assert group["algorithm"] == "muon"
             assert all(
                 p.ndim >= 2 for p in group["params"]
             ), "Muon optimizer only supports matrix parameters."
@@ -210,8 +110,7 @@ class Muon(Optimizer):
             if not group_params:
                 continue
 
-            # Wrap hyperparameters in tensors for torch.compile
-            muon_update_args = dict(
+            update_args = dict(
                 lr=torch.tensor(group["lr"]),
                 momentum=torch.tensor(group["mu"]),
                 weight_decay=torch.tensor(group["weight_decay"]),
@@ -226,301 +125,81 @@ class Muon(Optimizer):
                 cautious_wd=group["cautious_wd"],
             )
 
-            # Create batches of parameters of size self._world_size
-            for params in create_param_batches(
-                group_params, batch_size=self._world_size
-            ):
+            shape_groups: dict[tuple, list] = defaultdict(list)
+            for p in group_params:
+                sharding = p.placements if isinstance(p, DTensor) else None
+                shape_groups[(p.shape, sharding, p.dtype)].append(p)
+
+            for (_shape, _sharding, _dtype), params in shape_groups.items():
                 gradients = [p.grad for p in params]
-                states = [self._get_or_initialize_state(p, algo_name) for p in params]
+                states = [self._get_or_initialize_state(p, "muon") for p in params]
                 momentums = [s["momentum"] for s in states]
 
-                # Get sharding state for DTensor
-                is_batch_sharded = False
-                is_matrix_sharded = False
-                sharded_mesh_dim = None
-                sharded_tensor_dim = None
+                is_batch_sharded, is_matrix_sharded, sharded_tensor_dim = (
+                    self._get_shard_info(params[0], group)
+                )
 
-                if isinstance(params[0], DTensor):
-                    if not isinstance(self._distributed_mesh, DeviceMesh):
-                        raise RuntimeError(
-                            "Must create optimizer with DeviceMesh if using DTensor parameters."
-                        )
-
-                    # Find the sharded placement and get its mesh and tensor dimensions
-                    # Skip any Shard() placements on size-1 mesh dimension = Replicate()
-                    shard_placements = [
-                        (i, p)
-                        for i, p in enumerate(params[0].placements)
-                        if p.is_shard() and params[0].device_mesh.size(i) > 1
-                    ]
-
-                    # If we don't flatten 3D matrices, we can ignore shard placements along batch dimensions
-                    # Only keep placements that shard one of the two matrix dimensions
-                    if not group["flatten"]:
-                        matrix_dims = {params[0].ndim - 1, params[0].ndim - 2}
-                        is_batch_sharded = any(
-                            p.dim not in matrix_dims for _, p in shard_placements
-                        )
-                        shard_placements = [
-                            (i, p) for i, p in shard_placements if p.dim in matrix_dims
-                        ]
-
-                    # Check that we have no more than 1 sharded matrix dimension
-                    # Note that non-flattened 3D tensors can have additional sharded batch dimensions
-                    # Flattened 3D tensors are limited to one sharded dimension out of all dimensions
-                    if len(shard_placements) == 1:
-                        is_matrix_sharded = True
-                        sharded_mesh_dim = shard_placements[0][0]
-                        sharded_tensor_dim = shard_placements[0][1].dim
-                    elif len(shard_placements) > 1:
-                        raise NotImplementedError(
-                            "Muon does not support parameters with multiple sharded dimensions."
-                        )
-
-                    # Check that the sharded mesh dimension matches optimizer's device mesh
-                    if (
-                        sharded_mesh_dim is not None
-                        and params[0].device_mesh.get_group(sharded_mesh_dim)
-                        != self._process_group
-                    ):
-                        raise RuntimeError(
-                            f"Got DTensor sharded over mesh dimension {sharded_mesh_dim} different from the optimizer's device mesh. "
-                            f"DTensor has mesh: {params[0].device_mesh}, placements: {params[0].placements}, but optimizer was created with mesh: {self._distributed_mesh}."
-                        )
-
-                # Special case for 3D tensors sharded along batch dimension
-                # As long as matrix dimensions are not sharded, each device will have whole matrices
-                # Each device already has different matrices of the batch, so we can't parallelize further
+                megabatch_args = update_args
                 if is_batch_sharded and not is_matrix_sharded:
-                    for x, g, m in zip(params, gradients, momentums):
-                        yield AsyncTask(
-                            muon_update_batch_async(
-                                X=[x],
-                                G=[g],
-                                M=[m],
-                                shard_dim=None,  # No sharded matrix dim
-                                **muon_update_args,
-                            )
-                        )
-                # Otherwise, we parallelize the Muon update across devices
-                else:
-                    yield AsyncTask(
-                        muon_update_batch_async(
-                            X=pad_batch(params, self._world_size),
-                            G=pad_batch(gradients, self._world_size),
-                            M=pad_batch(momentums, self._world_size),
-                            shard_dim=sharded_tensor_dim,
-                            **muon_update_args,
-                        )
+                    megabatch_args = {**update_args, "process_group": None}
+
+                yield AsyncTask(
+                    muon_update_megabatch_async(
+                        X=params,
+                        G=gradients,
+                        M=momentums,
+                        shard_dim=sharded_tensor_dim,
+                        **megabatch_args,
                     )
-
-    def _create_lion_tasks(
-        self,
-        param_groups: List[dict],
-        algo_name: str = "lion",
-    ) -> Generator["AsyncTask", None, None]:
-        """
-        Helper function to generate AsyncTask objects for Lion updates.
-        """
-        for group in param_groups:
-            assert group["algorithm"] == algo_name
-
-            # Get parameters and optimizer states
-            params = [p for p in group["params"] if p.grad is not None]
-            if not params:
-                continue
-            gradients = [p.grad for p in params]
-            states = [self._get_or_initialize_state(p, algo_name) for p in params]
-            momentums = [s["momentum"] for s in states]
-
-            # Wrap hyperparameters in tensors for torch.compile
-            lr = torch.tensor(group["lr"])
-            beta1 = torch.tensor(group["beta1"])
-            beta2 = torch.tensor(group["beta2"])
-            weight_decay = torch.tensor(group["weight_decay"])
-            cautious_wd = group["cautious_wd"]
-
-            yield AsyncTask(
-                lion_update_foreach_async(
-                    X=to_local(params),
-                    G=to_local(gradients),
-                    M=to_local(momentums),
-                    lr=lr,
-                    beta1=beta1,
-                    beta2=beta2,
-                    weight_decay=weight_decay,
-                    cautious_wd=cautious_wd,
                 )
-            )
-
-    def _create_adamw_tasks(
-        self,
-        param_groups: List[dict],
-        algo_name: str = "adamw",
-    ) -> Generator["AsyncTask", None, None]:
-        """
-        Helper function to generate AsyncTask objects for AdamW updates.
-        """
-        for group in param_groups:
-            assert group["algorithm"] == algo_name
-
-            # Get parameters and optimizer states
-            params = [p for p in group["params"] if p.grad is not None]
-            if not params:
-                continue
-            gradients = [p.grad for p in params]
-            states = [self._get_or_initialize_state(p, algo_name) for p in params]
-            momentums = [s["momentum"] for s in states]
-            variances = [s["variance"] for s in states]
-
-            # Wrap hyperparameters in tensors for torch.compile
-            lr = torch.tensor(group["lr"])
-            beta1 = torch.tensor(group["beta1"])
-            beta2 = torch.tensor(group["beta2"])
-            weight_decay = torch.tensor(group["weight_decay"])
-            cautious_wd = group["cautious_wd"]
-            epsilon = torch.tensor(group["epsilon"])
-            step = torch.tensor(group["step"])
-
-            yield AsyncTask(
-                adamw_update_foreach_async(
-                    X=to_local(params),
-                    G=to_local(gradients),
-                    M=to_local(momentums),
-                    V=to_local(variances),
-                    lr=lr,
-                    beta1=beta1,
-                    beta2=beta2,
-                    weight_decay=weight_decay,
-                    step=step,
-                    epsilon=epsilon,
-                    cautious_wd=cautious_wd,
-                )
-            )
 
 
-def muon_update_batch_async(
-    X: List[Tensor],  # Model weights (modified in place)
-    G: List[Tensor],  # Gradient
-    M: List[Tensor],  # Momentum buffer (modified in place)
-    lr: Tensor,  # Learning rate (scalar tensor)
-    momentum: Tensor,  # Momentum factor (scalar tensor)
-    weight_decay: Tensor,  # Weight decay (scalar tensor)
-    epsilon: Tensor,  # Epsilon (scalar tensor)
-    nesterov: bool,  # Whether to use Nesterov momentum
-    flatten: bool,  # Whether to flatten 3D+ tensors to 2D
-    adjust_lr: Optional[str],  # How to adjust learning rate
-    device_rank: int,  # Rank of the current device
-    world_size: int,  # Total number of devices to parallelize over
-    shard_dim: Optional[int] = None,  # Shard dimension for DTensor (if applicable)
+def muon_update_megabatch_async(
+    X: List[Tensor],
+    G: List[Tensor],
+    M: List[Tensor],
+    lr: Tensor,
+    momentum: Tensor,
+    weight_decay: Tensor,
+    epsilon: Tensor,
+    nesterov: bool,
+    flatten: bool,
+    adjust_lr: Optional[str],
+    device_rank: int,
+    world_size: int,
+    shard_dim: Optional[int] = None,
     process_group: Optional[ProcessGroup] = None,
     newton_schulz_func: Optional[Callable] = None,
     cautious_wd: bool = False,
 ) -> Generator[None, None, None]:
     """
-    Batched version of Muon update. Batch size should be equal to number of GPUs.
-    All tensors in a batch should have identical shape, sharding, and dtype.
-    Identical hyperparameters are used for all tensors in the batch.
+    Mega-batched Muon update: processes ALL same-shape parameters in one
+    communication round instead of world_size-sized batches.
     """
+    N = len(X)
+    assert N == len(G) == len(M)
 
-    assert len(X) == len(G)
-    assert len(X) == len(M)
-
-    # Update momentum and compute the inputs for orthogonalization
+    # Pre-orthogonalize: update momentum
     U = muon_update_pre_orthogonalize(
-        G=to_local(G),
-        M=to_local(M),
-        momentum=momentum,
-        nesterov=nesterov,
+        G=to_local(G), M=to_local(M), momentum=momentum, nesterov=nesterov,
     )
 
-    # Get one whole matrix for each device to orthogonalize
-    if shard_dim is not None:
-        # Use all-to-all to transform from a batch of shards to a single whole matrix
-        # https://www.essential.ai/blog/infra
-        assert len(X) == world_size, "Batch size must equal world size"
-        assert (
-            process_group is not None
-        ), "process_group must be provided for sharded DTensors"
-        assert isinstance(X[0], DTensor), "X should contain DTensors"
-        assert not isinstance(U[0], DTensor), "U should contain local shards"
-        assert (
-            X[0].size(shard_dim) % world_size == 0
-        ), f"Shard dimension {shard_dim} size {X[0].size(shard_dim)} is not divisible by world size {world_size}."
+    # Convert shard_dim to negative for comm_dim
+    comm_dim = (shard_dim - X[0].ndim) if shard_dim is not None else None
 
-        # Allocate buffers to receive shards of one whole matrix from other devices
-        single_matrix_shards = [torch.empty_like(u) for u in U]
-
-        # Redistribute the shards to form one unique full tensor on each device
-        work = dist.all_to_all(
-            single_matrix_shards, U, group=process_group, async_op=True
-        )
-        yield
-        work.wait()
-
-        # Concatentate shards to form a whole matrix to orthogonalize
-        single_matrix = torch.cat(single_matrix_shards, dim=shard_dim)
-        single_matrix = muon_update_newton_schulz(
-            single_matrix,
-            newton_schulz_func=newton_schulz_func,
-            flatten=flatten,
-            epsilon=epsilon,
-        )
-
-        # Split result back into shards
-        # Contiguous is needed for all-to-all to work correctly
-        single_matrix_shards = [
-            x.contiguous()
-            for x in torch.tensor_split(single_matrix, world_size, dim=shard_dim)
-        ]
-
-        # Redistribute the orthogonalized tensor back to original layout
-        work = dist.all_to_all(
-            U, single_matrix_shards, group=process_group, async_op=True
-        )
-        yield
-        work.wait()
-
-    # Matrices are not sharded, so we can distribute the batch across different devices
-    # Get a single matrix of the batch corresponding to this device
-    elif len(U) > 1:
-        assert len(U) == world_size, "Batch size must equal world size"
-        assert process_group is not None
-
-        single_matrix = U[device_rank]
-        assert not isinstance(single_matrix, DTensor)
-
-        single_matrix = muon_update_newton_schulz(
-            single_matrix,
-            newton_schulz_func=newton_schulz_func,
-            flatten=flatten,
-            epsilon=epsilon,
-        )
-
-        # Allocate empty tensors to receive updates from other devices
-        U = [torch.empty_like(u) for u in U]
-
-        # All gather orthogonalized results from other devices into buffer
-        work = dist.all_gather(
-            U, single_matrix.contiguous(), group=process_group, async_op=True
-        )
-        yield
-        work.wait()
-
-    # Single tensor with no sharded dimension. This happens in 2 cases:
-    # - Running on a single GPU
-    # - 3D+ tensors sharded along a batch dimension (different whole matrices per device)
-    else:
-        assert len(U) == 1
-        U[0] = muon_update_newton_schulz(
-            U[0],
-            newton_schulz_func=newton_schulz_func,
-            flatten=flatten,
-            epsilon=epsilon,
-        )
+    # Orthogonalize via shared megabatch communication
+    U = yield from megabatch_orthogonalize_async(
+        U,
+        comm_dim=comm_dim,
+        device_rank=device_rank,
+        world_size=world_size,
+        process_group=process_group,
+        newton_schulz_func=newton_schulz_func,
+        flatten=flatten,
+        epsilon=epsilon,
+    )
 
     # Compute scaled learning rate
-    # Do this before to_local(X) because we use the full tensor shape, not the shard shape
     if adjust_lr is None:
         adjusted_lr = lr
     elif adjust_lr == "spectral_norm":
@@ -530,7 +209,7 @@ def muon_update_batch_async(
     else:
         raise ValueError(f"Unknown adjust_lr value: {adjust_lr}")
 
-    # Update model parameters with orthogonalized output
+    # Post-orthogonalize: apply update
     muon_update_post_orthogonalize(
         X=to_local(X),
         U=U,
@@ -606,51 +285,6 @@ def muon_update_post_orthogonalize(
     # Weight update
     U = torch._foreach_mul(U, adjusted_lr)
     torch._foreach_sub_(X, U)
-
-
-def muon_update_newton_schulz(
-    X: Tensor,
-    newton_schulz_func: Callable,
-    flatten: bool,
-    epsilon: Tensor,
-) -> Tensor:
-    """
-    Flatten the input tensor if needed and call the Newton-Schulz function.
-    """
-    original_shape = X.shape
-    if flatten and X.ndim >= 3:
-        # Flatten 3D+ tensors to 2D matrix
-        X = X.flatten(start_dim=1)
-    elif X.ndim >= 4:
-        # Given 4D+ batch, flatten to 3D batch
-        X = X.flatten(end_dim=-3)
-
-    return newton_schulz_func(X, epsilon=epsilon).reshape(original_shape)
-
-
-def adjust_lr_rms_norm(lr, param_shape, flatten):
-    # Adjust learning rate for constant element-wise RMS norm
-    # https://arxiv.org/abs/2502.16982
-    if flatten:
-        fan_out = param_shape[0]
-        fan_in = math.prod(param_shape[1:])
-    else:
-        fan_out, fan_in = param_shape[-2:]
-    adjusted_ratio = 0.2 * math.sqrt(max(fan_out, fan_in))
-    adjusted_lr = lr * adjusted_ratio
-    return adjusted_lr
-
-
-def adjust_lr_spectral_norm(lr, param_shape, flatten):
-    # Adjust from spectral norm 1 to RMS operator norm 1
-    # https://arxiv.org/abs/2310.17813
-    if flatten:
-        fan_out = param_shape[0]
-        fan_in = math.prod(param_shape[1:])
-    else:
-        fan_out, fan_in = param_shape[-2:]
-    adjusted_lr = lr * math.sqrt(fan_out / fan_in)
-    return adjusted_lr
 
 
 @torch.compile(fullgraph=True)

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -6,14 +6,14 @@ from torch.distributed.tensor import DeviceMesh, DTensor
 from torch.optim.optimizer import ParamsT
 from typing import Callable, Generator, List, Optional, Tuple, Union
 
-from .megabatch_base import DistributedOrthoBase, megabatch_orthogonalize_async
-from .opt_utils import AsyncTask, to_local
-from .muon import (
-    muon_update_pre_orthogonalize,
-    muon_update_post_orthogonalize,
+from .megabatch_base import (
+    DistributedOrthoBase,
+    megabatch_orthogonalize_async,
     adjust_lr_spectral_norm,
     adjust_lr_rms_norm,
 )
+from .opt_utils import AsyncTask, to_local
+from .muon import muon_update_pre_orthogonalize, muon_update_post_orthogonalize
 
 
 class NorMuon(DistributedOrthoBase):


### PR DESCRIPTION
## Summary
- Muon now inherits from `DistributedOrthoBase` and uses `megabatch_orthogonalize_async`, matching NorMuon and Dion2
- All same-shape params are processed in one communication round instead of `world_size`-sized batches
- Moves `muon_update_newton_schulz`, `adjust_lr_spectral_norm`, `adjust_lr_rms_norm` to `megabatch_base.py` (shared utilities, breaks circular import)
- `muon.py`: 675 → 318 lines (-357, 53% reduction)
- No functionality lost — nesterov, cautious_wd, all distributed paths preserved

## Test plan
- [x] Single-GPU: mixed shapes, megabatch, nesterov, cautious_wd
- [x] DDP 2×H100: exact cross-rank agreement (0.00 diff)
- [x] NorMuon and Dion2 still work (they import shared functions)
- [ ] FSDP multi-GPU training run