### PR TITLE
Add: MuonH (Hyperball optimizer) + add option for 'neuron' or 'short_axis' normalization for norMuon and MuonH

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This repository provides efficient implementations of orthonormal optimizers for distributed ML training.
 You can find the following optimizers:
 * [Muon](https://kellerjordan.github.io/posts/muon/)
+* [MuonH](https://tinyurl.com/muonh)
 * [Dion2](https://arxiv.org/abs/2512.16928) and [Dion](https://arxiv.org/pdf/2504.05295) (Dion is a legacy optimizer; we recommend using Dion2)
 * [NorMuon](https://arxiv.org/abs/2510.05491) 
 
@@ -15,6 +16,7 @@ You can find the following optimizers:
 1. [Quick Start](#-quick-start)
 1. [Introduction](#introduction)
 1. [Optimizers](#optimizers)
+   * [MuonH](#muonh)
 1. [Building Parameter Groups](#building-parameter-groups)
    * [Example Code](#example-code)
    * [Per-Head Newton-Schulz for Attention Projections](#per-head-newton-schulz-for-attention-projections)
@@ -53,7 +55,7 @@ pip install git+https://github.com/microsoft/dion.git
 Then in your code, you can use:
 
 ```python
-from dion import Dion2, Muon, NorMuon, Dion
+from dion import Dion2, Muon, MuonH, NorMuon, Dion
 ```
 
 Please carefully go through this readme for detailed instructions on using our optimizers. There are major differences compared to PyTorch built-in optimizers, such as `Adam`/`AdamW`.
@@ -146,12 +148,12 @@ The practical effectiveness of orthonormal optimizers was first demonstrated by 
 
 Our current implementations support the following parallelization techniques:
 
-| Parallelization    | Dion | Dion2 | Muon | NorMuon |
-|--------------------|------|-------|------|---------| 
-| Single device      | Yes  |  Yes  | Yes  |   Yes   |
-| PyTorch DDP        | Yes  |  Yes  | Yes  |   Yes   |
-| PyTorch FSDP2      | Yes  |  Yes  | Yes  |   Yes   |
-| PyTorch FSDP2 + TP | Yes  |  No   | No   |   No    |
+| Parallelization    | Dion | Dion2 | Muon | MuonH | NorMuon |
+|--------------------|------|-------|------|-------|---------| 
+| Single device      | Yes  |  Yes  | Yes  |  Yes  |   Yes   |
+| PyTorch DDP        | Yes  |  Yes  | Yes  |  Yes  |   Yes   |
+| PyTorch FSDP2      | Yes  |  Yes  | Yes  |  Yes  |   Yes   |
+| PyTorch FSDP2 + TP | Yes  |  No   | No   |   No  |   No    |
 
 For faster performance, these optimizers will process parameters in batches and interleave multiple batches to overlap compute with communication.
 
@@ -159,8 +161,33 @@ We include optimizer implementations in the `dion/` directory of this repo.
  
 * `dion.py`: High-performance version of Dion. Depending on how each batch of matrices is sharded, we select the best communication patterns to compute Dion's orthonormal update. All-reduce operations may be split into reduce-scatter and all-gather across the batch dimension to more efficiently distribute work and avoid redundant computation.
 * `muon.py`: High-performance version of Muon. For sharded matrices, all-to-all communication is used to simultaneously unshard and distribute a batch of matrices. For replicated matrices, Muon will distribute work across all devices and all-gather final results.
+* `muonh.py`: Muon with a hyperball update. After Newton-Schulz orthonormalization (and optional update normalization), each matrix update is scaled relative to that matrix's Frobenius norm and projected back to its initial Frobenius norm.
 * **`dion2.py`**: High-performance implementation of Dion2, using a similar all-to-all communication pattern for distributed orthonormalization. Only an α-fraction of the momentum matrix is communicated and orthonormalized, significantly reducing both communication overhead and computation cost.
 * `normuon.py`: A variant of the Muon optimizer that introduces neuron-wise normalization to improve stability and convergence efficiency, modified to take similar arguments as `muon.py`. See [the paper](https://arxiv.org/abs/2510.05491) for more details.
+
+### MuonH
+
+MuonH combines Muon's momentum + Newton-Schulz direction with a hyperball projection step. Conceptually, the optimizer keeps each matrix parameter on a Frobenius sphere: after forming the Muon-style update direction, MuonH moves along that direction and projects back to the matrix's initial Frobenius norm. This implementation follows [Fantastic Pretraining Optimizers and Where to Find Them 2.1: Hyperball Optimization](https://tinyurl.com/muonh).
+
+Compared with Muon, MuonH has a few important usage constraints and semantics:
+
+* **Non-zero initialization is required.** MuonH initializes its hyperball radius from the parameter norm on the first optimizer step, so a zero-initialized matrix will raise an error.
+* **Hyperball state is per matrix.** For ordinary 2D weights this is one radius per parameter. For packed matrix tensors such as MoE expert weights of shape `(n_experts, d_out, d_in)`, MuonH treats each trailing 2D matrix independently when `flatten=False`, so each expert gets its own momentum / normalization / hyperball radius.
+* **`flatten=False` is the right mode for packed experts.** A tensor of shape `(..., d_out, d_in)` is treated as a batch of matrices. This is the intended mode for MoE expert MLP weights and other native 3D matrix batches.
+* **`flatten=True` changes the semantics.** With `flatten=True`, MuonH flattens the parameter to one 2D matrix before orthonormalization and hyperball projection. Use this for convolution kernels only when you explicitly want the whole tensor treated as one matrix.
+* **`num_heads` is not supported.** MuonH deliberately rejects `num_heads > 1`. If you want per-head MuonH behavior, represent heads as explicit matrices, e.g. a native 3D tensor of shape `(num_heads, head_dim, in_features)` or separate `Parameter`s.
+* **Optional normalization matches NorMuon-style update normalization.** `normalization=None` disables it, `normalization="neuron"` normalizes along the last dimension, and `normalization="short_axis"` normalizes along the shorter matrix axis.
+* **Matrix params do not use decoupled weight decay.** As with Muon, embeddings, LM heads, biases, and normalization parameters should remain on AdamW or Lion parameter groups.
+
+Example:
+
+```python
+optimizer = MuonH(
+    param_groups,
+    lr=0.01,
+    normalization="short_axis",
+)
+```
 
 We also provide some reference implementations:
 
@@ -172,17 +199,19 @@ We also provide some reference implementations:
 
 ## Building Parameter Groups
 
-Unlike typical PyTorch optimizers (e.g. `Adam`/`AdamW`), Dion and Muon require separating your model's parameters into different groups (same in spirit as [Modula](https://docs.modula.systems/)). These orthonormal optimization algorithms are only applicable to two-dimensional matrix weights. Non-matrix parameters require a different scalar optimizer algorithm (element-wise updates) and may also use a different learning rate. We currently support Lion and AdamW.
+Unlike typical PyTorch optimizers (e.g. `Adam`/`AdamW`), Dion and the Muon-family optimizers require separating your model's parameters into different groups (same in spirit as [Modula](https://docs.modula.systems/)). These orthonormal optimization algorithms are intended for matrix weights. For Muon, MuonH, and NorMuon, a parameter with shape `(..., d_out, d_in)` may also be treated as a batch of matrices when that matches the model semantics. Non-matrix parameters require a different scalar optimizer algorithm (element-wise updates) and may also use a different learning rate. We currently support Lion and AdamW.
 
 The details of parameter grouping are dependent on model architecture and implementation. Therefore, we leave it up to you to categorize your model's parameters and create the necessary parameter groups.
 
-* In transformer models and many other neural networks, most parameters are `nn.Linear` layers with two-dimensional weight matrices. These parameters should use Dion or Muon. A shape-dependent learning rate scale factor will be automatically applied for each matrix.
+* In transformer models and many other neural networks, most parameters are `nn.Linear` layers with two-dimensional weight matrices. These parameters should use Dion, Muon, MuonH, or NorMuon. A shape-dependent learning rate scale factor will be automatically applied for each matrix.
 * Biases in `nn.Linear` layers (if used) are one-dimensional vectors, which must be placed into a separate parameter group from the weight matrices. Use Lion or AdamW.
 * Normalization layers (e.g. `nn.LayerNorm`, `nn.RMSNorm`) may contain vectors of learnable weights. Use Lion or AdamW.
 * Embedding layers (e.g. `nn.Embedding`) are stored as 2D tensors, but should be treated as a collection of 1D vectors using Lion or AdamW. (Warning: using Dion here will run without error, but will give poor performance.)
 * Unembedding layers (e.g. LM head) are typically implemented as a `nn.Linear` layer, but shoud also be treated as a collection of 1D vectors. Furthermore, they should use a **smaller scaled learning rate**. It is very important to manually identify this layer and place it into its own parameter group, as it is otherwise indistinguishable from weight matrices!
 (Warning: using Dion here will run without error, but will give poor performance.)
-* Convolution layers typically use parameter tensors with 3+ dimensions. These are currently not supported for Dion. Support for convolution layers in Muon is experimental, and can be enabled with the option `flatten=True` to automatically flatten them to 2D matrices when computing the optimizer update.
+* Packed expert weights such as MoE MLP parameters with shape `(n_experts, d_out, d_in)` are a natural fit for Muon, MuonH, and NorMuon with `flatten=False`, since each expert is treated as an independent matrix.
+* Convolution layers typically use parameter tensors with 3+ dimensions. These are currently not supported for Dion. Support for convolution layers in Muon-family optimizers is experimental and generally requires `flatten=True` so the whole kernel tensor is treated as one 2D matrix.
+* MuonH requires non-zero matrix initialization. Do not assign zero-initialized output projections or other zero-initialized matrices to MuonH.
 
 We summarize the above in this table. Let `d_in` be the input dimension of the unembedding layer. In transformer language models, this is the base dimension of the model.
 
@@ -258,15 +287,15 @@ param_groups = [
 
 When `num_heads > 1`, the optimizer views each 2D weight as a batch of `num_heads` matrices of shape `(head_dim, in_features)` internally. The learning-rate adjustment (`spectral_norm` / `rms_norm`) is computed per-head, and Newton-Schulz runs on each head independently. With FSDP, sharding dim 0 along head boundaries (i.e. `num_heads % world_size == 0`) avoids the all-to-all that would otherwise be needed to assemble the fused matrix before NS.
 
-Requirements: the parameter must be 2D, `num_heads` must divide dim 0, and when using FSDP it must also divide the world size. Place Q / K / V / gate projections in one group (axis-0 heads); O-projection heads are on axis 1 and are not covered by this option.
+Requirements: the parameter must be 2D, `num_heads` must divide dim 0, and when using FSDP it must also divide the world size. Place Q / K / V / gate projections in one group (axis-0 heads); O-projection heads are on axis 1 and are not covered by this option. MuonH does not implement this option; use an explicit 3D parameter or separate Parameters if you want per-head MuonH behavior.
 
 ## Distributed Training Configuration
 
 For our efficient distributed optimizers to work correctly, they need information about the model's parallelization scheme. This is provided by passing `DeviceMesh` objects during optimizer construction.
 
-### 1D Sharding Configuration (Dion2, Muon, NorMuon)
+### 1D Sharding Configuration (Dion2, Muon, MuonH, NorMuon)
 
-Most optimizers in this codebase (Dion2, Muon, NorMuon) currently support only 1D sharding. They accept a single 1D device mesh via the `distributed_mesh` argument and adapt their behavior based on how this mesh is used:
+Most optimizers in this codebase (Dion2, Muon, MuonH, NorMuon) currently support only 1D sharding. They accept a single 1D device mesh via the `distributed_mesh` argument and adapt their behavior based on how this mesh is used:
 
 - **If the mesh is used for parameter sharding**: The optimizer efficiently unshards parameters using all-to-all communication
 - **If the mesh is not used for sharding**: The optimizer distributes work across devices and all-gathers the final results
@@ -285,7 +314,7 @@ mesh = init_device_mesh(
 fully_shard(model, mesh=mesh)
 
 # Pass only the sharded dimension to the optimizer
-optimizer = Dion2(                     # or Muon or NorMuon
+optimizer = Dion2(                     # or Muon or MuonH or NorMuon
     param_groups,
     distributed_mesh=mesh["shard"],    # 1D sub-mesh (sharded dimension only)
     ...
@@ -308,7 +337,7 @@ mesh = init_device_mesh(
 fs_mesh = mesh["dp", "cp"]._flatten()
 fully_shard(model, mesh=fs_mesh)
 
-optimizer = Dion2(                  # or Muon or NorMuon
+optimizer = Dion2(                  # or Muon or MuonH or NorMuon
     param_groups,
     distributed_mesh = fs_mesh,     # Sharded data parallel across flattened mesh 
     ...
@@ -322,7 +351,7 @@ Training with DistributedDataParallel (DDP) is also supported. DDP uses PyTorch 
 ```python
 ddp_model = DistributedDataParallel(model, ...)
 
-optimizer = Dion2(                              # or Muon or NorMuon
+optimizer = Dion2(                              # or Muon or MuonH or NorMuon
     param_groups,
     distributed_mesh=ddp_model.process_group,
     ...
@@ -363,6 +392,7 @@ optimizer = Dion(
 * **2D sharding:** If weights are sharded with both FSDP and TP, it is required that the sharding methods are applied to different matrix dimensions. The TP sharding dimension is controlled via `RowwiseParallel` and `ColwiseParallel`, but the FSDP sharding dimension needs to be manually specified when applied on top of TP. See `models/gpt_model.py` for an example of explicitly providing `fully_shard()` with per-parameter shard dimensions. Double-sharded matrices along the same dimension will raise an error in Dion.
 * **Learning rate scaling:** Dion will automatically scale the provided learning rate by `sqrt(d_out / d_in)` for matrix parameters. Muon will apply the same scaling by default, but also supports the `0.2 * sqrt(max(d_in, d_out))` scale factor recommended by Moonshot AI. Our default scale factor is intended to induce a consistent change to activation vector values, which enables learning rate transfer across model size. See [Deriving Muon](https://jeremybernste.in/writing/deriving-muon) for more information.
 * **Nesterov momentum:** In Muon, we set Nesterov momentum to `False` by default, as we observed better performance without it. Dion does not implement Nesterov momentum.
+* **MuonH initialization and batching:** MuonH requires non-zero matrix initialization. For packed expert tensors such as `(n_experts, d_out, d_in)`, keep `flatten=False` so each expert is treated as its own matrix. For convolution kernels, `flatten=True` is usually the only sensible MuonH mode.
 
 
 ## Other Features

--- a/dion/__init__.py
+++ b/dion/__init__.py
@@ -3,6 +3,7 @@ from .dion import DionMixedPrecisionConfig
 from .dion_simple import Dion as DionSimple
 from .dion_reference import Dion as DionReference
 from .muon import Muon
+from .muonh import MuonH
 from .muon_reference import Muon as MuonReference
 from .dion2 import Dion2
 from .normuon import NorMuon

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -19,6 +19,36 @@ from .opt_utils import AsyncRuntime, AsyncTask, to_local
 from .scalar_opts import adamw_update_foreach_async, lion_update_foreach_async
 
 
+def canonical_normalization(
+    normalization: Optional[str],
+    allow_none: bool = False,
+) -> Optional[str]:
+    """Validate and canonicalize an update-normalization mode string.
+
+    Accepts ``'neuron'``/``'short_axis'`` (case-insensitive). When
+    ``allow_none=True``, also accepts ``None`` and the string ``'None'``,
+    returning Python ``None`` for both. Raises ``ValueError`` otherwise.
+    """
+    if normalization is None or (
+        isinstance(normalization, str) and normalization.lower() == "none"
+    ):
+        if allow_none:
+            return None
+        raise ValueError(
+            f"Invalid normalization: {normalization}. Must be 'neuron' or 'short_axis'."
+        )
+    if isinstance(normalization, str):
+        value = normalization.lower()
+        if value in ("neuron", "short_axis"):
+            return value
+    valid = (
+        "None, 'None', 'neuron', or 'short_axis'"
+        if allow_none
+        else "'neuron' or 'short_axis'"
+    )
+    raise ValueError(f"Invalid normalization: {normalization}. Must be {valid}.")
+
+
 class DistributedOrthoBase(Optimizer):
     """
     Shared base class for distributed orthogonalization optimizers (NorMuon, Dion2).

--- a/dion/muonh.py
+++ b/dion/muonh.py
@@ -352,6 +352,30 @@ def muonh_update_megabatch_async(
     )
 
 
+@torch.compile(fullgraph=True, dynamic=False)
+def _muonh_sum_sq_compiled(U_stacked: Tensor, red_dim: int) -> Tensor:
+    return U_stacked.float().square().sum(dim=red_dim, keepdim=True)
+
+
+@torch.compile(fullgraph=True, dynamic=False)
+def _muonh_normalize_finish_compiled(
+    U_stacked: Tensor,
+    V_stacked: Tensor,
+    sum_sq: Tensor,
+    red_dim_size: int,
+    muon_beta2: Tensor,
+    epsilon: float,
+) -> Tuple[Tensor, Tensor]:
+    V_dtype = V_stacked.dtype
+    variance_new = (sum_sq / red_dim_size).to(dtype=V_dtype)
+    norm_U = U_stacked.float().norm(p=2, dim=(-2, -1), keepdim=True)
+    V_stacked = torch.lerp(V_stacked, variance_new, 1 - muon_beta2)
+    normalized_U = U_stacked.float() / (V_stacked.float().sqrt() + epsilon)
+    norm_U_new = normalized_U.norm(p=2, dim=(-2, -1), keepdim=True).clamp(min=epsilon)
+    normalized_U = (normalized_U * (norm_U / norm_U_new)).to(dtype=V_dtype)
+    return normalized_U, V_stacked
+
+
 def muonh_normalization_async(
     U: List[Tensor],
     V: List[Tensor],
@@ -362,7 +386,11 @@ def muonh_normalization_async(
     process_group: Optional[ProcessGroup],
     epsilon: Tensor,
 ) -> Generator[None, None, List[Tensor]]:
-    """Optional MuonH update normalization, with reductions when the normalized axis is sharded."""
+    """Optional MuonH update normalization, with reductions when the normalized axis is sharded.
+
+    Pure-tensor pre-/post-comm sections are compiled; the async dist.all_reduce
+    sits in between and stays in eager Python.
+    """
     U_stacked = torch.stack(U)
     V_stacked = torch.stack(V)
 
@@ -370,7 +398,7 @@ def muonh_normalization_async(
     if normalization == "short_axis" and param_shape[-2] < param_shape[-1]:
         red_dim = -2
 
-    sum_sq = U_stacked.float().square().sum(dim=red_dim, keepdim=True)
+    sum_sq = _muonh_sum_sq_compiled(U_stacked, red_dim)
     shard_dim_neg = None
     if shard_dim is not None:
         shard_dim_neg = shard_dim if shard_dim < 0 else shard_dim - len(param_shape)
@@ -379,21 +407,53 @@ def muonh_normalization_async(
         yield
         work.wait()
 
-    red_dim_size = param_shape[red_dim]
-    variance_new = sum_sq / red_dim_size
-    norm_U = U_stacked.float().norm(p=2, dim=(-2, -1), keepdim=True)
+    normalized_U, V_stacked = _muonh_normalize_finish_compiled(
+        U_stacked, V_stacked, sum_sq, param_shape[red_dim], muon_beta2, float(epsilon),
+    )
 
-    V_dtype = V_stacked.dtype
-    V_stacked = torch.lerp(V_stacked, variance_new.to(dtype=V_dtype), 1 - muon_beta2)
+    torch._foreach_copy_(list(V), list(V_stacked.unbind(0)))
+    return list(normalized_U.unbind(0))
 
-    normalized_U = U_stacked.float() / (V_stacked.float().sqrt() + float(epsilon))
-    norm_U_new = normalized_U.norm(p=2, dim=(-2, -1), keepdim=True).clamp(min=float(epsilon))
-    normalized_U = normalized_U * (norm_U / norm_U_new)
-    normalized_U = normalized_U.to(dtype=V_dtype)
 
-    for i in range(len(V)):
-        V[i].copy_(V_stacked[i])
-    return [normalized_U[i] for i in range(len(U))]
+@torch.compile(fullgraph=True, dynamic=False)
+def _muonh_sq_sum_flat_compiled(stacked: Tensor) -> Tensor:
+    return stacked.float().square().flatten(1).sum(dim=-1)
+
+
+@torch.compile(fullgraph=True, dynamic=False)
+def _muonh_step_compiled(
+    X_stacked: Tensor,
+    U_stacked: Tensor,
+    update_sq_sums: Tensor,
+    radii: Tensor,
+    adjusted_lr: Tensor,
+    eps: float,
+) -> Tuple[Tensor, Tensor]:
+    x_dtype = X_stacked.dtype
+    extra = X_stacked.ndim - 1
+    update_norms = update_sq_sums.sqrt()
+    scales = (adjusted_lr * radii / update_norms.clamp_min(eps)).to(dtype=x_dtype)
+    for _ in range(extra):
+        scales = scales.unsqueeze(-1)
+    candidate_stacked = X_stacked - U_stacked * scales
+    candidate_sq_sums = candidate_stacked.float().square().flatten(1).sum(dim=-1)
+    return candidate_stacked, candidate_sq_sums
+
+
+@torch.compile(fullgraph=True, dynamic=False)
+def _muonh_project_compiled(
+    candidate_stacked: Tensor,
+    candidate_sq_sums: Tensor,
+    radii: Tensor,
+    eps: float,
+) -> Tensor:
+    x_dtype = candidate_stacked.dtype
+    extra = candidate_stacked.ndim - 1
+    candidate_norms = candidate_sq_sums.sqrt()
+    scales = (radii / candidate_norms.clamp_min(eps)).to(dtype=x_dtype)
+    for _ in range(extra):
+        scales = scales.unsqueeze(-1)
+    return candidate_stacked * scales
 
 
 def muonh_update_post_orthogonalize_async(
@@ -404,27 +464,42 @@ def muonh_update_post_orthogonalize_async(
     epsilon: Tensor,
     process_group: Optional[ProcessGroup],
 ) -> Generator[None, None, None]:
-    """Apply a scale-invariant hyperball step and project back to stored radii."""
-    device = X[0].device
+    """Apply a scale-invariant hyperball step and project back to stored radii.
+
+    Pure-tensor sections are compiled and split around the optional async
+    all-reduces of the update / candidate Frobenius norms.
+    """
     eps = float(epsilon)
-    radii = torch.stack([r.to(device=device, dtype=torch.float32) for r in R])
-    lr = adjusted_lr.to(device=device, dtype=torch.float32)
+    radii = torch.stack(list(R))
+    x_dtype = X[0].dtype
 
-    update_norms = yield from _fro_norms_async(U, process_group)
-    step_scales = lr * radii / update_norms.clamp_min(eps)
-    candidates = [
-        x - u.to(dtype=x.dtype) * step_scales[i].to(device=x.device, dtype=x.dtype)
-        for i, (x, u) in enumerate(zip(X, U))
-    ]
+    U_stacked = torch.stack(U).to(dtype=x_dtype)
+    X_stacked = torch.stack(list(X))
 
-    candidate_norms = yield from _fro_norms_async(candidates, process_group)
-    project_scales = radii / candidate_norms.clamp_min(eps)
-    for i, (x, candidate) in enumerate(zip(X, candidates)):
-        x.copy_(candidate * project_scales[i].to(device=x.device, dtype=candidate.dtype))
+    update_sq_sums = _muonh_sq_sum_flat_compiled(U_stacked)
+    if process_group is not None:
+        work = dist.all_reduce(update_sq_sums, group=process_group, async_op=True)
+        yield
+        work.wait()
+
+    candidate_stacked, candidate_sq_sums = _muonh_step_compiled(
+        X_stacked, U_stacked, update_sq_sums, radii, adjusted_lr, eps,
+    )
+    if process_group is not None:
+        work = dist.all_reduce(candidate_sq_sums, group=process_group, async_op=True)
+        yield
+        work.wait()
+
+    final_stacked = _muonh_project_compiled(
+        candidate_stacked, candidate_sq_sums, radii, eps,
+    )
+    torch._foreach_copy_(list(X), list(final_stacked.unbind(0)))
 
 
 def _local_square_sums(tensors: List[Tensor]) -> Tensor:
-    return torch.stack([t.float().square().sum() for t in tensors])
+    """Per-tensor sum of squares, fused via a single stack + flatten + sum."""
+    stacked = torch.stack(tensors).float()
+    return stacked.square().flatten(1).sum(dim=-1) if stacked.ndim > 1 else stacked.square()
 
 
 def _fro_norms_async(

--- a/dion/muonh.py
+++ b/dion/muonh.py
@@ -1,0 +1,439 @@
+import torch
+import torch.distributed as dist
+from collections import defaultdict
+from torch import Tensor
+from torch.distributed import ProcessGroup
+from torch.distributed.tensor import DeviceMesh, DTensor
+from torch.optim.optimizer import ParamsT
+from typing import Callable, Generator, List, Optional, Tuple, Union
+
+from .megabatch_base import (
+    DistributedOrthoBase,
+    megabatch_orthogonalize_async,
+    adjust_lr_spectral_norm,
+    adjust_lr_rms_norm,
+)
+from .opt_utils import AsyncTask, to_local
+from .muon import muon_update_pre_orthogonalize
+
+
+def _canonical_normalization(normalization: Optional[str]) -> Optional[str]:
+    if normalization is None:
+        return None
+    if isinstance(normalization, str):
+        value = normalization.lower()
+        if value == "none":
+            return None
+        if value in ("neuron", "short_axis"):
+            return value
+    raise ValueError(
+        f"Invalid normalization: {normalization}. "
+        "Must be None, 'None', 'neuron', or 'short_axis'."
+    )
+
+
+class MuonH(DistributedOrthoBase):
+    """
+    Distributed MuonH optimizer for PyTorch FSDP2. Also compatible with DDP.
+
+    MuonH uses Muon's momentum + orthogonalization direction, then applies a
+    hyperball update: the step is scaled relative to each parameter's Frobenius
+    norm, and the parameter is projected back to its initial Frobenius norm.
+
+    Args:
+        params: Parameters for the optimizer.
+        distributed_mesh: DeviceMesh or ProcessGroup for distributed training.
+            Use DeviceMesh for FSDP2 and ProcessGroup for DistributedDataParallel.
+        lr: Base hyperball learning rate. This controls the relative move size
+            before projection back to the Frobenius sphere.
+        mu: Momentum factor for Muon.
+        muon_beta2: EMA factor for optional normalization buffers.
+        normalization: Optional update normalization. None/'None' disables it,
+            'neuron' normalizes along the last dimension, and 'short_axis'
+            normalizes along the shorter matrix axis.
+        betas: Tuple of (beta1, beta2) for AdamW and Lion param groups.
+        weight_decay: Weight decay factor for AdamW/Lion param groups.
+            MuonH matrix params do not use decoupled weight decay.
+        epsilon: Small value for orthogonalization.
+        hyperball_eps: Small value for hyperball norm divisions.
+        nesterov: Whether to use Nesterov momentum.
+        adjust_lr: How to adjust the learning rate ("spectral_norm" or "rms_norm" or None).
+        flatten: Whether to flatten 3D+ tensors to 2D for orthogonalization.
+        use_gram_newton_schulz: Whether to use Gram Newton-Schulz for orthogonalization.
+        use_triton: Whether to use Triton kernel for Newton-Schulz.
+        newton_schulz_func: Use a custom Newton-Schulz function for orthogonalization.
+
+    Muon optimizer algorithm by Keller Jordan: https://kellerjordan.github.io/posts/muon/
+    Hyperball optimization: https://psychedelic-sunstone-851.notion.site/Fantastic-Pretraining-Optimizers-and-Where-to-Find-Them-2-1-Hyperball-Optimization-2e924306e6f280e7a5ffee00eb40a0dd
+    """
+
+    def __init__(
+        self,
+        params: ParamsT,
+        distributed_mesh: Optional[Union[DeviceMesh, ProcessGroup]] = None,
+        lr: float = 0.01,
+        mu: float = 0.95,
+        muon_beta2: float = 0.95,
+        normalization: Optional[str] = None,
+        betas: Tuple[float, float] = (0.9, 0.95),
+        weight_decay: float = 0.01,
+        epsilon: float = 1e-8,
+        hyperball_eps: float = 1e-10,
+        nesterov: bool = False,
+        adjust_lr: Optional[str] = None,
+        flatten: bool = False,
+        use_gram_newton_schulz: bool = False,
+        use_triton: bool = False,
+        use_polar_express: bool = True,
+        newton_schulz_func: Optional[Callable] = None,
+    ):
+        if lr < 0.0:
+            raise ValueError(f"Invalid learning rate: {lr}")
+        if mu < 0.0:
+            raise ValueError(f"Invalid momentum factor (mu): {mu}")
+        if muon_beta2 < 0.0:
+            raise ValueError(f"Invalid muon_beta2: {muon_beta2}")
+        if len(betas) != 2 or betas[0] < 0.0 or betas[1] < 0.0:
+            raise ValueError(f"Invalid betas: {betas}")
+        if hyperball_eps < 0.0:
+            raise ValueError(f"Invalid hyperball_eps: {hyperball_eps}")
+        if adjust_lr not in ("spectral_norm", "rms_norm", None):
+            raise ValueError(
+                f"Invalid adjust_lr value: {adjust_lr}. Must be 'spectral_norm', 'rms_norm', or None."
+            )
+
+        normalization = _canonical_normalization(normalization)
+        defaults = dict(
+            lr=lr,
+            mu=mu,
+            muon_beta2=muon_beta2,
+            normalization=normalization,
+            beta1=betas[0],
+            beta2=betas[1],
+            weight_decay=weight_decay,
+            algorithm="muonh",
+            step=0,
+            epsilon=epsilon,
+            hyperball_eps=hyperball_eps,
+            nesterov=nesterov,
+            flatten=flatten,
+            adjust_lr=adjust_lr,
+        )
+        super().__init__(
+            params, distributed_mesh, "muonh", defaults,
+            use_gram_newton_schulz=use_gram_newton_schulz,
+            use_triton=use_triton,
+            use_polar_express=use_polar_express,
+            newton_schulz_func=newton_schulz_func,
+        )
+
+    def _get_or_initialize_state(self, param: Tensor, algo: str) -> dict:
+        state = super()._get_or_initialize_state(param, algo)
+        if algo == self._algo_name and "hyperball_radius" not in state:
+            local = to_local(param)
+            state["hyperball_radius"] = torch.zeros(
+                (), device=local.device, dtype=torch.float32
+            )
+            state["hyperball_radius_initialized"] = False
+        return state
+
+    def _get_or_initialize_variance(
+        self, param: Tensor, state: dict, normalization: Optional[str]
+    ) -> Optional[Tensor]:
+        if normalization is None:
+            return None
+
+        local = to_local(param)
+        shape = list(local.shape)
+        if normalization == "neuron":
+            shape[-1] = 1
+        elif normalization == "short_axis":
+            red_dim = -1 if param.shape[-2] >= param.shape[-1] else -2
+            shape[red_dim] = 1
+        else:
+            raise ValueError(f"Unknown normalization: {normalization}")
+
+        variance = state.get("variance_normalization")
+        if variance is None or tuple(variance.shape) != tuple(shape):
+            variance = torch.zeros(shape, device=local.device, dtype=local.dtype)
+            state["variance_normalization"] = variance
+        return variance
+
+    def _initialize_hyperball_radii(
+        self,
+        params: List[Tensor],
+        states: List[dict],
+        process_group: Optional[ProcessGroup],
+        shard_dim: Optional[int],
+        hyperball_eps: Tensor,
+    ):
+        if all(s["hyperball_radius_initialized"] for s in states):
+            return
+
+        local_params = to_local(params)
+        sq_norms = _local_square_sums(local_params)
+        if process_group is not None and shard_dim is not None:
+            dist.all_reduce(sq_norms, group=process_group)
+        radii = sq_norms.sqrt()
+
+        eps = float(hyperball_eps)
+        if bool((radii <= eps).any().item()):
+            raise ValueError(
+                "MuonH requires non-zero matrix parameters because the "
+                "hyperball radius is initialized from the parameter norm."
+            )
+
+        for state, radius in zip(states, radii):
+            if not state["hyperball_radius_initialized"]:
+                state["hyperball_radius"].copy_(radius)
+                state["hyperball_radius_initialized"] = True
+
+    def _create_ortho_tasks(
+        self, param_groups: List[dict]
+    ) -> Generator["AsyncTask", None, None]:
+        """
+        Mega-batched MuonH task creation: groups ALL same-shape parameters
+        into a single task to minimize communication rounds and kernel launches.
+        """
+        for group in param_groups:
+            assert group["algorithm"] == self._algo_name
+            assert all(
+                p.ndim >= 2 for p in group["params"]
+            ), "MuonH optimizer only supports matrix parameters."
+
+            group_params = [p for p in group["params"] if p.grad is not None]
+            if not group_params:
+                continue
+
+            normalization = _canonical_normalization(group["normalization"])
+            hyperball_eps = torch.tensor(group["hyperball_eps"])
+            update_args = dict(
+                lr=torch.tensor(group["lr"]),
+                momentum=torch.tensor(group["mu"]),
+                muon_beta2=torch.tensor(group["muon_beta2"]),
+                normalization=normalization,
+                epsilon=torch.tensor(group["epsilon"]),
+                hyperball_eps=hyperball_eps,
+                nesterov=group["nesterov"],
+                flatten=group["flatten"],
+                adjust_lr=group["adjust_lr"],
+                device_rank=self._device_rank,
+                world_size=self._world_size,
+                process_group=self._process_group,
+                newton_schulz_func=self._newton_schulz_func,
+            )
+
+            shape_groups: dict[tuple, list] = defaultdict(list)
+            for p in group_params:
+                sharding = p.placements if isinstance(p, DTensor) else None
+                shape_groups[(p.shape, sharding, p.dtype)].append(p)
+
+            num_heads = self._resolve_num_heads(group)
+
+            for (_shape, _sharding, _dtype), params in shape_groups.items():
+                gradients = [p.grad for p in params]
+                states = [self._get_or_initialize_state(p, self._algo_name) for p in params]
+                momentums = [s["momentum"] for s in states]
+
+                if num_heads is not None:
+                    params, gradients, momentums = self._prepare_head_split(
+                        num_heads, params, gradients, momentums
+                    )
+                    megabatch_args = {**update_args, "process_group": None}
+                    shard_dim = None
+                else:
+                    is_batch_sharded, is_matrix_sharded, sharded_tensor_dim = (
+                        self._get_shard_info(params[0], group)
+                    )
+                    megabatch_args = update_args
+                    if is_batch_sharded and not is_matrix_sharded:
+                        megabatch_args = {**update_args, "process_group": None}
+                    shard_dim = sharded_tensor_dim
+
+                variances = [
+                    self._get_or_initialize_variance(p, s, normalization)
+                    for p, s in zip(params, states)
+                ]
+                radii = [s["hyperball_radius"] for s in states]
+                self._initialize_hyperball_radii(
+                    params=params,
+                    states=states,
+                    process_group=megabatch_args["process_group"],
+                    shard_dim=shard_dim,
+                    hyperball_eps=hyperball_eps,
+                )
+
+                yield AsyncTask(
+                    muonh_update_megabatch_async(
+                        X=params,
+                        G=gradients,
+                        M=momentums,
+                        V=variances,
+                        R=radii,
+                        shard_dim=shard_dim,
+                        **megabatch_args,
+                    )
+                )
+
+
+def muonh_update_megabatch_async(
+    X: List[Tensor],
+    G: List[Tensor],
+    M: List[Tensor],
+    V: List[Optional[Tensor]],
+    R: List[Tensor],
+    lr: Tensor,
+    momentum: Tensor,
+    muon_beta2: Tensor,
+    normalization: Optional[str],
+    epsilon: Tensor,
+    hyperball_eps: Tensor,
+    nesterov: bool,
+    flatten: bool,
+    adjust_lr: Optional[str],
+    device_rank: int,
+    world_size: int,
+    shard_dim: Optional[int] = None,
+    process_group: Optional[ProcessGroup] = None,
+    newton_schulz_func: Optional[Callable] = None,
+) -> Generator[None, None, None]:
+    """
+    Mega-batched MuonH update: Muon orthogonalization followed by optional
+    normalization and a Frobenius-sphere hyperball step.
+    """
+    N = len(X)
+    assert N == len(G) == len(M) == len(V) == len(R)
+
+    U = muon_update_pre_orthogonalize(
+        G=to_local(G), M=to_local(M), momentum=momentum, nesterov=nesterov,
+    )
+
+    comm_dim = (shard_dim - X[0].ndim) if shard_dim is not None else None
+    U = yield from megabatch_orthogonalize_async(
+        U,
+        comm_dim=comm_dim,
+        device_rank=device_rank,
+        world_size=world_size,
+        process_group=process_group,
+        newton_schulz_func=newton_schulz_func,
+        flatten=flatten,
+        epsilon=epsilon,
+    )
+
+    if normalization is not None:
+        U = yield from muonh_normalization_async(
+            U=U,
+            V=V,
+            muon_beta2=muon_beta2,
+            normalization=normalization,
+            param_shape=X[0].shape,
+            shard_dim=shard_dim,
+            process_group=process_group,
+            epsilon=hyperball_eps,
+        )
+
+    if adjust_lr is None:
+        adjusted_lr = lr
+    elif adjust_lr == "spectral_norm":
+        adjusted_lr = adjust_lr_spectral_norm(lr, X[0].shape, flatten=flatten)
+    elif adjust_lr == "rms_norm":
+        adjusted_lr = adjust_lr_rms_norm(lr, X[0].shape, flatten=flatten)
+    else:
+        raise ValueError(f"Unknown adjust_lr value: {adjust_lr}")
+
+    norm_group = process_group if shard_dim is not None else None
+    yield from muonh_update_post_orthogonalize_async(
+        X=to_local(X),
+        U=U,
+        R=R,
+        adjusted_lr=adjusted_lr,
+        epsilon=hyperball_eps,
+        process_group=norm_group,
+    )
+
+
+def muonh_normalization_async(
+    U: List[Tensor],
+    V: List[Tensor],
+    muon_beta2: Tensor,
+    normalization: str,
+    param_shape: torch.Size,
+    shard_dim: Optional[int],
+    process_group: Optional[ProcessGroup],
+    epsilon: Tensor,
+) -> Generator[None, None, List[Tensor]]:
+    """Optional MuonH update normalization, with reductions when the normalized axis is sharded."""
+    U_stacked = torch.stack(U)
+    V_stacked = torch.stack(V)
+
+    red_dim = -1
+    if normalization == "short_axis" and param_shape[-2] < param_shape[-1]:
+        red_dim = -2
+
+    sum_sq = U_stacked.float().square().sum(dim=red_dim, keepdim=True)
+    shard_dim_neg = None
+    if shard_dim is not None:
+        shard_dim_neg = shard_dim if shard_dim < 0 else shard_dim - len(param_shape)
+    if process_group is not None and shard_dim_neg == red_dim:
+        work = dist.all_reduce(sum_sq, group=process_group, async_op=True)
+        yield
+        work.wait()
+
+    red_dim_size = param_shape[red_dim]
+    variance_new = sum_sq / red_dim_size
+    norm_U = U_stacked.float().norm(p=2, dim=(-2, -1), keepdim=True)
+
+    V_dtype = V_stacked.dtype
+    V_stacked = torch.lerp(V_stacked, variance_new.to(dtype=V_dtype), 1 - muon_beta2)
+
+    normalized_U = U_stacked.float() / (V_stacked.float().sqrt() + float(epsilon))
+    norm_U_new = normalized_U.norm(p=2, dim=(-2, -1), keepdim=True).clamp(min=float(epsilon))
+    normalized_U = normalized_U * (norm_U / norm_U_new)
+    normalized_U = normalized_U.to(dtype=V_dtype)
+
+    for i in range(len(V)):
+        V[i].copy_(V_stacked[i])
+    return [normalized_U[i] for i in range(len(U))]
+
+
+def muonh_update_post_orthogonalize_async(
+    X: List[Tensor],
+    U: List[Tensor],
+    R: List[Tensor],
+    adjusted_lr: Tensor,
+    epsilon: Tensor,
+    process_group: Optional[ProcessGroup],
+) -> Generator[None, None, None]:
+    """Apply a scale-invariant hyperball step and project back to stored radii."""
+    device = X[0].device
+    eps = float(epsilon)
+    radii = torch.stack([r.to(device=device, dtype=torch.float32) for r in R])
+    lr = adjusted_lr.to(device=device, dtype=torch.float32)
+
+    update_norms = yield from _fro_norms_async(U, process_group)
+    step_scales = lr * radii / update_norms.clamp_min(eps)
+    candidates = [
+        x - u.to(dtype=x.dtype) * step_scales[i].to(device=x.device, dtype=x.dtype)
+        for i, (x, u) in enumerate(zip(X, U))
+    ]
+
+    candidate_norms = yield from _fro_norms_async(candidates, process_group)
+    project_scales = radii / candidate_norms.clamp_min(eps)
+    for i, (x, candidate) in enumerate(zip(X, candidates)):
+        x.copy_(candidate * project_scales[i].to(device=x.device, dtype=candidate.dtype))
+
+
+def _local_square_sums(tensors: List[Tensor]) -> Tensor:
+    return torch.stack([t.float().square().sum() for t in tensors])
+
+
+def _fro_norms_async(
+    tensors: List[Tensor],
+    process_group: Optional[ProcessGroup],
+) -> Generator[None, None, Tensor]:
+    sq_norms = _local_square_sums(tensors)
+    if process_group is not None:
+        work = dist.all_reduce(sq_norms, group=process_group, async_op=True)
+        yield
+        work.wait()
+    return sq_norms.sqrt()

--- a/dion/muonh.py
+++ b/dion/muonh.py
@@ -139,6 +139,18 @@ class MuonH(DistributedOrthoBase):
             )
         return state
 
+    def _get_or_initialize_hyperball_radius(
+        self, param: Tensor, state: dict, flatten: bool
+    ) -> Tensor:
+        local = to_local(param)
+        shape = () if flatten or local.ndim == 2 else tuple(local.shape[:-2])
+        radius = state.get("hyperball_radius")
+        if radius is None or tuple(radius.shape) != shape:
+            radius = torch.zeros(shape, device=local.device, dtype=torch.float32)
+            state["hyperball_radius"] = radius
+            state["hyperball_radius_initialized"] = torch.zeros((), dtype=torch.bool)
+        return radius
+
     def _get_or_initialize_variance(
         self, param: Tensor, state: dict, normalization: Optional[str]
     ) -> Optional[Tensor]:
@@ -166,15 +178,15 @@ class MuonH(DistributedOrthoBase):
         params: List[Tensor],
         states: List[dict],
         process_group: Optional[ProcessGroup],
-        shard_dim: Optional[int],
+        flatten: bool,
         hyperball_eps: Tensor,
     ):
         if all(s["hyperball_radius_initialized"] for s in states):
             return
 
         local_params = to_local(params)
-        sq_norms = _local_square_sums(local_params)
-        if process_group is not None and shard_dim is not None:
+        sq_norms = _local_square_sums(local_params, flatten=flatten)
+        if process_group is not None:
             dist.all_reduce(sq_norms, group=process_group)
         radii = sq_norms.sqrt()
 
@@ -236,32 +248,35 @@ class MuonH(DistributedOrthoBase):
                 gradients = [p.grad for p in params]
                 states = [self._get_or_initialize_state(p, self._algo_name) for p in params]
                 momentums = [s["momentum"] for s in states]
-
                 if num_heads is not None:
-                    params, gradients, momentums = self._prepare_head_split(
-                        num_heads, params, gradients, momentums
+                    raise ValueError(
+                        "MuonH does not support num_heads > 1. Split heads into "
+                        "explicit parameters or use a native 3D parameter instead."
                     )
+
+                is_batch_sharded, is_matrix_sharded, sharded_tensor_dim = (
+                    self._get_shard_info(params[0], group)
+                )
+                megabatch_args = update_args
+                if is_batch_sharded and not is_matrix_sharded:
                     megabatch_args = {**update_args, "process_group": None}
-                    shard_dim = None
-                else:
-                    is_batch_sharded, is_matrix_sharded, sharded_tensor_dim = (
-                        self._get_shard_info(params[0], group)
-                    )
-                    megabatch_args = update_args
-                    if is_batch_sharded and not is_matrix_sharded:
-                        megabatch_args = {**update_args, "process_group": None}
-                    shard_dim = sharded_tensor_dim
+                shard_dim = sharded_tensor_dim
 
                 variances = [
                     self._get_or_initialize_variance(p, s, normalization)
                     for p, s in zip(params, states)
                 ]
-                radii = [s["hyperball_radius"] for s in states]
+                radii = [
+                    self._get_or_initialize_hyperball_radius(
+                        p, s, flatten=group["flatten"]
+                    )
+                    for p, s in zip(params, states)
+                ]
                 self._initialize_hyperball_radii(
                     params=params,
                     states=states,
-                    process_group=megabatch_args["process_group"],
-                    shard_dim=shard_dim,
+                    process_group=megabatch_args["process_group"] if shard_dim is not None else None,
+                    flatten=group["flatten"],
                     hyperball_eps=hyperball_eps,
                 )
 
@@ -343,14 +358,14 @@ def muonh_update_megabatch_async(
     else:
         raise ValueError(f"Unknown adjust_lr value: {adjust_lr}")
 
-    norm_group = process_group if shard_dim is not None else None
     yield from muonh_update_post_orthogonalize_async(
         X=to_local(X),
         U=U,
         R=R,
         adjusted_lr=adjusted_lr,
         epsilon=hyperball_eps,
-        process_group=norm_group,
+        flatten=flatten,
+        process_group=process_group if shard_dim is not None else None,
     )
 
 
@@ -419,16 +434,16 @@ def muonh_normalization_async(
 
 @torch.compile(fullgraph=True)
 def _muonh_local_sums_compiled(X_stacked: Tensor, U_stacked: Tensor) -> Tensor:
-    """Per-matrix local |U|^2, |X|^2, <X, U>, packed into a single [3, N] fp32 tensor.
+    """Per-matrix local |U|^2, |X|^2, <X, U> packed into one fp32 tensor.
 
     Packing into one tensor lets the caller fuse the three reductions into a
     single async all-reduce instead of issuing one round per quantity.
     """
     X_f = X_stacked.float()
     U_f = U_stacked.float()
-    u_sq = U_f.square().flatten(1).sum(dim=-1)
-    x_sq = X_f.square().flatten(1).sum(dim=-1)
-    xu = (X_f * U_f).flatten(1).sum(dim=-1)
+    u_sq = U_f.square().sum(dim=(-2, -1))
+    x_sq = X_f.square().sum(dim=(-2, -1))
+    xu = (X_f * U_f).sum(dim=(-2, -1))
     return torch.stack([u_sq, x_sq, xu], dim=0)
 
 
@@ -436,10 +451,11 @@ def _muonh_local_sums_compiled(X_stacked: Tensor, U_stacked: Tensor) -> Tensor:
 def _muonh_apply_step_compiled(
     X_stacked: Tensor,
     U_stacked: Tensor,
-    sums: Tensor,  # [3, N]: [|U|^2, |X|^2, <X, U>]
+    sums: Tensor,
     radii: Tensor,
     adjusted_lr: Tensor,
     eps: float,
+    flatten: bool,
 ) -> Tensor:
     """Apply hyperball step + Frobenius-sphere projection in one fused multiply-subtract.
 
@@ -458,7 +474,7 @@ def _muonh_apply_step_compiled(
     scale_X_f = radii / candidate_norm   # = r / |candidate|
     scale_U_f = s_uf * scale_X_f         # = lr*r / (|U| * |candidate|) * r
 
-    extra = X_stacked.ndim - 1
+    extra = X_stacked.ndim - 1 if flatten else 2
     scale_X = scale_X_f.to(dtype=x_dtype)
     scale_U = scale_U_f.to(dtype=x_dtype)
     for _ in range(extra):
@@ -473,6 +489,7 @@ def muonh_update_post_orthogonalize_async(
     R: List[Tensor],
     adjusted_lr: Tensor,
     epsilon: Tensor,
+    flatten: bool,
     process_group: Optional[ProcessGroup],
 ) -> Generator[None, None, None]:
     """Apply a scale-invariant hyperball step and project back to stored radii.
@@ -495,12 +512,14 @@ def muonh_update_post_orthogonalize_async(
         work.wait()
 
     final_stacked = _muonh_apply_step_compiled(
-        X_stacked, U_stacked, sums, radii, adjusted_lr, eps,
+        X_stacked, U_stacked, sums, radii, adjusted_lr, eps, flatten,
     )
     torch._foreach_copy_(list(X), list(final_stacked.unbind(0)))
 
 
-def _local_square_sums(tensors: List[Tensor]) -> Tensor:
+def _local_square_sums(tensors: List[Tensor], flatten: bool) -> Tensor:
     """Per-tensor sum of squares, fused via a single stack + flatten + sum."""
     stacked = torch.stack(tensors).float()
-    return stacked.square().flatten(1).sum(dim=-1) if stacked.ndim > 1 else stacked.square()
+    if flatten:
+        return stacked.square().flatten(1).sum(dim=-1)
+    return stacked.square().sum(dim=(-2, -1))

--- a/dion/muonh.py
+++ b/dion/muonh.py
@@ -1,3 +1,4 @@
+import math
 import torch
 import torch.distributed as dist
 from collections import defaultdict
@@ -152,17 +153,20 @@ class MuonH(DistributedOrthoBase):
         return radius
 
     def _get_or_initialize_variance(
-        self, param: Tensor, state: dict, normalization: Optional[str]
+        self, param: Tensor, state: dict, normalization: Optional[str], flatten: bool
     ) -> Optional[Tensor]:
         if normalization is None:
             return None
 
         local = to_local(param)
-        shape = list(local.shape)
+        if flatten and local.ndim >= 3:
+            shape = [local.shape[0], math.prod(local.shape[1:])]
+        else:
+            shape = list(local.shape)
         if normalization == "neuron":
             shape[-1] = 1
         elif normalization == "short_axis":
-            red_dim = -1 if param.shape[-2] >= param.shape[-1] else -2
+            red_dim = -1 if shape[-2] >= shape[-1] else -2
             shape[red_dim] = 1
         else:
             raise ValueError(f"Unknown normalization: {normalization}")
@@ -263,7 +267,9 @@ class MuonH(DistributedOrthoBase):
                 shard_dim = sharded_tensor_dim
 
                 variances = [
-                    self._get_or_initialize_variance(p, s, normalization)
+                    self._get_or_initialize_variance(
+                        p, s, normalization, flatten=group["flatten"]
+                    )
                     for p, s in zip(params, states)
                 ]
                 radii = [
@@ -344,6 +350,7 @@ def muonh_update_megabatch_async(
             muon_beta2=muon_beta2,
             normalization=normalization,
             param_shape=X[0].shape,
+            flatten=flatten,
             shard_dim=shard_dim,
             process_group=process_group,
             epsilon=hyperball_eps,
@@ -399,6 +406,7 @@ def muonh_normalization_async(
     muon_beta2: Tensor,
     normalization: str,
     param_shape: torch.Size,
+    flatten: bool,
     shard_dim: Optional[int],
     process_group: Optional[ProcessGroup],
     epsilon: Tensor,
@@ -410,30 +418,48 @@ def muonh_normalization_async(
     """
     U_stacked = torch.stack(U)
     V_stacked = torch.stack(V)
+    original_shape = U_stacked.shape
+
+    local_shape = U[0].shape
+
+    if flatten and len(param_shape) >= 3:
+        U_stacked = U_stacked.flatten(start_dim=2)
+        flat_shape = torch.Size((local_shape[0], math.prod(local_shape[1:])))
+        shard_dim_neg = None
+        if shard_dim is not None:
+            shard_dim_pos = shard_dim if shard_dim >= 0 else shard_dim + len(param_shape)
+            shard_dim_neg = -2 if shard_dim_pos == 0 else -1
+    else:
+        flat_shape = local_shape
+        shard_dim_neg = None
+        if shard_dim is not None:
+            shard_dim_neg = shard_dim if shard_dim < 0 else shard_dim - len(local_shape)
 
     red_dim = -1
-    if normalization == "short_axis" and param_shape[-2] < param_shape[-1]:
+    if normalization == "short_axis" and flat_shape[-2] < flat_shape[-1]:
         red_dim = -2
 
     sum_sq = _muonh_sum_sq_compiled(U_stacked, red_dim)
-    shard_dim_neg = None
-    if shard_dim is not None:
-        shard_dim_neg = shard_dim if shard_dim < 0 else shard_dim - len(param_shape)
     if process_group is not None and shard_dim_neg == red_dim:
         work = dist.all_reduce(sum_sq, group=process_group, async_op=True)
         yield
         work.wait()
 
     normalized_U, V_stacked = _muonh_normalize_finish_compiled(
-        U_stacked, V_stacked, sum_sq, param_shape[red_dim], muon_beta2, float(epsilon),
+        U_stacked, V_stacked, sum_sq, flat_shape[red_dim], muon_beta2, float(epsilon),
     )
+
+    if flatten and len(param_shape) >= 3:
+        normalized_U = normalized_U.reshape(original_shape)
 
     torch._foreach_copy_(list(V), list(V_stacked.unbind(0)))
     return list(normalized_U.unbind(0))
 
 
 @torch.compile(fullgraph=True)
-def _muonh_local_sums_compiled(X_stacked: Tensor, U_stacked: Tensor) -> Tensor:
+def _muonh_local_sums_compiled(
+    X_stacked: Tensor, U_stacked: Tensor, flatten: bool
+) -> Tensor:
     """Per-matrix local |U|^2, |X|^2, <X, U> packed into one fp32 tensor.
 
     Packing into one tensor lets the caller fuse the three reductions into a
@@ -441,9 +467,10 @@ def _muonh_local_sums_compiled(X_stacked: Tensor, U_stacked: Tensor) -> Tensor:
     """
     X_f = X_stacked.float()
     U_f = U_stacked.float()
-    u_sq = U_f.square().sum(dim=(-2, -1))
-    x_sq = X_f.square().sum(dim=(-2, -1))
-    xu = (X_f * U_f).sum(dim=(-2, -1))
+    red_dims = tuple(range(1, X_stacked.ndim)) if flatten else (-2, -1)
+    u_sq = U_f.square().sum(dim=red_dims)
+    x_sq = X_f.square().sum(dim=red_dims)
+    xu = (X_f * U_f).sum(dim=red_dims)
     return torch.stack([u_sq, x_sq, xu], dim=0)
 
 
@@ -505,7 +532,7 @@ def muonh_update_post_orthogonalize_async(
     U_stacked = torch.stack(U).to(dtype=x_dtype)
     X_stacked = torch.stack(list(X))
 
-    sums = _muonh_local_sums_compiled(X_stacked, U_stacked)
+    sums = _muonh_local_sums_compiled(X_stacked, U_stacked, flatten)
     if process_group is not None:
         work = dist.all_reduce(sums, group=process_group, async_op=True)
         yield

--- a/dion/muonh.py
+++ b/dion/muonh.py
@@ -9,6 +9,7 @@ from typing import Callable, Generator, List, Optional, Tuple, Union
 
 from .megabatch_base import (
     DistributedOrthoBase,
+    canonical_normalization,
     megabatch_orthogonalize_async,
     adjust_lr_spectral_norm,
     adjust_lr_rms_norm,
@@ -18,18 +19,7 @@ from .muon import muon_update_pre_orthogonalize
 
 
 def _canonical_normalization(normalization: Optional[str]) -> Optional[str]:
-    if normalization is None:
-        return None
-    if isinstance(normalization, str):
-        value = normalization.lower()
-        if value == "none":
-            return None
-        if value in ("neuron", "short_axis"):
-            return value
-    raise ValueError(
-        f"Invalid normalization: {normalization}. "
-        "Must be None, 'None', 'neuron', or 'short_axis'."
-    )
+    return canonical_normalization(normalization, allow_none=True)
 
 
 class MuonH(DistributedOrthoBase):
@@ -39,6 +29,13 @@ class MuonH(DistributedOrthoBase):
     MuonH uses Muon's momentum + orthogonalization direction, then applies a
     hyperball update: the step is scaled relative to each parameter's Frobenius
     norm, and the parameter is projected back to its initial Frobenius norm.
+
+    .. note::
+        Matrix parameters MUST be non-zero at optimizer construction. The
+        hyperball radius is initialized from the parameter's Frobenius norm on
+        the first step, so a zero-initialized parameter (common for output
+        projections under standard Muon practice) will raise ``ValueError``.
+        Use a non-zero init (e.g. Kaiming) for any layer assigned to MuonH.
 
     Args:
         params: Parameters for the optimizer.
@@ -134,7 +131,12 @@ class MuonH(DistributedOrthoBase):
             state["hyperball_radius"] = torch.zeros(
                 (), device=local.device, dtype=torch.float32
             )
-            state["hyperball_radius_initialized"] = False
+            # Stored as a CPU tensor (not a Python bool) so it survives
+            # state-dict round-trips through tensor-only checkpointing
+            # libraries. CPU avoids a device sync on the steady-state check.
+            state["hyperball_radius_initialized"] = torch.zeros(
+                (), dtype=torch.bool
+            )
         return state
 
     def _get_or_initialize_variance(
@@ -186,7 +188,7 @@ class MuonH(DistributedOrthoBase):
         for state, radius in zip(states, radii):
             if not state["hyperball_radius_initialized"]:
                 state["hyperball_radius"].copy_(radius)
-                state["hyperball_radius_initialized"] = True
+                state["hyperball_radius_initialized"].fill_(True)
 
     def _create_ortho_tasks(
         self, param_groups: List[dict]
@@ -352,12 +354,12 @@ def muonh_update_megabatch_async(
     )
 
 
-@torch.compile(fullgraph=True, dynamic=False)
+@torch.compile(fullgraph=True)
 def _muonh_sum_sq_compiled(U_stacked: Tensor, red_dim: int) -> Tensor:
     return U_stacked.float().square().sum(dim=red_dim, keepdim=True)
 
 
-@torch.compile(fullgraph=True, dynamic=False)
+@torch.compile(fullgraph=True)
 def _muonh_normalize_finish_compiled(
     U_stacked: Tensor,
     V_stacked: Tensor,
@@ -415,45 +417,54 @@ def muonh_normalization_async(
     return list(normalized_U.unbind(0))
 
 
-@torch.compile(fullgraph=True, dynamic=False)
-def _muonh_sq_sum_flat_compiled(stacked: Tensor) -> Tensor:
-    return stacked.float().square().flatten(1).sum(dim=-1)
+@torch.compile(fullgraph=True)
+def _muonh_local_sums_compiled(X_stacked: Tensor, U_stacked: Tensor) -> Tensor:
+    """Per-matrix local |U|^2, |X|^2, <X, U>, packed into a single [3, N] fp32 tensor.
+
+    Packing into one tensor lets the caller fuse the three reductions into a
+    single async all-reduce instead of issuing one round per quantity.
+    """
+    X_f = X_stacked.float()
+    U_f = U_stacked.float()
+    u_sq = U_f.square().flatten(1).sum(dim=-1)
+    x_sq = X_f.square().flatten(1).sum(dim=-1)
+    xu = (X_f * U_f).flatten(1).sum(dim=-1)
+    return torch.stack([u_sq, x_sq, xu], dim=0)
 
 
-@torch.compile(fullgraph=True, dynamic=False)
-def _muonh_step_compiled(
+@torch.compile(fullgraph=True)
+def _muonh_apply_step_compiled(
     X_stacked: Tensor,
     U_stacked: Tensor,
-    update_sq_sums: Tensor,
+    sums: Tensor,  # [3, N]: [|U|^2, |X|^2, <X, U>]
     radii: Tensor,
     adjusted_lr: Tensor,
     eps: float,
-) -> Tuple[Tensor, Tensor]:
-    x_dtype = X_stacked.dtype
-    extra = X_stacked.ndim - 1
-    update_norms = update_sq_sums.sqrt()
-    scales = (adjusted_lr * radii / update_norms.clamp_min(eps)).to(dtype=x_dtype)
-    for _ in range(extra):
-        scales = scales.unsqueeze(-1)
-    candidate_stacked = X_stacked - U_stacked * scales
-    candidate_sq_sums = candidate_stacked.float().square().flatten(1).sum(dim=-1)
-    return candidate_stacked, candidate_sq_sums
-
-
-@torch.compile(fullgraph=True, dynamic=False)
-def _muonh_project_compiled(
-    candidate_stacked: Tensor,
-    candidate_sq_sums: Tensor,
-    radii: Tensor,
-    eps: float,
 ) -> Tensor:
-    x_dtype = candidate_stacked.dtype
-    extra = candidate_stacked.ndim - 1
-    candidate_norms = candidate_sq_sums.sqrt()
-    scales = (radii / candidate_norms.clamp_min(eps)).to(dtype=x_dtype)
+    """Apply hyperball step + Frobenius-sphere projection in one fused multiply-subtract.
+
+    Uses the closed form |X - s*U|^2 = |X|^2 - 2*s*<X,U> + s^2*|U|^2 to skip
+    materializing the intermediate candidate tensor and a second reduction.
+    """
+    x_dtype = X_stacked.dtype
+    u_sq = sums[0]
+    x_sq = sums[1]
+    xu = sums[2]
+
+    u_norm = u_sq.sqrt().clamp_min(eps)
+    s_uf = adjusted_lr * radii / u_norm  # = lr * r / |U|
+    candidate_sq = (x_sq - 2.0 * s_uf * xu + s_uf * s_uf * u_sq).clamp_min(eps * eps)
+    candidate_norm = candidate_sq.sqrt()
+    scale_X_f = radii / candidate_norm   # = r / |candidate|
+    scale_U_f = s_uf * scale_X_f         # = lr*r / (|U| * |candidate|) * r
+
+    extra = X_stacked.ndim - 1
+    scale_X = scale_X_f.to(dtype=x_dtype)
+    scale_U = scale_U_f.to(dtype=x_dtype)
     for _ in range(extra):
-        scales = scales.unsqueeze(-1)
-    return candidate_stacked * scales
+        scale_X = scale_X.unsqueeze(-1)
+        scale_U = scale_U.unsqueeze(-1)
+    return X_stacked * scale_X - U_stacked * scale_U
 
 
 def muonh_update_post_orthogonalize_async(
@@ -466,8 +477,9 @@ def muonh_update_post_orthogonalize_async(
 ) -> Generator[None, None, None]:
     """Apply a scale-invariant hyperball step and project back to stored radii.
 
-    Pure-tensor sections are compiled and split around the optional async
-    all-reduces of the update / candidate Frobenius norms.
+    Folds the two FSDP2 reductions (update Frobenius norm and post-step
+    Frobenius norm) into a single all-reduce of [|U|^2, |X|^2, <X, U>], using
+    the closed form for |candidate|^2.
     """
     eps = float(epsilon)
     radii = torch.stack(list(R))
@@ -476,22 +488,14 @@ def muonh_update_post_orthogonalize_async(
     U_stacked = torch.stack(U).to(dtype=x_dtype)
     X_stacked = torch.stack(list(X))
 
-    update_sq_sums = _muonh_sq_sum_flat_compiled(U_stacked)
+    sums = _muonh_local_sums_compiled(X_stacked, U_stacked)
     if process_group is not None:
-        work = dist.all_reduce(update_sq_sums, group=process_group, async_op=True)
+        work = dist.all_reduce(sums, group=process_group, async_op=True)
         yield
         work.wait()
 
-    candidate_stacked, candidate_sq_sums = _muonh_step_compiled(
-        X_stacked, U_stacked, update_sq_sums, radii, adjusted_lr, eps,
-    )
-    if process_group is not None:
-        work = dist.all_reduce(candidate_sq_sums, group=process_group, async_op=True)
-        yield
-        work.wait()
-
-    final_stacked = _muonh_project_compiled(
-        candidate_stacked, candidate_sq_sums, radii, eps,
+    final_stacked = _muonh_apply_step_compiled(
+        X_stacked, U_stacked, sums, radii, adjusted_lr, eps,
     )
     torch._foreach_copy_(list(X), list(final_stacked.unbind(0)))
 
@@ -500,15 +504,3 @@ def _local_square_sums(tensors: List[Tensor]) -> Tensor:
     """Per-tensor sum of squares, fused via a single stack + flatten + sum."""
     stacked = torch.stack(tensors).float()
     return stacked.square().flatten(1).sum(dim=-1) if stacked.ndim > 1 else stacked.square()
-
-
-def _fro_norms_async(
-    tensors: List[Tensor],
-    process_group: Optional[ProcessGroup],
-) -> Generator[None, None, Tensor]:
-    sq_norms = _local_square_sums(tensors)
-    if process_group is not None:
-        work = dist.all_reduce(sq_norms, group=process_group, async_op=True)
-        yield
-        work.wait()
-    return sq_norms.sqrt()

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -1,3 +1,4 @@
+import math
 import torch
 import torch.distributed as dist
 from collections import defaultdict
@@ -124,7 +125,7 @@ class NorMuon(DistributedOrthoBase):
         return super()._get_or_initialize_state(param, algo)
 
     def _get_or_initialize_variance(
-        self, param: Tensor, state: dict, normalization: str
+        self, param: Tensor, state: dict, normalization: str, flatten: bool
     ) -> Tensor:
         """Lazily allocate the per-param variance EMA buffer.
 
@@ -137,11 +138,14 @@ class NorMuon(DistributedOrthoBase):
         the EMA is rebuilding from the new reduction axis.
         """
         local = to_local(param)
-        shape = list(local.shape)
+        if flatten and local.ndim >= 3:
+            shape = [local.shape[0], math.prod(local.shape[1:])]
+        else:
+            shape = list(local.shape)
         if normalization == "neuron":
             shape[-1] = 1
         elif normalization == "short_axis":
-            red_dim = -1 if param.shape[-2] >= param.shape[-1] else -2
+            red_dim = -1 if shape[-2] >= shape[-1] else -2
             shape[red_dim] = 1
         else:
             raise ValueError(f"Unknown normalization: {normalization}")
@@ -227,7 +231,9 @@ class NorMuon(DistributedOrthoBase):
                 # Variance buffer shape depends on normalization + (post-split)
                 # param shape, so initialize after head split.
                 variances_neuron = [
-                    self._get_or_initialize_variance(p, s, normalization)
+                    self._get_or_initialize_variance(
+                        p, s, normalization, flatten=group["flatten"]
+                    )
                     for p, s in zip(params, states)
                 ]
 
@@ -296,13 +302,21 @@ def normuon_update_megabatch_async(
     U_stacked = torch.stack(U)
     V_stacked = torch.stack(V_local)
     if normalization == "neuron":
-        U_stacked, V_stacked = normuon_normalization_stacked(U_stacked, V_stacked, muon_beta2)
+        if flatten and X[0].ndim >= 3:
+            U_stacked, V_stacked = normuon_normalization_stacked_flattened(
+                U_stacked, V_stacked, muon_beta2,
+            )
+        else:
+            U_stacked, V_stacked = normuon_normalization_stacked(
+                U_stacked, V_stacked, muon_beta2,
+            )
     elif normalization == "short_axis":
         U_stacked, V_stacked = yield from normuon_short_axis_normalization_async(
             U_stacked,
             V_stacked,
             muon_beta2=muon_beta2,
             param_shape=X[0].shape,
+            flatten=flatten,
             shard_dim=shard_dim,
             process_group=process_group,
         )
@@ -363,6 +377,7 @@ def normuon_short_axis_normalization_async(
     V: Tensor,  # [N, ..., 1]   (variance buffer, with 1 along the long axis)
     muon_beta2: Tensor,
     param_shape: torch.Size,
+    flatten: bool,
     shard_dim: Optional[int],
     process_group: Optional[ProcessGroup],
 ) -> Generator[None, None, Tuple[Tensor, Tensor]]:
@@ -376,22 +391,36 @@ def normuon_short_axis_normalization_async(
     Pure-tensor pre-/post-comm sections are compiled; the async dist.all_reduce
     sits in between and stays in eager Python.
     """
+    original_shape = U.shape
+    local_shape = U.shape[1:]
+    if flatten and len(param_shape) >= 3:
+        U = U.flatten(start_dim=2)
+        flat_shape = torch.Size((local_shape[0], math.prod(local_shape[1:])))
+        shard_dim_neg = None
+        if shard_dim is not None:
+            shard_dim_pos = shard_dim if shard_dim >= 0 else shard_dim + len(param_shape)
+            shard_dim_neg = -2 if shard_dim_pos == 0 else -1
+    else:
+        flat_shape = local_shape
+        shard_dim_neg = None
+        if shard_dim is not None:
+            shard_dim_neg = shard_dim if shard_dim < 0 else shard_dim - len(local_shape)
+
     red_dim = -1
-    if param_shape[-2] < param_shape[-1]:
+    if flat_shape[-2] < flat_shape[-1]:
         red_dim = -2
 
     sum_sq = _normuon_short_axis_sum_sq_compiled(U, red_dim)
-    shard_dim_neg = None
-    if shard_dim is not None:
-        shard_dim_neg = shard_dim if shard_dim < 0 else shard_dim - len(param_shape)
     if process_group is not None and shard_dim_neg == red_dim:
         work = dist.all_reduce(sum_sq, group=process_group, async_op=True)
         yield
         work.wait()
 
     normalized_U, V = _normuon_short_axis_finish_compiled(
-        U, V, sum_sq, param_shape[red_dim], muon_beta2,
+        U, V, sum_sq, flat_shape[red_dim], muon_beta2,
     )
+    if flatten and len(param_shape) >= 3:
+        normalized_U = normalized_U.reshape(original_shape)
     return normalized_U, V
 
 
@@ -428,3 +457,15 @@ def normuon_normalization_stacked(
     normalized_U = normalized_U * (norm_U / norm_U_new)
 
     return normalized_U, V
+
+
+@torch.compile(fullgraph=True)
+def normuon_normalization_stacked_flattened(
+    U: Tensor,
+    V: Tensor,
+    muon_beta2: Tensor,
+) -> Tuple[Tensor, Tensor]:
+    original_shape = U.shape
+    U = U.flatten(start_dim=2)
+    normalized_U, V = normuon_normalization_stacked(U, V, muon_beta2)
+    return normalized_U.reshape(original_shape), V

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -1,4 +1,5 @@
 import torch
+import torch.distributed as dist
 from collections import defaultdict
 from torch import Tensor
 from torch.distributed import ProcessGroup
@@ -16,6 +17,16 @@ from .opt_utils import AsyncTask, to_local
 from .muon import muon_update_pre_orthogonalize, muon_update_post_orthogonalize
 
 
+def _canonical_normalization(normalization: str) -> str:
+    if isinstance(normalization, str):
+        value = normalization.lower()
+        if value in ("neuron", "short_axis"):
+            return value
+    raise ValueError(
+        f"Invalid normalization: {normalization}. Must be 'neuron' or 'short_axis'."
+    )
+
+
 class NorMuon(DistributedOrthoBase):
     """
     Distributed NorMuon optimizer for PyTorch FSDP2. Also compatible with DDP.
@@ -28,6 +39,10 @@ class NorMuon(DistributedOrthoBase):
             For element-wise update rules, this is the actual learning rate and no additional scaling is done.
         mu: Momentum factor for NorMuon algorithm.
         muon_beta2: Second beta parameter for NorMuon algorithm's adaptive updates.
+        normalization: Update normalization mode. 'neuron' (default) normalizes
+            along the last dimension. 'short_axis' normalizes along the shorter
+            matrix axis (equivalent to 'neuron' for tall matrices, but for wide
+            matrices reduces along rows instead of columns).
         betas: Tuple of (beta1, beta2) for AdamW and Lion algorithms.
         weight_decay: Weight decay factor.
         cautious_wd: Whether to apply weight decay only where update and parameter signs align.
@@ -57,6 +72,7 @@ class NorMuon(DistributedOrthoBase):
         lr: float = 0.01,
         mu: float = 0.95,
         muon_beta2: float = 0.95,
+        normalization: str = "neuron",
         betas: Tuple[float, float] = (0.9, 0.95),
         weight_decay: float = 0.01,
         cautious_wd: bool = False,
@@ -82,10 +98,12 @@ class NorMuon(DistributedOrthoBase):
                 f"Invalid adjust_lr value: {adjust_lr}. Must be 'spectral_norm', 'rms_norm', or None."
             )
 
+        normalization = _canonical_normalization(normalization)
         defaults = dict(
             lr=lr,
             mu=mu,
             muon_beta2=muon_beta2,
+            normalization=normalization,
             beta1=betas[0],
             beta2=betas[1],
             weight_decay=weight_decay,
@@ -106,10 +124,28 @@ class NorMuon(DistributedOrthoBase):
         )
 
     def _get_or_initialize_state(self, param: Tensor, algo: str) -> dict:
-        state = super()._get_or_initialize_state(param, algo)
-        if algo == self._algo_name and "variance_neuron" not in state:
-            state["variance_neuron"] = torch.zeros_like(param[..., 0:1])
-        return state
+        # Variance buffer is initialized lazily in _get_or_initialize_variance
+        # since its shape depends on the group's normalization mode.
+        return super()._get_or_initialize_state(param, algo)
+
+    def _get_or_initialize_variance(
+        self, param: Tensor, state: dict, normalization: str
+    ) -> Tensor:
+        local = to_local(param)
+        shape = list(local.shape)
+        if normalization == "neuron":
+            shape[-1] = 1
+        elif normalization == "short_axis":
+            red_dim = -1 if param.shape[-2] >= param.shape[-1] else -2
+            shape[red_dim] = 1
+        else:
+            raise ValueError(f"Unknown normalization: {normalization}")
+
+        variance = state.get("variance_neuron")
+        if variance is None or tuple(variance.shape) != tuple(shape):
+            variance = torch.zeros(shape, device=local.device, dtype=local.dtype)
+            state["variance_neuron"] = variance
+        return variance
 
     def _get_shard_info(self, param: Tensor, group: dict):
         result = super()._get_shard_info(param, group)
@@ -138,11 +174,13 @@ class NorMuon(DistributedOrthoBase):
             if not group_params:
                 continue
 
+            normalization = _canonical_normalization(group["normalization"])
             update_args = dict(
                 lr=torch.tensor(group["lr"]),
                 momentum=torch.tensor(group["mu"]),
                 muon_beta2=torch.tensor(group["muon_beta2"]),
                 weight_decay=torch.tensor(group["weight_decay"]),
+                normalization=normalization,
                 epsilon=torch.tensor(group["epsilon"]),
                 nesterov=group["nesterov"],
                 flatten=group["flatten"],
@@ -165,13 +203,10 @@ class NorMuon(DistributedOrthoBase):
                 gradients = [p.grad for p in params]
                 states = [self._get_or_initialize_state(p, self._algo_name) for p in params]
                 momentums = [s["momentum"] for s in states]
-                variances_neuron = [s["variance_neuron"] for s in states]
 
                 if num_heads is not None:
-                    params, gradients, momentums, variances_neuron = (
-                        self._prepare_head_split(
-                            num_heads, params, gradients, momentums, variances_neuron
-                        )
+                    params, gradients, momentums = self._prepare_head_split(
+                        num_heads, params, gradients, momentums
                     )
                     megabatch_args = {**update_args, "process_group": None}
                     shard_dim = None
@@ -183,6 +218,13 @@ class NorMuon(DistributedOrthoBase):
                     if is_batch_sharded and not is_matrix_sharded:
                         megabatch_args = {**update_args, "process_group": None}
                     shard_dim = sharded_tensor_dim
+
+                # Variance buffer shape depends on normalization + (post-split)
+                # param shape, so initialize after head split.
+                variances_neuron = [
+                    self._get_or_initialize_variance(p, s, normalization)
+                    for p, s in zip(params, states)
+                ]
 
                 yield AsyncTask(
                     normuon_update_megabatch_async(
@@ -205,6 +247,7 @@ def normuon_update_megabatch_async(
     momentum: Tensor,
     muon_beta2: Tensor,
     weight_decay: Tensor,
+    normalization: str,
     epsilon: Tensor,
     nesterov: bool,
     flatten: bool,
@@ -247,7 +290,19 @@ def normuon_update_megabatch_async(
     V_local = to_local(V)
     U_stacked = torch.stack(U)
     V_stacked = torch.stack(V_local)
-    U_stacked, V_stacked = normuon_normalization_stacked(U_stacked, V_stacked, muon_beta2)
+    if normalization == "neuron":
+        U_stacked, V_stacked = normuon_normalization_stacked(U_stacked, V_stacked, muon_beta2)
+    elif normalization == "short_axis":
+        U_stacked, V_stacked = yield from normuon_short_axis_normalization_async(
+            U_stacked,
+            V_stacked,
+            muon_beta2=muon_beta2,
+            param_shape=X[0].shape,
+            shard_dim=shard_dim,
+            process_group=process_group,
+        )
+    else:
+        raise ValueError(f"Unknown normalization: {normalization}")
     for i in range(N):
         V_local[i].copy_(V_stacked[i])
     U = [U_stacked[i] for i in range(N)]
@@ -271,6 +326,47 @@ def normuon_update_megabatch_async(
         weight_decay=weight_decay,
         cautious_wd=cautious_wd,
     )
+
+
+def normuon_short_axis_normalization_async(
+    U: Tensor,  # [N, rows, cols]
+    V: Tensor,  # [N, ..., 1]   (variance buffer, with 1 along the long axis)
+    muon_beta2: Tensor,
+    param_shape: torch.Size,
+    shard_dim: Optional[int],
+    process_group: Optional[ProcessGroup],
+) -> Generator[None, None, Tuple[Tensor, Tensor]]:
+    """
+    Short-axis NorMuon normalization: variance is tracked per index along the
+    shorter matrix axis (reduction is over the longer axis). Equivalent to
+    'neuron' for tall matrices; for wide matrices it reduces along rows
+    instead of columns. An async all-reduce is issued when the reduced axis
+    is sharded.
+    """
+    red_dim = -1
+    if param_shape[-2] < param_shape[-1]:
+        red_dim = -2
+
+    sum_sq = U.float().square().sum(dim=red_dim, keepdim=True)
+    shard_dim_neg = None
+    if shard_dim is not None:
+        shard_dim_neg = shard_dim if shard_dim < 0 else shard_dim - len(param_shape)
+    if process_group is not None and shard_dim_neg == red_dim:
+        work = dist.all_reduce(sum_sq, group=process_group, async_op=True)
+        yield
+        work.wait()
+
+    red_dim_size = param_shape[red_dim]
+    V_dtype = V.dtype
+    U_v = U.to(dtype=V_dtype)
+    norm_U = U_v.norm(p=2, dim=(-2, -1), keepdim=True)
+    variance_new = (sum_sq / red_dim_size).to(dtype=V_dtype)
+    V = torch.lerp(V, variance_new, 1 - muon_beta2)
+    denom = V.sqrt() + 1e-8
+    normalized_U = U_v / denom
+    norm_U_new = normalized_U.norm(p=2, dim=(-2, -1), keepdim=True).clamp(min=1e-8)
+    normalized_U = normalized_U * (norm_U / norm_U_new)
+    return normalized_U, V
 
 
 @torch.compile(fullgraph=True)

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -9,6 +9,7 @@ from typing import Callable, Generator, List, Optional, Tuple, Union
 
 from .megabatch_base import (
     DistributedOrthoBase,
+    canonical_normalization,
     megabatch_orthogonalize_async,
     adjust_lr_spectral_norm,
     adjust_lr_rms_norm,
@@ -18,13 +19,7 @@ from .muon import muon_update_pre_orthogonalize, muon_update_post_orthogonalize
 
 
 def _canonical_normalization(normalization: str) -> str:
-    if isinstance(normalization, str):
-        value = normalization.lower()
-        if value in ("neuron", "short_axis"):
-            return value
-    raise ValueError(
-        f"Invalid normalization: {normalization}. Must be 'neuron' or 'short_axis'."
-    )
+    return canonical_normalization(normalization, allow_none=False)
 
 
 class NorMuon(DistributedOrthoBase):
@@ -131,6 +126,16 @@ class NorMuon(DistributedOrthoBase):
     def _get_or_initialize_variance(
         self, param: Tensor, state: dict, normalization: str
     ) -> Tensor:
+        """Lazily allocate the per-param variance EMA buffer.
+
+        Note on resume / mode switch: the buffer is keyed by shape, so loading
+        a checkpoint and then changing the ``normalization`` mode (e.g.
+        ``neuron`` -> ``short_axis`` for a wide matrix) silently re-initializes
+        the EMA to zero. This is intentional: the saved variance is no longer
+        meaningful under the new mode, and a hard error would force the user
+        to manually clear state. The trade-off is a brief warm-up period where
+        the EMA is rebuilding from the new reduction axis.
+        """
         local = to_local(param)
         shape = list(local.shape)
         if normalization == "neuron":
@@ -328,6 +333,31 @@ def normuon_update_megabatch_async(
     )
 
 
+@torch.compile(fullgraph=True)
+def _normuon_short_axis_sum_sq_compiled(U: Tensor, red_dim: int) -> Tensor:
+    return U.float().square().sum(dim=red_dim, keepdim=True)
+
+
+@torch.compile(fullgraph=True)
+def _normuon_short_axis_finish_compiled(
+    U: Tensor,
+    V: Tensor,
+    sum_sq: Tensor,
+    red_dim_size: int,
+    muon_beta2: Tensor,
+) -> Tuple[Tensor, Tensor]:
+    V_dtype = V.dtype
+    U_v = U.to(dtype=V_dtype)
+    norm_U = U_v.norm(p=2, dim=(-2, -1), keepdim=True)
+    variance_new = (sum_sq / red_dim_size).to(dtype=V_dtype)
+    V = torch.lerp(V, variance_new, 1 - muon_beta2)
+    denom = V.sqrt() + 1e-8
+    normalized_U = U_v / denom
+    norm_U_new = normalized_U.norm(p=2, dim=(-2, -1), keepdim=True).clamp(min=1e-8)
+    normalized_U = normalized_U * (norm_U / norm_U_new)
+    return normalized_U, V
+
+
 def normuon_short_axis_normalization_async(
     U: Tensor,  # [N, rows, cols]
     V: Tensor,  # [N, ..., 1]   (variance buffer, with 1 along the long axis)
@@ -342,12 +372,15 @@ def normuon_short_axis_normalization_async(
     'neuron' for tall matrices; for wide matrices it reduces along rows
     instead of columns. An async all-reduce is issued when the reduced axis
     is sharded.
+
+    Pure-tensor pre-/post-comm sections are compiled; the async dist.all_reduce
+    sits in between and stays in eager Python.
     """
     red_dim = -1
     if param_shape[-2] < param_shape[-1]:
         red_dim = -2
 
-    sum_sq = U.float().square().sum(dim=red_dim, keepdim=True)
+    sum_sq = _normuon_short_axis_sum_sq_compiled(U, red_dim)
     shard_dim_neg = None
     if shard_dim is not None:
         shard_dim_neg = shard_dim if shard_dim < 0 else shard_dim - len(param_shape)
@@ -356,16 +389,9 @@ def normuon_short_axis_normalization_async(
         yield
         work.wait()
 
-    red_dim_size = param_shape[red_dim]
-    V_dtype = V.dtype
-    U_v = U.to(dtype=V_dtype)
-    norm_U = U_v.norm(p=2, dim=(-2, -1), keepdim=True)
-    variance_new = (sum_sq / red_dim_size).to(dtype=V_dtype)
-    V = torch.lerp(V, variance_new, 1 - muon_beta2)
-    denom = V.sqrt() + 1e-8
-    normalized_U = U_v / denom
-    norm_U_new = normalized_U.norm(p=2, dim=(-2, -1), keepdim=True).clamp(min=1e-8)
-    normalized_U = normalized_U * (norm_U / norm_U_new)
+    normalized_U, V = _normuon_short_axis_finish_compiled(
+        U, V, sum_sq, param_shape[red_dim], muon_beta2,
+    )
     return normalized_U, V
 
 

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -158,6 +158,37 @@ class TestMuonH:
         with pytest.raises(ValueError):
             MuonH(_make_params([(32, 64)]), normalization="invalid")
 
+    @pytest.mark.parametrize("normalization", [None, "neuron", "short_axis"])
+    def test_3d_experts_match_separate_params(self, normalization):
+        from dion import MuonH
+
+        torch.manual_seed(11)
+        init = torch.randn(4, 32, 16, device=DEVICE)
+
+        packed = torch.nn.Parameter(init.clone())
+        packed_opt = MuonH([packed], lr=0.01, normalization=normalization)
+
+        separate = [
+            torch.nn.Parameter(init[i].clone()) for i in range(init.shape[0])
+        ]
+        separate_opt = MuonH(separate, lr=0.01, normalization=normalization)
+
+        for step in range(3):
+            torch.manual_seed(200 + step)
+            grad = torch.randn_like(init)
+            packed.grad = grad.clone()
+            for i, p in enumerate(separate):
+                p.grad = grad[i].clone()
+            packed_opt.step()
+            separate_opt.step()
+
+        torch.testing.assert_close(
+            packed.data,
+            torch.stack([p.data for p in separate]),
+            rtol=1e-5,
+            atol=1e-5,
+        )
+
 
 # ---------------------------------------------------------------------------
 # NorMuon
@@ -392,13 +423,39 @@ class TestNumHeads:
         from dion import NorMuon
         self._run_parity(NorMuon, dict(lr=0.01, normalization="short_axis"))
 
-    def test_muonh_matches_3d(self):
+    def test_muonh_rejects_num_heads(self):
         from dion import MuonH
-        self._run_parity(MuonH, dict(lr=0.01))
+        w = torch.nn.Parameter(torch.randn(32, 16, device=DEVICE))
+        w.grad = torch.randn_like(w)
+        opt = MuonH([{"params": [w], "num_heads": 4}], lr=0.01)
+        with pytest.raises(ValueError, match="does not support num_heads"):
+            opt.step()
 
-    def test_muonh_matches_3d_short_axis(self):
+    def test_muonh_rejects_num_heads_short_axis(self):
         from dion import MuonH
-        self._run_parity(MuonH, dict(lr=0.01, normalization="short_axis"))
+        w = torch.nn.Parameter(torch.randn(32, 16, device=DEVICE))
+        w.grad = torch.randn_like(w)
+        opt = MuonH(
+            [{"params": [w], "num_heads": 4}],
+            lr=0.01,
+            normalization="short_axis",
+        )
+        with pytest.raises(ValueError, match="does not support num_heads"):
+            opt.step()
+
+    def test_muonh_num_heads_one_is_noop(self):
+        from dion import MuonH
+        w = torch.nn.Parameter(torch.randn(32, 16, device=DEVICE))
+        w_ref = torch.nn.Parameter(w.data.clone())
+        g = torch.randn_like(w)
+        for _ in range(2):
+            w.grad = g.clone()
+            w_ref.grad = g.clone()
+        opt = MuonH([{"params": [w], "num_heads": 1}], lr=0.01)
+        opt_ref = MuonH([w_ref], lr=0.01)
+        opt.step()
+        opt_ref.step()
+        torch.testing.assert_close(w.data, w_ref.data)
 
     def test_muon_invalid_num_heads(self):
         from dion import Muon

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -224,13 +224,21 @@ class TestNorMuon:
 
     def test_short_axis_matches_neuron_for_tall(self):
         """For tall matrices the reduction axis is the same, so short_axis
-        must produce numerically identical updates to neuron."""
+        and neuron should produce numerically equivalent updates.
+
+        The two paths are not bitwise identical: ``neuron`` does the variance
+        reduction in the param dtype via ``(U*U).mean(-1)``, while
+        ``short_axis`` reduces in fp32 via ``square().sum(-1)/N`` and casts
+        back. Tolerances are sized to allow that difference plus its
+        accumulation across 3 steps, and to avoid flaking on hardware whose
+        matmul/reduction kernels differ from Hopper's.
+        """
         from dion import NorMuon
         p1 = _make_params([(128, 64)])
         r1 = _run_steps(NorMuon, p1, dict(lr=0.01, normalization="neuron"))
         p2 = _make_params([(128, 64)])
         r2 = _run_steps(NorMuon, p2, dict(lr=0.01, normalization="short_axis"))
-        torch.testing.assert_close(r1[0], r2[0], rtol=1e-5, atol=1e-5)
+        torch.testing.assert_close(r1[0], r2[0], rtol=1e-3, atol=1e-4)
 
     def test_invalid_normalization(self):
         from dion import NorMuon
@@ -379,6 +387,18 @@ class TestNumHeads:
     def test_normuon_matches_3d(self):
         from dion import NorMuon
         self._run_parity(NorMuon, dict(lr=0.01))
+
+    def test_normuon_matches_3d_short_axis(self):
+        from dion import NorMuon
+        self._run_parity(NorMuon, dict(lr=0.01, normalization="short_axis"))
+
+    def test_muonh_matches_3d(self):
+        from dion import MuonH
+        self._run_parity(MuonH, dict(lr=0.01))
+
+    def test_muonh_matches_3d_short_axis(self):
+        from dion import MuonH
+        self._run_parity(MuonH, dict(lr=0.01, normalization="short_axis"))
 
     def test_muon_invalid_num_heads(self):
         from dion import Muon
@@ -635,3 +655,130 @@ class TestTiming:
         t1 = time.perf_counter()
         # Should register nonzero time
         assert t1 > t0
+
+
+# ---------------------------------------------------------------------------
+# DTensor-sharded MuonH smoke test (multi-process, NCCL)
+# ---------------------------------------------------------------------------
+#
+# Most of MuonH's complexity is the FSDP2 sharding/all-reduce paths
+# (radius init, normalization reduction, fused post-step reduction). The
+# single-GPU tests above don't exercise any of that. This launches two
+# real ranks via mp.spawn, runs a few steps on a 2-way Shard(dim) DTensor,
+# and verifies that (a) it completes without error, (b) the parameter
+# Frobenius norm stays at the initial radius, and (c) the parameter is
+# updated identically across ranks.
+
+
+def _muonh_dtensor_worker(rank, world_size, port, shard_dim, normalization, queue):
+    import os, traceback
+    try:
+        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        os.environ["MASTER_PORT"] = str(port)
+        os.environ["RANK"] = str(rank)
+        os.environ["WORLD_SIZE"] = str(world_size)
+        os.environ["LOCAL_RANK"] = str(rank)
+
+        import torch
+        import torch.distributed as dist
+        from torch.distributed.device_mesh import init_device_mesh
+        from torch.distributed.tensor import distribute_tensor, Shard
+
+        torch.cuda.set_device(rank)
+        dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+        mesh = init_device_mesh("cuda", (world_size,), mesh_dim_names=("fs",))
+
+        from dion import MuonH
+
+        device = f"cuda:{rank}"
+        torch.manual_seed(42)
+        full = torch.randn(64, 128, device=device)
+        initial_norm = float(full.float().norm())
+
+        param = torch.nn.Parameter(distribute_tensor(full, mesh, [Shard(shard_dim)]))
+        opt = MuonH(
+            [param],
+            distributed_mesh=mesh,
+            lr=0.01,
+            normalization=normalization,
+        )
+
+        for step in range(3):
+            torch.manual_seed(100 + step)
+            grad_full = torch.randn(64, 128, device=device)
+            param.grad = distribute_tensor(grad_full, mesh, [Shard(shard_dim)])
+            opt.step()
+
+        # Reconstruct the full tensor and report its Frobenius norm.
+        full_param = param.full_tensor()
+        final_norm = float(full_param.float().norm())
+        # Hash a fingerprint of the full tensor for cross-rank consistency.
+        fingerprint = float(full_param.float().sum())
+        queue.put((rank, "ok", initial_norm, final_norm, fingerprint))
+    except Exception:
+        queue.put((rank, "err", traceback.format_exc(), None, None))
+    finally:
+        try:
+            import torch.distributed as dist
+            if dist.is_initialized():
+                dist.destroy_process_group()
+        except Exception:
+            pass
+
+
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2, reason="Requires >=2 CUDA devices"
+)
+class TestMuonHDTensor:
+    @pytest.mark.parametrize(
+        "shard_dim,normalization",
+        [
+            (0, None),          # tall, batch-sharded (matrix dims unsharded)
+            (-2, "neuron"),     # matrix-sharded along rows, neuron normalization
+            (-1, "neuron"),     # matrix-sharded along last dim (MuonH-only path)
+            (-2, "short_axis"), # the case the reviewer specifically called out
+            (-1, "short_axis"),
+        ],
+    )
+    def test_sharded_step(self, shard_dim, normalization):
+        import torch.multiprocessing as mp
+
+        world_size = 2
+        # Deterministic-ish port per param combo to avoid collisions across runs.
+        port = 29500 + (abs(hash((shard_dim, str(normalization)))) % 500)
+        ctx = mp.get_context("spawn")
+        queue = ctx.Queue()
+        procs = [
+            ctx.Process(
+                target=_muonh_dtensor_worker,
+                args=(rank, world_size, port, shard_dim, normalization, queue),
+            )
+            for rank in range(world_size)
+        ]
+        for p in procs:
+            p.start()
+        for p in procs:
+            p.join(timeout=180)
+        results = []
+        while not queue.empty():
+            results.append(queue.get())
+        for p in procs:
+            if p.is_alive():
+                p.terminate()
+            assert p.exitcode == 0, f"Worker exited with code {p.exitcode}"
+
+        assert len(results) == world_size, f"Expected {world_size} results, got {results}"
+        for rank, status, *info in results:
+            assert status == "ok", f"Rank {rank} failed:\n{info[0]}"
+
+        # Frobenius radius preserved (core MuonH invariant) across ranks.
+        norms = [(r[2], r[3]) for r in results]
+        for initial, final in norms:
+            assert abs(final - initial) / initial < 1e-3, (
+                f"Frobenius radius drifted: initial={initial}, final={final}"
+            )
+        # Both ranks should see the same reconstructed parameter.
+        fps = [r[4] for r in results]
+        assert abs(fps[0] - fps[1]) < 1e-3 * max(1.0, abs(fps[0])), (
+            f"Reconstructed parameter differs across ranks: {fps}"
+        )

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -196,6 +196,47 @@ class TestNorMuon:
         assert "variance_neuron" in state
         assert state["variance_neuron"].shape == (64, 1)
 
+    @pytest.mark.parametrize("normalization", ["neuron", "short_axis"])
+    def test_normalization_options(self, normalization):
+        from dion import NorMuon
+        params = _make_params([(64, 128), (128, 64)])
+        _run_steps(NorMuon, params, dict(lr=0.01, normalization=normalization))
+
+    def test_variance_shapes(self):
+        from dion import NorMuon
+        wide = torch.nn.Parameter(torch.randn(64, 128, device=DEVICE))
+        tall = torch.nn.Parameter(torch.randn(128, 64, device=DEVICE))
+
+        opt = NorMuon([wide], lr=0.01, normalization="neuron")
+        wide.grad = torch.randn_like(wide)
+        opt.step()
+        assert opt.state[wide]["variance_neuron"].shape == (64, 1)
+
+        opt = NorMuon([wide], lr=0.01, normalization="short_axis")
+        wide.grad = torch.randn_like(wide)
+        opt.step()
+        assert opt.state[wide]["variance_neuron"].shape == (1, 128)
+
+        opt = NorMuon([tall], lr=0.01, normalization="short_axis")
+        tall.grad = torch.randn_like(tall)
+        opt.step()
+        assert opt.state[tall]["variance_neuron"].shape == (128, 1)
+
+    def test_short_axis_matches_neuron_for_tall(self):
+        """For tall matrices the reduction axis is the same, so short_axis
+        must produce numerically identical updates to neuron."""
+        from dion import NorMuon
+        p1 = _make_params([(128, 64)])
+        r1 = _run_steps(NorMuon, p1, dict(lr=0.01, normalization="neuron"))
+        p2 = _make_params([(128, 64)])
+        r2 = _run_steps(NorMuon, p2, dict(lr=0.01, normalization="short_axis"))
+        torch.testing.assert_close(r1[0], r2[0], rtol=1e-5, atol=1e-5)
+
+    def test_invalid_normalization(self):
+        from dion import NorMuon
+        with pytest.raises(ValueError):
+            NorMuon(_make_params([(32, 64)]), normalization="invalid")
+
     def test_megabatch_same_shape(self):
         from dion import NorMuon
         params = _make_params([(64, 128)] * 5)

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -94,6 +94,72 @@ class TestMuon:
 
 
 # ---------------------------------------------------------------------------
+# MuonH
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA required")
+class TestMuonH:
+    def test_basic(self):
+        from dion import MuonH
+        params = _make_params([(64, 128), (128, 64)])
+        _run_steps(MuonH, params, dict(lr=0.01))
+
+    @pytest.mark.parametrize("normalization", [None, "None", "neuron", "short_axis"])
+    def test_normalization_options(self, normalization):
+        from dion import MuonH
+        params = _make_params([(64, 128), (128, 64)])
+        _run_steps(MuonH, params, dict(lr=0.01, normalization=normalization))
+
+    @pytest.mark.parametrize("normalization", [None, "neuron", "short_axis"])
+    def test_preserves_frobenius_norm(self, normalization):
+        from dion import MuonH
+        params = _make_params([(64, 128), (128, 64)])
+        before = [p.data.float().norm() for p in params]
+        _run_steps(
+            MuonH,
+            params,
+            dict(lr=0.01, normalization=normalization),
+            n_steps=2,
+        )
+        after = [p.data.float().norm() for p in params]
+        for a, b in zip(after, before):
+            torch.testing.assert_close(a, b, rtol=1e-5, atol=1e-5)
+
+    def test_variance_shapes(self):
+        from dion import MuonH
+        wide = torch.nn.Parameter(torch.randn(64, 128, device=DEVICE))
+        tall = torch.nn.Parameter(torch.randn(128, 64, device=DEVICE))
+
+        opt = MuonH([wide], lr=0.01, normalization="neuron")
+        wide.grad = torch.randn_like(wide)
+        opt.step()
+        assert opt.state[wide]["variance_normalization"].shape == (64, 1)
+
+        opt = MuonH([wide], lr=0.01, normalization="short_axis")
+        wide.grad = torch.randn_like(wide)
+        opt.step()
+        assert opt.state[wide]["variance_normalization"].shape == (1, 128)
+
+        opt = MuonH([tall], lr=0.01, normalization="short_axis")
+        tall.grad = torch.randn_like(tall)
+        opt.step()
+        assert opt.state[tall]["variance_normalization"].shape == (128, 1)
+
+    def test_zero_radius_rejected(self):
+        from dion import MuonH
+        param = torch.nn.Parameter(torch.zeros(64, 128, device=DEVICE))
+        param.grad = torch.randn_like(param)
+        opt = MuonH([param], lr=0.01)
+        with pytest.raises(ValueError, match="non-zero"):
+            opt.step()
+
+    def test_invalid_normalization(self):
+        from dion import MuonH
+        with pytest.raises(ValueError):
+            MuonH(_make_params([(32, 64)]), normalization="invalid")
+
+
+# ---------------------------------------------------------------------------
 # NorMuon
 # ---------------------------------------------------------------------------
 

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -189,6 +189,38 @@ class TestMuonH:
             atol=1e-5,
         )
 
+    @pytest.mark.parametrize("normalization", [None, "neuron", "short_axis"])
+    def test_flatten_3d_matches_explicit_2d(self, normalization):
+        from dion import MuonH
+
+        torch.manual_seed(13)
+        init = torch.randn(4, 32, 16, device=DEVICE)
+
+        packed = torch.nn.Parameter(init.clone())
+        packed_opt = MuonH(
+            [packed], lr=0.01, normalization=normalization, flatten=True
+        )
+
+        flat = torch.nn.Parameter(init.clone().flatten(start_dim=1))
+        flat_opt = MuonH(
+            [flat], lr=0.01, normalization=normalization, flatten=False
+        )
+
+        for step in range(3):
+            torch.manual_seed(300 + step)
+            grad = torch.randn_like(init)
+            packed.grad = grad.clone()
+            flat.grad = grad.flatten(start_dim=1).clone()
+            packed_opt.step()
+            flat_opt.step()
+
+        torch.testing.assert_close(
+            packed.data.flatten(start_dim=1),
+            flat.data,
+            rtol=1e-5,
+            atol=1e-5,
+        )
+
 
 # ---------------------------------------------------------------------------
 # NorMuon
@@ -270,6 +302,38 @@ class TestNorMuon:
         p2 = _make_params([(128, 64)])
         r2 = _run_steps(NorMuon, p2, dict(lr=0.01, normalization="short_axis"))
         torch.testing.assert_close(r1[0], r2[0], rtol=1e-3, atol=1e-4)
+
+    @pytest.mark.parametrize("normalization", ["neuron", "short_axis"])
+    def test_flatten_3d_matches_explicit_2d(self, normalization):
+        from dion import NorMuon
+
+        torch.manual_seed(17)
+        init = torch.randn(4, 32, 16, device=DEVICE)
+
+        packed = torch.nn.Parameter(init.clone())
+        packed_opt = NorMuon(
+            [packed], lr=0.01, normalization=normalization, flatten=True
+        )
+
+        flat = torch.nn.Parameter(init.clone().flatten(start_dim=1))
+        flat_opt = NorMuon(
+            [flat], lr=0.01, normalization=normalization, flatten=False
+        )
+
+        for step in range(3):
+            torch.manual_seed(400 + step)
+            grad = torch.randn_like(init)
+            packed.grad = grad.clone()
+            flat.grad = grad.flatten(start_dim=1).clone()
+            packed_opt.step()
+            flat_opt.step()
+
+        torch.testing.assert_close(
+            packed.data.flatten(start_dim=1),
+            flat.data,
+            rtol=1e-5,
+            atol=1e-5,
+        )
 
     def test_invalid_normalization(self):
         from dion import NorMuon


### PR DESCRIPTION
Both the optimizer and "short_axis" normalization inspired by https://github.com/KellerJordan/modded-nanogpt/pull/273. Big thanks to @WhenWen. 

[MuonH writeup](https://psychedelic-sunstone-851.notion.site/Fantastic-Pretraining-Optimizers-and-Where-to-Find-Them-2-1-Hyperball-Optimization-2e924306e6f280e7a5ffee00eb40a0dd)

only 3-4% slower on opt.step gpu time compared to normuon. 