### PR TITLE
Bump gram-newton-schulz to 0.1.1

### DIFF
--- a/requirements_dion.txt
+++ b/requirements_dion.txt
@@ -1,3 +1,3 @@
 numpy
 torch>=2.7.1
-gram-newton-schulz==0.1.0
+gram-newton-schulz==0.1.1


### PR DESCRIPTION
Upgrades gram-newton-schulz to 0.1.1, which relaxes the Python version requirement.