### PR TITLE
Fix UnboundLocalError for single-param FSDP groups in megabatch_orthogonalize_async

### DIFF
--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -260,7 +260,7 @@ def megabatch_orthogonalize_async(
     N = len(U)
 
     # Pad to divisible by world_size (needed by both distributed paths)
-    if process_group is not None and N > 1:
+    if process_group is not None and N >= 1:
         pad_n = (world_size - N % world_size) % world_size
         U_work = U + [torch.zeros_like(U[0])] * pad_n if pad_n > 0 else U
         N_total = len(U_work)


### PR DESCRIPTION
## Summary

- Fixes `UnboundLocalError: cannot access local variable 'per_rank'` in `megabatch_orthogonalize_async` when a param group contains a single FSDP-sharded 2D parameter (N == 1).

## Problem

In `megabatch_orthogonalize_async()`, the padding/`per_rank` computation block (line 263) is gated behind `process_group is not None and N > 1`. However, the FSDP sharded communication path (line 271: `comm_dim is not None and process_group is not None`) uses `per_rank` to build `input_chunks` regardless of `N`. When a param group has only one 2D parameter (e.g., a latent predictor with a single weight matrix), `N == 1` causes `per_rank` to never be assigned, and the sharded path crashes with `UnboundLocalError`.

## Fix

Change the guard from `N > 1` to `N >= 1`. This ensures `per_rank` (and the padding logic) is computed whenever a `process_group` is present, which is exactly when it is needed.

## Test plan

- Verified that training with a model containing a single-parameter FSDP-sharded group (latent predictor) no longer crashes.
- The change is a no-op for `N == 0` (empty param groups) since the condition `N >= 1` still excludes that case, and for `N > 1` the behavior is identical.