### PR TITLE
Auto-enable polar express when gram-NS is turned on

### DIFF
--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -75,7 +75,7 @@ class DistributedOrthoBase(Optimizer):
             self._newton_schulz_func = newton_schulz_func
         elif use_gram_newton_schulz:
             from gram_newton_schulz import GramNewtonSchulz
-            assert use_polar_express, "At present, Gram Newton Schulz only uses Polar Express"
+            use_polar_express = True
             _gns = GramNewtonSchulz(
                 ns_use_kernels=use_triton,
                 use_gram_newton_schulz=True,


### PR DESCRIPTION
One-line fix: replace `assert use_polar_express` with `use_polar_express = True` in the gram-NS branch. Users no longer need to pass both flags — `use_gram_newton_schulz=True` is sufficient.