### PR TITLE
Fix misleading pseudo-code in scatter_add_ comment

### DIFF
--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -354,7 +354,8 @@ def dion2_post_orthogonalize(
     U_scaled = [neg_lr * u for u in U]
     # Apply the orthogonalized update to only the selected rows/columns.
     # scatter_add_ accumulates values into positions specified by the index tensor:
-    #   x[..., idx_exp[..., j], j] += u_scaled[..., :, j]  (for select_dim == -2)
+    #   x[..., idx_exp[..., i, j], j] += u_scaled[..., i, j]  (for select_dim == -2)
+    # where i ranges over the k selected rows and j over all columns.
     for x, u_scaled, idx in zip(X, U_scaled, indices):
         if select_dim == -2:
             idx_exp = idx.unsqueeze(-1).expand_as(u_scaled)


### PR DESCRIPTION
## Summary

Minor follow-up to #59. The comment added for `scatter_add_` in `dion2_post_orthogonalize` used `:` where a loop index was intended:

```python
#   x[..., idx_exp[..., j], j] += u_scaled[..., :, j]  (for select_dim == -2)
```

The `:` conflates the selected-row dimension with "all." The actual semantics is a double loop over the selected rows `i` and columns `j`:

```python
#   x[..., idx_exp[..., i, j], j] += u_scaled[..., i, j]  (for select_dim == -2)
# where i ranges over the k selected rows and j over all columns.
```

No behavior change — comment only.