### PR TITLE
Pin gram-newton-schulz to no-autotune commit (fix B200 NaN/OOM)

### DIFF
--- a/requirements_dion.txt
+++ b/requirements_dion.txt
@@ -1,3 +1,3 @@
 numpy
 torch>=2.7.1
-gram-newton-schulz==0.1.1
+gram-newton-schulz @ git+https://github.com/NoahAmsel/gram-newton-schulz.git@3b5aaa6c6bfd95d974d543d998653a440ccfc7be


### PR DESCRIPTION
## Summary

- Pin gram-newton-schulz to [NoahAmsel's fork commit `3b5aaa6`](https://github.com/NoahAmsel/gram-newton-schulz/commit/3b5aaa6c6bfd95d974d543d998653a440ccfc7be) which disables the quack autotuner for non-symmetric GEMMs
- Fixes NaN on B200 when the quack autotuner selects certain configs
- Fixes OOM when 8 GPUs simultaneously autotune on cuda:0
- Uses a commit hash pin (not branch name) for reproducible installs

Supersedes #57 — same underlying fix, pinned to a specific commit instead of a moving branch ref.

## Test plan

- [ ] Verify `pip install` resolves the pinned commit correctly
- [ ] Run a short training job with `--use_gram_newton_schulz` on B200 and confirm no NaN/OOM