### PR TITLE
Fix ROCm crash in Newton-Schulz Triton kernels (#61)

### DIFF
--- a/dion/newton_schulz_triton.py
+++ b/dion/newton_schulz_triton.py
@@ -1,6 +1,10 @@
 import torch
 from torch import Tensor
 
+# Triton's tl.dot input_precision is backend-specific: CUDA accepts
+# "ieee"/"tf32"/"tf32x3", while ROCm only accepts "ieee" (see issue #61).
+_IS_HIP = torch.version.hip is not None
+
 try:
     import triton
     import triton.language as tl
@@ -165,7 +169,7 @@ def ns_line_1(A: Tensor, *, out: Tensor = None):
     batch_size = A.size(0) if A.ndim == 3 else 1
     input_batch_stride = A.stride(0) if A.ndim == 3 else 0
     output_batch_stride = out.stride(0) if out.ndim == 3 else 0
-    input_precision = "ieee" if A.dtype == torch.float32 else "tf32"
+    input_precision = "ieee" if (_IS_HIP or A.dtype == torch.float32) else "tf32"
 
     grid = lambda meta: (
         batch_size
@@ -299,7 +303,7 @@ def ns_line_2(A: Tensor, alpha: float, beta: float, *, out: Tensor = None):
     batch_size = A.size(0) if A.ndim == 3 else 1
     input_batch_stride = A.stride(0) if A.ndim == 3 else 0
     output_batch_stride = out.stride(0) if out.ndim == 3 else 0
-    input_precision = "ieee" if A.dtype == torch.float32 else "tf32"
+    input_precision = "ieee" if (_IS_HIP or A.dtype == torch.float32) else "tf32"
 
     grid = lambda meta: (
         batch_size


### PR DESCRIPTION
## Summary
- Fixes #61 — `normuon` crashes on AMD MI250x / ROCm with `AssertionError: input_precision must be one of ('ieee',). Got tf32`.
- Root cause: `dion/newton_schulz_triton.py` unconditionally selected `input_precision="tf32"` for non-fp32 inputs when calling `tl.dot`. Triton on CUDA accepts `ieee`/`tf32`/`tf32x3`; Triton on ROCm only accepts `ieee`, so the kernel launch asserts on every optimizer step for bf16/fp16 params.
- Fix: fall back to `"ieee"` when torch is built against HIP (`torch.version.hip is not None`). CUDA path is unchanged.

## Test plan
- [ ] CUDA: existing `tests/test_newton_shulz.py` still passes (no behavior change on CUDA).
- [ ] ROCm: verified by @gbouras13 on 2× MI250x nodes, torch 2.7.1 + ROCm 6.3.3, with the `normuon` optimizer in bf16 — previously failing at the first optimizer step.

Note: there is no ROCm runner in CI, so the ROCm path cannot be covered by a unit test here; verification requires AMD hardware.