### PR TITLE
Revert use_gram_newton_schulz default to False due to bug

### DIFF
--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -61,7 +61,7 @@ class Dion2(DistributedOrthoBase):
         flatten: bool = False,
         use_triton: bool = False,
         use_polar_express: bool = True,
-        use_gram_newton_schulz: bool = True,
+        use_gram_newton_schulz: bool = False,
         newton_schulz_func: Optional[Callable] = None,
         verbose: bool = False,
     ):

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -34,7 +34,7 @@ class DistributedOrthoBase(Optimizer):
         distributed_mesh: Optional[Union[DeviceMesh, ProcessGroup]],
         algo_name: str,
         defaults: dict,
-        use_gram_newton_schulz: bool = True,
+        use_gram_newton_schulz: bool = False,
         use_triton: bool = False,
         use_polar_express: bool = True,
         newton_schulz_func: Optional[Callable] = None,

--- a/dion/muon.py
+++ b/dion/muon.py
@@ -61,7 +61,7 @@ class Muon(DistributedOrthoBase):
         nesterov: bool = False,
         adjust_lr: Optional[str] = "spectral_norm",
         flatten: bool = False,
-        use_gram_newton_schulz: bool = True,
+        use_gram_newton_schulz: bool = False,
         use_triton: bool = False,
         use_polar_express: bool = True,
         newton_schulz_func: Optional[Callable] = None,

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -64,7 +64,7 @@ class NorMuon(DistributedOrthoBase):
         nesterov: bool = False,
         adjust_lr: Optional[str] = "spectral_norm",
         flatten: bool = False,
-        use_gram_newton_schulz: bool = True,
+        use_gram_newton_schulz: bool = False,
         use_triton: bool = False,
         use_polar_express: bool = True,
         newton_schulz_func: Optional[Callable] = None,


### PR DESCRIPTION
Reverts the default value of `use_gram_newton_schulz` back to `False` in all optimizers (`Dion2`, `Muon`, `NorMuon`, and `DistributedOrthoBase`) due to a bug in the gram Newton-Schulz implementation.

This was set to `True` in #54 but causes issues, so this PR rolls it back until the bug is fixed.