### PR TITLE
Support 3D+ parameters in Dion2

### DIFF
--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -295,22 +295,33 @@ def dion2_pre_orthogonalize(
     _, indices = torch.topk(slice_norms, k, dim=-1, sorted=False)
 
     # Batched gather for slice extraction
+    # Use expand(*shape, ...) instead of fixed -1 counts to support arbitrary
+    # batch dimensions (e.g. 3D params have shape (B, R, C) so indices are 3D).
     if select_dim == -2:
         # Selecting rows
         num_cols = M[0].size(-1)
-        indices_expanded = indices.unsqueeze(-1).expand(-1, -1, num_cols)
+        indices_expanded = indices.unsqueeze(-1).expand(*indices.shape, num_cols)
         selected_stacked = torch.gather(M_stacked, dim=-2, index=indices_expanded)
     else:
         # Selecting cols
         num_rows = M[0].size(-2)
-        indices_expanded = indices.unsqueeze(-2).expand(-1, num_rows, -1)
+        indices_expanded = indices.unsqueeze(-2).expand(
+            *indices.shape[:-1], num_rows, indices.shape[-1]
+        )
         selected_stacked = torch.gather(M_stacked, dim=-1, index=indices_expanded)
 
-    # Apply error feedback decay to selected slices in original M tensors
+    # Apply error feedback decay to selected slices in original M tensors.
+    # Reuse the already-gathered selected_stacked slices and use scatter_ to
+    # write back, since index_select/index_copy_ require 1D indices and fail
+    # for 3D+ parameters where indices have batch dimensions.
     indices_list = list(indices.unbind(dim=0))
-    for m, idx in zip(M, indices_list):
-        selected_slice = m.index_select(dim=select_dim, index=idx)
-        m.index_copy_(dim=select_dim, index=idx, source=selected_slice * ef_decay)
+    selected_list = list(selected_stacked.unbind(dim=0))
+    for m, idx, selected in zip(M, indices_list, selected_list):
+        if select_dim == -2:
+            idx_exp = idx.unsqueeze(-1).expand(*idx.shape, m.size(-1))
+        else:
+            idx_exp = idx.unsqueeze(-2).expand(*idx.shape[:-1], m.size(-2), idx.shape[-1])
+        m.scatter_(dim=select_dim, index=idx_exp, src=selected * ef_decay)
 
     # Convert to bf16 and unstack for communication
     U_selected = list(selected_stacked.to(dtype=torch.bfloat16).unbind(dim=0))
@@ -341,8 +352,14 @@ def dion2_post_orthogonalize(
     # Apply weight update
     neg_lr = -adjusted_lr
     U_scaled = [neg_lr * u for u in U]
+    # Use scatter_add_ instead of index_add_ to support multi-dimensional
+    # indices from 3D+ parameters (index_add_ requires 1D indices).
     for x, u_scaled, idx in zip(X, U_scaled, indices):
-        x.index_add_(dim=select_dim, index=idx, source=u_scaled)
+        if select_dim == -2:
+            idx_exp = idx.unsqueeze(-1).expand_as(u_scaled)
+        else:
+            idx_exp = idx.unsqueeze(-2).expand_as(u_scaled)
+        x.scatter_add_(dim=select_dim, index=idx_exp, src=u_scaled)
 
 
 # A helper function to print selection choice for each matrix

--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -294,26 +294,26 @@ def dion2_pre_orthogonalize(
     # Batched topk: indices shape (batch_size, k)
     _, indices = torch.topk(slice_norms, k, dim=-1, sorted=False)
 
-    # Batched gather for slice extraction
-    # Use expand(*shape, ...) instead of fixed -1 counts to support arbitrary
-    # batch dimensions (e.g. 3D params have shape (B, R, C) so indices are 3D).
+    # Extract the selected rows/columns from each momentum tensor.
+    # `indices` has shape (..., k) where k is the number of selected slices.
+    # `gather` requires the index tensor to have the same number of dimensions
+    # as the source, so we expand the indices to cover the non-selected dimension.
     if select_dim == -2:
-        # Selecting rows
+        # Selecting rows: expand indices from (..., k) to (..., k, num_cols)
         num_cols = M[0].size(-1)
         indices_expanded = indices.unsqueeze(-1).expand(*indices.shape, num_cols)
         selected_stacked = torch.gather(M_stacked, dim=-2, index=indices_expanded)
     else:
-        # Selecting cols
+        # Selecting cols: expand indices from (..., k) to (..., num_rows, k)
         num_rows = M[0].size(-2)
         indices_expanded = indices.unsqueeze(-2).expand(
             *indices.shape[:-1], num_rows, indices.shape[-1]
         )
         selected_stacked = torch.gather(M_stacked, dim=-1, index=indices_expanded)
 
-    # Apply error feedback decay to selected slices in original M tensors.
-    # Reuse the already-gathered selected_stacked slices and use scatter_ to
-    # write back, since index_select/index_copy_ require 1D indices and fail
-    # for 3D+ parameters where indices have batch dimensions.
+    # Apply error feedback decay to selected slices in the original M tensors.
+    # We reuse the already-gathered slices and write them back (scaled) using
+    # scatter_, which places values into positions specified by the index tensor.
     indices_list = list(indices.unbind(dim=0))
     selected_list = list(selected_stacked.unbind(dim=0))
     for m, idx, selected in zip(M, indices_list, selected_list):
@@ -352,8 +352,9 @@ def dion2_post_orthogonalize(
     # Apply weight update
     neg_lr = -adjusted_lr
     U_scaled = [neg_lr * u for u in U]
-    # Use scatter_add_ instead of index_add_ to support multi-dimensional
-    # indices from 3D+ parameters (index_add_ requires 1D indices).
+    # Apply the orthogonalized update to only the selected rows/columns.
+    # scatter_add_ accumulates values into positions specified by the index tensor:
+    #   x[..., idx_exp[..., j], j] += u_scaled[..., :, j]  (for select_dim == -2)
     for x, u_scaled, idx in zip(X, U_scaled, indices):
         if select_dim == -2:
             idx_exp = idx.unsqueeze(-1).expand_as(u_scaled)

--- a/requirements_dion.txt
+++ b/requirements_dion.txt
@@ -1,3 +1,3 @@
 numpy
 torch>=2.7.1
-gram-newton-schulz @ git+https://github.com/NoahAmsel/gram-newton-schulz.git@3b5aaa6c6bfd95d974d543d998653a440ccfc7be
+gram-newton-schulz==0.1.2

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -190,6 +190,34 @@ class TestDion2:
         params = _make_params([(128, 32)])
         _run_steps(Dion2, params, dict(lr=0.01, verbose=True))
 
+    def test_3d_params_wide(self):
+        """3D params (batch of wide matrices) should work with select_dim=-2."""
+        from dion import Dion2
+        params = _make_params([(4, 32, 128)])
+        before = params[0].data.clone()
+        _run_steps(Dion2, params, dict(lr=0.01, fraction=0.5), n_steps=3)
+        assert not torch.equal(params[0].data, before)
+
+    def test_3d_params_tall(self):
+        """3D params (batch of tall matrices) should work with select_dim=-1."""
+        from dion import Dion2
+        params = _make_params([(4, 128, 32)])
+        before = params[0].data.clone()
+        _run_steps(Dion2, params, dict(lr=0.01, fraction=0.25), n_steps=3)
+        assert not torch.equal(params[0].data, before)
+
+    def test_3d_params_flatten(self):
+        """3D params with flatten=True should flatten to 2D for ortho."""
+        from dion import Dion2
+        params = _make_params([(4, 32, 128)])
+        _run_steps(Dion2, params, dict(lr=0.01, flatten=True), n_steps=3)
+
+    def test_3d_megabatch(self):
+        """Multiple 3D params with same shape should be megabatched."""
+        from dion import Dion2
+        params = _make_params([(4, 32, 64)] * 3)
+        _run_steps(Dion2, params, dict(lr=0.01), n_steps=3)
+
 
 # ---------------------------------------------------------------------------
 # Mixed param groups (matrix + scalar)


### PR DESCRIPTION
## Summary

Dion2 previously crashed on parameters with 3 or more dimensions (e.g. shape `(B, R, C)`) due to indexing operations that assumed 2D tensors.

## Changes

### 3D parameter support (`dion2_pre_orthogonalize`, `dion2_post_orthogonalize`)
- Replaced `index_select`/`index_copy_`/`index_add_` (which require 1D indices) with `gather`/`scatter_`/`scatter_add_` (which support multi-dimensional indices)
- 3D+ tensors with `flatten=False` are treated as batches of 2D matrices, with independent row/column selection per batch element

### Pin gram-newton-schulz to release
- Pin `gram-newton-schulz` to published release `0.1.2` instead of a git commit hash

### Tests
- Added tests for 3D params: wide, tall, flatten, and megabatch configurations
