### PR TITLE
normuon default: adjust_lr = "spectral_norm"

### DIFF
--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -62,7 +62,7 @@ class NorMuon(DistributedOrthoBase):
         cautious_wd: bool = False,
         epsilon: float = 1e-8,
         nesterov: bool = False,
-        adjust_lr: Optional[str] = "rms_norm",
+        adjust_lr: Optional[str] = "spectral_norm",
         flatten: bool = False,
         use_gram_newton_schulz: bool = False,
         use_triton: bool = False,


### PR DESCRIPTION
Changes the NorMuon default for `adjust_lr` to `"spectral_norm"`.