### PR TITLE
Add hybrid Newton-Schulz from DeepSeek-V4 (#66)

### DIFF
--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -43,7 +43,7 @@ class Dion2(DistributedOrthoBase):
         use_polar_express: Whether to use Polar Express orthogonalization (default).
             Overridden by ``use_hybrid_newton_schulz`` or ``newton_schulz_func``.
         use_hybrid_newton_schulz: Whether to use the 10-step hybrid Newton-Schulz
-            schedule from DeepSeek-V4 (8 aggressive iterations + 2 stabilizing iterations).
+            schedule (8 Muon iterations + 2 classical stabilizing iterations).
         newton_schulz_func: Use a custom Newton-Schulz function for orthogonalization.
             Signature is ``func(input: Tensor, epsilon: float) -> Tensor``.
         verbose: Whether to print debug information during updates. If True, it prints whether rows or columns are selected for the submatrix selection process.

--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -40,6 +40,10 @@ class Dion2(DistributedOrthoBase):
             False: Tensors are not flattened. 3D+ tensors are treated as batches of 2D matrices.
         use_gram_newton_schulz: Whether to use Gram Newton-Schulz for orthogonalization.
         use_triton: Whether to use Triton kernel for Newton-Schulz. Ignored if custom function is provided.
+        use_polar_express: Whether to use Polar Express orthogonalization (default).
+            Overridden by ``use_hybrid_newton_schulz`` or ``newton_schulz_func``.
+        use_hybrid_newton_schulz: Whether to use the 10-step hybrid Newton-Schulz
+            schedule from DeepSeek-V4 (8 aggressive iterations + 2 stabilizing iterations).
         newton_schulz_func: Use a custom Newton-Schulz function for orthogonalization.
             Signature is ``func(input: Tensor, epsilon: float) -> Tensor``.
         verbose: Whether to print debug information during updates. If True, it prints whether rows or columns are selected for the submatrix selection process.
@@ -61,6 +65,7 @@ class Dion2(DistributedOrthoBase):
         flatten: bool = False,
         use_triton: bool = False,
         use_polar_express: bool = True,
+        use_hybrid_newton_schulz: bool = False,
         use_gram_newton_schulz: bool = False,
         newton_schulz_func: Optional[Callable] = None,
         verbose: bool = False,
@@ -97,6 +102,7 @@ class Dion2(DistributedOrthoBase):
             use_gram_newton_schulz=use_gram_newton_schulz,
             use_triton=use_triton,
             use_polar_express=use_polar_express,
+            use_hybrid_newton_schulz=use_hybrid_newton_schulz,
             newton_schulz_func=newton_schulz_func,
         )
         self.verbose = verbose

--- a/dion/hybrid_newton_schulz.py
+++ b/dion/hybrid_newton_schulz.py
@@ -2,25 +2,31 @@ import torch
 from torch import Tensor
 
 
-# Hybrid Newton-Schulz coefficients from DeepSeek-V4 (Algorithm 1, Eq. 28).
-# https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro
-# First 8 iterations drive singular values rapidly toward 1; last 2 iterations
-# stabilize at 1 via the standard (2, -1.5, 0.5) fixed-point schedule.
+# Two-stage Newton-Schulz schedule.
+# Stage 1 (8 iterations): Keller Jordan's Muon quintic, tuned to inflate
+#   small singular values aggressively (https://kellerjordan.github.io/posts/muon/).
+#   p(x) = 3.4445 x - 4.7750 x^3 + 2.0315 x^5 does not fix at 1 — iterates
+#   oscillate around 1 with slowly decaying amplitude.
+# Stage 2 (2 iterations): classical quintic p(x) = 2x - 1.5 x^3 + 0.5 x^5,
+#   which has p(1) = 1 and p'(1) = 0 (cubic convergence), pinning singular
+#   values at 1 once they are in the basin of attraction.
 _HYBRID_NS_COEFFS = [(3.4445, -4.7750, 2.0315)] * 8 + [(2.0, -1.5, 0.5)] * 2
 
 
 @torch.compile(dynamic=False, fullgraph=True)
 def hybrid_newton_schulz(G: Tensor, epsilon: float = 1e-6) -> Tensor:
     """
-    Hybrid Newton-Schulz orthogonalization from DeepSeek-V4.
+    Two-stage Newton-Schulz orthogonalization.
 
-    Performs 10 iterations in two stages: 8 steps with coefficients
-    (3.4445, -4.7750, 2.0315) for rapid convergence, then 2 steps with
-    (2.0, -1.5, 0.5) to stabilize singular values at 1. Input is normalized
-    by its Frobenius norm (paper verbatim; no safety cushion).
+    Performs 10 iterations: 8 with Keller Jordan's Muon coefficients
+    (3.4445, -4.7750, 2.0315) to inflate small singular values quickly,
+    then 2 with the classical quintic (2, -1.5, 0.5) to pin them at 1.
+    Input is scaled by its Frobenius norm (||X||_2 <= ||X||_F), so the
+    starting spectral norm is at most 1 with no safety cushion.
 
-    Paper: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro
-    Section 2.4, Algorithm 1 and Equation 28.
+    Refs:
+      - Muon optimizer: https://kellerjordan.github.io/posts/muon/
+      - Classical Newton-Schulz iteration for the matrix sign function.
 
     Signature matches zeropower_via_newtonschulz5: func(input, epsilon) -> Tensor.
     """

--- a/dion/hybrid_newton_schulz.py
+++ b/dion/hybrid_newton_schulz.py
@@ -1,0 +1,48 @@
+import torch
+from torch import Tensor
+
+
+# Hybrid Newton-Schulz coefficients from DeepSeek-V4 (Algorithm 1, Eq. 28).
+# https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro
+# First 8 iterations drive singular values rapidly toward 1; last 2 iterations
+# stabilize at 1 via the standard (2, -1.5, 0.5) fixed-point schedule.
+_HYBRID_NS_COEFFS = [(3.4445, -4.7750, 2.0315)] * 8 + [(2.0, -1.5, 0.5)] * 2
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def hybrid_newton_schulz(G: Tensor, epsilon: float = 1e-6) -> Tensor:
+    """
+    Hybrid Newton-Schulz orthogonalization from DeepSeek-V4.
+
+    Performs 10 iterations in two stages: 8 steps with coefficients
+    (3.4445, -4.7750, 2.0315) for rapid convergence, then 2 steps with
+    (2.0, -1.5, 0.5) to stabilize singular values at 1. Input is normalized
+    by its Frobenius norm (paper verbatim; no safety cushion).
+
+    Paper: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro
+    Section 2.4, Algorithm 1 and Equation 28.
+
+    Signature matches zeropower_via_newtonschulz5: func(input, epsilon) -> Tensor.
+    """
+    assert G.ndim >= 2
+    X = G.bfloat16()
+
+    is_tall = G.size(-2) > G.size(-1)
+
+    # Frobenius normalization: ensures ||X||_2 <= 1 since ||X||_2 <= ||X||_F.
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + epsilon)
+
+    if is_tall:
+        # Tall: use X.mT @ X (small cols x cols) + right-multiply.
+        for a, b, c in _HYBRID_NS_COEFFS:
+            A = X.mT @ X
+            B = b * A + c * (A @ A)
+            X = a * X + X @ B
+    else:
+        # Wide: use X @ X.mT (small rows x rows) + left-multiply.
+        for a, b, c in _HYBRID_NS_COEFFS:
+            A = X @ X.mT
+            B = b * A + c * (A @ A)
+            X = a * X + B @ X
+
+    return X

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -15,6 +15,7 @@ from .newton_schulz_triton import (
     zeropower_via_newtonschulz5,
 )
 from .polar_express import polar_express, polar_express_triton
+from .hybrid_newton_schulz import hybrid_newton_schulz
 from .opt_utils import AsyncRuntime, AsyncTask, to_local
 from .scalar_opts import adamw_update_foreach_async, lion_update_foreach_async
 
@@ -37,6 +38,7 @@ class DistributedOrthoBase(Optimizer):
         use_gram_newton_schulz: bool = False,
         use_triton: bool = False,
         use_polar_express: bool = True,
+        use_hybrid_newton_schulz: bool = False,
         newton_schulz_func: Optional[Callable] = None,
     ):
         super().__init__(params, defaults)
@@ -92,6 +94,8 @@ class DistributedOrthoBase(Optimizer):
                 compile_kwargs=dict(fullgraph=True, mode="default"),
             )
             self._newton_schulz_func = lambda X, epsilon=None: _gns(X)
+        elif use_hybrid_newton_schulz:
+            self._newton_schulz_func = hybrid_newton_schulz
         elif use_polar_express and use_triton:
             self._newton_schulz_func = polar_express_triton
         elif use_polar_express:

--- a/dion/muon.py
+++ b/dion/muon.py
@@ -41,6 +41,10 @@ class Muon(DistributedOrthoBase):
             False: Tensors are not flattened. 3D+ tensors are treated as batches of 2D matrices.
         use_triton: Whether to use Triton kernel for Newton-Schulz. Ignored if custom function is provided.
         use_gram_newton_schulz: Whether to use Gram Newton-Schulz for orthogonalization.
+        use_polar_express: Whether to use Polar Express orthogonalization (default).
+            Overridden by ``use_hybrid_newton_schulz`` or ``newton_schulz_func``.
+        use_hybrid_newton_schulz: Whether to use the 10-step hybrid Newton-Schulz
+            schedule from DeepSeek-V4 (8 aggressive iterations + 2 stabilizing iterations).
         newton_schulz_func: Use a custom Newton-Schulz function for orthogonalization.
             Signature is ``func(input: Tensor, epsilon: float) -> Tensor``.
 
@@ -64,6 +68,7 @@ class Muon(DistributedOrthoBase):
         use_gram_newton_schulz: bool = False,
         use_triton: bool = False,
         use_polar_express: bool = True,
+        use_hybrid_newton_schulz: bool = False,
         newton_schulz_func: Optional[Callable] = None,
     ):
         if lr < 0.0:
@@ -96,6 +101,7 @@ class Muon(DistributedOrthoBase):
             use_gram_newton_schulz=use_gram_newton_schulz,
             use_triton=use_triton,
             use_polar_express=use_polar_express,
+            use_hybrid_newton_schulz=use_hybrid_newton_schulz,
             newton_schulz_func=newton_schulz_func,
         )
 

--- a/dion/muon.py
+++ b/dion/muon.py
@@ -44,7 +44,7 @@ class Muon(DistributedOrthoBase):
         use_polar_express: Whether to use Polar Express orthogonalization (default).
             Overridden by ``use_hybrid_newton_schulz`` or ``newton_schulz_func``.
         use_hybrid_newton_schulz: Whether to use the 10-step hybrid Newton-Schulz
-            schedule from DeepSeek-V4 (8 aggressive iterations + 2 stabilizing iterations).
+            schedule (8 Muon iterations + 2 classical stabilizing iterations).
         newton_schulz_func: Use a custom Newton-Schulz function for orthogonalization.
             Signature is ``func(input: Tensor, epsilon: float) -> Tensor``.
 

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -45,7 +45,7 @@ class NorMuon(DistributedOrthoBase):
         use_polar_express: Whether to use Polar Express orthogonalization (default).
             Overridden by ``use_hybrid_newton_schulz`` or ``newton_schulz_func``.
         use_hybrid_newton_schulz: Whether to use the 10-step hybrid Newton-Schulz
-            schedule from DeepSeek-V4 (8 aggressive iterations + 2 stabilizing iterations).
+            schedule (8 Muon iterations + 2 classical stabilizing iterations).
         newton_schulz_func: Use a custom Newton-Schulz function for orthogonalization.
             Signature is ``func(input: Tensor, epsilon: float) -> Tensor``.
 

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -42,6 +42,10 @@ class NorMuon(DistributedOrthoBase):
             False: Tensors are not flattened. 3D+ tensors are treated as batches of 2D matrices.
         use_gram_newton_schulz: Whether to use Gram Newton-Schulz for orthogonalization.
         use_triton: Whether to use Triton kernel for Newton-Schulz. Ignored if custom function is provided.
+        use_polar_express: Whether to use Polar Express orthogonalization (default).
+            Overridden by ``use_hybrid_newton_schulz`` or ``newton_schulz_func``.
+        use_hybrid_newton_schulz: Whether to use the 10-step hybrid Newton-Schulz
+            schedule from DeepSeek-V4 (8 aggressive iterations + 2 stabilizing iterations).
         newton_schulz_func: Use a custom Newton-Schulz function for orthogonalization.
             Signature is ``func(input: Tensor, epsilon: float) -> Tensor``.
 
@@ -67,6 +71,7 @@ class NorMuon(DistributedOrthoBase):
         use_gram_newton_schulz: bool = False,
         use_triton: bool = False,
         use_polar_express: bool = True,
+        use_hybrid_newton_schulz: bool = False,
         newton_schulz_func: Optional[Callable] = None,
     ):
         if lr < 0.0:
@@ -102,6 +107,7 @@ class NorMuon(DistributedOrthoBase):
             use_gram_newton_schulz=use_gram_newton_schulz,
             use_triton=use_triton,
             use_polar_express=use_polar_express,
+            use_hybrid_newton_schulz=use_hybrid_newton_schulz,
             newton_schulz_func=newton_schulz_func,
         )
 

--- a/tests/test_hybrid_newton_schulz.py
+++ b/tests/test_hybrid_newton_schulz.py
@@ -1,4 +1,4 @@
-"""Tests for hybrid Newton-Schulz orthogonalization (DeepSeek-V4)."""
+"""Tests for hybrid (8 Muon + 2 classical) Newton-Schulz orthogonalization."""
 
 import pytest
 import torch

--- a/tests/test_hybrid_newton_schulz.py
+++ b/tests/test_hybrid_newton_schulz.py
@@ -1,0 +1,67 @@
+"""Tests for hybrid Newton-Schulz orthogonalization (DeepSeek-V4)."""
+
+import pytest
+import torch
+
+from dion.hybrid_newton_schulz import hybrid_newton_schulz
+from dion.polar_express import polar_express
+from dion.newton_schulz_triton import zeropower_via_newtonschulz5
+
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+SHAPES = [
+    (64, 128),    # wide
+    (128, 64),    # tall
+    (128, 128),   # square
+]
+BATCH_SHAPES = [
+    (4, 64, 128),   # batched wide
+    (4, 128, 64),   # batched tall
+]
+# Hybrid NS runs 10 bf16 iterations; the last 2 steps use the canonical
+# (2, -1.5, 0.5) schedule which pins singular values at 1, so orthogonality
+# residuals are comparable to NS5 rather than PE (looser 0.15 used for PE).
+ORTHO_ATOL = 0.05
+
+
+@pytest.mark.parametrize("shape", SHAPES + BATCH_SHAPES)
+def test_hybrid_newton_schulz_produces_orthogonal_output(shape):
+    torch.manual_seed(42)
+    G = torch.randn(shape, device=DEVICE)
+    X = hybrid_newton_schulz(G)
+
+    if shape[-2] <= shape[-1]:
+        product = X.float() @ X.float().mT
+    else:
+        product = X.float().mT @ X.float()
+
+    eye = torch.eye(product.shape[-1], device=DEVICE).expand_as(product)
+    err = (product - eye).abs().max().item()
+    assert err < ORTHO_ATOL, (
+        f"Not orthogonal for shape {shape}: max error {err:.4f}"
+    )
+
+
+@pytest.mark.parametrize("shape", SHAPES)
+def test_hybrid_newton_schulz_vs_references(shape):
+    torch.manual_seed(42)
+    G = torch.randn(shape, device=DEVICE)
+
+    X_hybrid = hybrid_newton_schulz(G)
+    X_pe = polar_express(G)
+    X_ns = zeropower_via_newtonschulz5(G)
+
+    assert X_hybrid.shape == X_pe.shape == X_ns.shape
+
+    for label, X, atol in [
+        ("hybrid", X_hybrid, ORTHO_ATOL),
+        ("PE", X_pe, 0.15),
+        ("NS", X_ns, 0.15),
+    ]:
+        if shape[-2] <= shape[-1]:
+            product = X.float() @ X.float().mT
+        else:
+            product = X.float().mT @ X.float()
+        eye = torch.eye(product.shape[-1], device=DEVICE)
+        err = (product - eye).abs().max().item()
+        assert err < atol, f"{label} not orthogonal for shape {shape}: {err:.4f}"


### PR DESCRIPTION
## Summary
- Adds the 10-step two-stage Newton-Schulz schedule from DeepSeek-V4 (Algorithm 1, Eq. 28) as an opt-in orthogonalization.
- First 8 iterations use coefficients (3.4445, -4.7750, 2.0315); last 2 use (2, -1.5, 0.5).
- Input is normalized by its Frobenius norm per the paper (no safety cushion).
- Enable with ``use_hybrid_newton_schulz=True`` on \`Muon\`, \`NorMuon\`, or \`Dion2\`. Default remains Polar Express.

## Files
- ``dion/hybrid_newton_schulz.py`` — pure-PyTorch, ``torch.compile``d implementation.
- ``dion/megabatch_base.py`` — dispatch branch (before Polar Express).
- ``dion/muon.py`` / ``dion/normuon.py`` / ``dion/dion2.py`` — new kwarg plumbed through.
- ``tests/test_hybrid_newton_schulz.py`` — orthogonality and shape-parity tests covering square/tall/wide/batched inputs.

## Notes
- Paper URL: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro (§2.4, Algorithm 1).
- No Triton variant in this PR — the goal for a first pass is to validate the schedule statistically. Triton reuse of the existing ``ns_line_1`` / ``ns_line_2`` kernels is straightforward to add later if the statistical story holds up.
- This is 10 iterations vs. 5 for Polar Express / NS5, so there is no compute win to claim; the question is purely whether the schedule converges better.

## Test plan
- [x] ``pytest tests/test_hybrid_newton_schulz.py`` — 8/8 pass locally (bf16, CUDA).
- [ ] 1B params / 1B tokens run on climbmix to compare against the current ``semantic/control`` baseline (follow-up).

Closes #66.