### PR TITLE
Change gram-newton-schulz pin to avoid autotuning issues

### DIFF
--- a/requirements_dion.txt
+++ b/requirements_dion.txt
@@ -1,3 +1,3 @@
 numpy
 torch>=2.7.1
-gram-newton-schulz @ git+https://github.com/NoahAmsel/gram-newton-schulz.git@debug-nan
+gram-newton-schulz @ git+https://github.com/NoahAmsel/gram-newton-schulz.git@no-autotune

--- a/requirements_dion.txt
+++ b/requirements_dion.txt
@@ -1,3 +1,3 @@
 numpy
 torch>=2.7.1
-gram-newton-schulz==0.1.1
+gram-newton-schulz @ git+https://github.com/NoahAmsel/gram-newton-schulz.git@debug-nan


### PR DESCRIPTION
We observed two issues when using Gram Newton Schulz:

1. nans on B200 when the quack autotuner selects certain configs
2. OOM when running in parallel due to memory pressure from 8 gpus simultaneously autotuning on cuda:0.

To fix both, I modified Gram Newton Schulz to avoid using the quack autotuner altogether. While we wait for that to be incorporated into Gram Newton Schulz (and to quickly pick up my fixes for any other issues like this that arise in the near-term), this commit pins to my fork of gram-newton-schulz