### PR TITLE
Work around torch.compile inductor bug for Dion2 3D tensor tests

### DIFF
--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -264,6 +264,13 @@ def dion2_update_megabatch_async(
     )
 
 
+# Workaround for a torch.compile bug in PyTorch 2.11's inductor backend:
+# the post-fusion loop reordering pass crashes when ForeachKernelSchedulerNode
+# appears inside a FusedSchedulerNode.
+# https://github.com/pytorch/pytorch/issues/176591
+# Disabling this pass is safe — it only affects a minor loop-order
+# optimization, not correctness.
+@torch._inductor.config.patch(loop_ordering_after_fusion=False)
 @torch.compile(fullgraph=True)
 def dion2_pre_orthogonalize(
     G: List[Tensor],

--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -264,13 +264,20 @@ def dion2_update_megabatch_async(
     )
 
 
-# Workaround for a torch.compile bug in PyTorch 2.11's inductor backend:
+# Workaround for a torch.compile bug in PyTorch ≤2.11's inductor backend:
 # the post-fusion loop reordering pass crashes when ForeachKernelSchedulerNode
-# appears inside a FusedSchedulerNode.
+# appears inside a FusedSchedulerNode.  Only triggered by recompilation across
+# different tensor dimensionalities (e.g. 2D then 3D).
 # https://github.com/pytorch/pytorch/issues/176591
-# Disabling this pass is safe — it only affects a minor loop-order
-# optimization, not correctness.
-@torch._inductor.config.patch(loop_ordering_after_fusion=False)
+# TODO: remove this decorator when pytorch/pytorch#176591 is fixed.
+_inductor_workaround = (
+    torch._inductor.config.patch(loop_ordering_after_fusion=False)
+    if torch.__version__ < "2.13"
+    else lambda fn: fn
+)
+
+
+@_inductor_workaround
 @torch.compile(fullgraph=True)
 def dion2_pre_orthogonalize(
     G: List[Tensor],
@@ -345,6 +352,9 @@ def dion2_pre_orthogonalize(
     return U_selected, indices_list
 
 
+# NOTE: if this function starts failing with an InductorError on recompilation
+# across tensor ranks, apply the same _inductor_workaround used on
+# dion2_pre_orthogonalize above.  See pytorch/pytorch#176591.
 @torch.compile(fullgraph=True)
 def dion2_post_orthogonalize(
     X: List[Tensor],


### PR DESCRIPTION
Four Dion2 tests on `main` fail with an `InductorError` when `torch.compile` recompiles `dion2_pre_orthogonalize` for 3D tensors after previously compiling it for 2D tensors:

```
pytest tests/test_optimizers.py -k "TestDion2::test_3d_params_tall or TestDion2::test_3d_params_wide or TestDion2::test_3d_megabatch or TestNumHeads::test_dion2_matches_3d"
```

The root cause is a bug in PyTorch 2.11's inductor scheduler: `FusedSchedulerNode.reorder_loops_by_dep_pair` asserts `isinstance(snode, SchedulerNode)`, but `ForeachKernelSchedulerNode` (produced by `_foreach_*` ops) is a sibling class, not a subclass. This crashes during the post-fusion loop reordering pass when the compiled function is recompiled for a different tensor dimensionality.

This is admittedly a somewhat hacky fix — we work around the PyTorch bug by disabling the `loop_ordering_after_fusion` inductor optimization on the affected function via `@torch._inductor.config.patch`. This is scoped narrowly to just `dion2_pre_orthogonalize` and only disables a minor loop-order optimization, not correctness. There is no public API alternative.

Upstream issue: https://github.com/pytorch/pytorch/issues/176591