### PR TITLE
Update defaults for NorMuon

### DIFF
--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -59,9 +59,9 @@ class Dion2(DistributedOrthoBase):
         epsilon: float = 1e-8,
         adjust_lr: Optional[str] = "spectral_norm",
         flatten: bool = False,
-        use_gram_newton_schulz: bool = False,
         use_triton: bool = False,
-        use_polar_express: bool = False,
+        use_polar_express: bool = True,
+        use_gram_newton_schulz: bool = True,
         newton_schulz_func: Optional[Callable] = None,
         verbose: bool = False,
     ):

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -34,9 +34,9 @@ class DistributedOrthoBase(Optimizer):
         distributed_mesh: Optional[Union[DeviceMesh, ProcessGroup]],
         algo_name: str,
         defaults: dict,
-        use_gram_newton_schulz: bool = False,
+        use_gram_newton_schulz: bool = True,
         use_triton: bool = False,
-        use_polar_express: bool = False,
+        use_polar_express: bool = True,
         newton_schulz_func: Optional[Callable] = None,
     ):
         super().__init__(params, defaults)

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -75,7 +75,14 @@ class DistributedOrthoBase(Optimizer):
                 )
             self._newton_schulz_func = newton_schulz_func
         elif use_gram_newton_schulz:
-            from gram_newton_schulz import GramNewtonSchulz
+            try:
+                from gram_newton_schulz import GramNewtonSchulz
+            except ImportError:
+                raise ImportError(
+                    "use_gram_newton_schulz=True requires the 'gram-newton-schulz' package, "
+                    "which is not installed. "
+                    "Install it with: pip install gram-newton-schulz"
+                )
             use_polar_express = True
             _gns = GramNewtonSchulz(
                 ns_use_kernels=use_triton,

--- a/dion/muon.py
+++ b/dion/muon.py
@@ -61,9 +61,9 @@ class Muon(DistributedOrthoBase):
         nesterov: bool = False,
         adjust_lr: Optional[str] = "spectral_norm",
         flatten: bool = False,
-        use_gram_newton_schulz: bool = False,
+        use_gram_newton_schulz: bool = True,
         use_triton: bool = False,
-        use_polar_express: bool = False,
+        use_polar_express: bool = True,
         newton_schulz_func: Optional[Callable] = None,
     ):
         if lr < 0.0:

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -64,9 +64,9 @@ class NorMuon(DistributedOrthoBase):
         nesterov: bool = False,
         adjust_lr: Optional[str] = "spectral_norm",
         flatten: bool = False,
-        use_gram_newton_schulz: bool = False,
+        use_gram_newton_schulz: bool = True,
         use_triton: bool = False,
-        use_polar_express: bool = False,
+        use_polar_express: bool = True,
         newton_schulz_func: Optional[Callable] = None,
     ):
         if lr < 0.0:

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -62,7 +62,7 @@ class NorMuon(DistributedOrthoBase):
         cautious_wd: bool = False,
         epsilon: float = 1e-8,
         nesterov: bool = False,
-        adjust_lr: Optional[str] = "rms_norm",
+        adjust_lr: Optional[str] = "spectral_norm",
         flatten: bool = False,
         use_gram_newton_schulz: bool = False,
         use_triton: bool = False,


### PR DESCRIPTION
Includes all changes from #53 plus an additional fix for a clear error message when the `gram-newton-schulz` package is missing.

## Changes

- `use_gram_newton_schulz` default: `False` → `True`
- `use_polar_express` default: `False` → `True`
- NorMuon `adjust_lr` default: `"rms_norm"` → `"spectral_norm"`
- Wrap `gram_newton_schulz` import in try/except with actionable error message (matching the existing `use_triton` pattern)

Supersedes #53.