### PR TITLE
deps: bump gram-newton-schulz to fix int/float schema mismatch with newer quack

### DIFF
--- a/requirements_dion.txt
+++ b/requirements_dion.txt
@@ -1,3 +1,3 @@
 numpy
 torch>=2.7.1
-gram-newton-schulz==0.1.2
+gram-newton-schulz @ git+https://github.com/Dao-AILab/gram-newton-schulz@2763e8b


### PR DESCRIPTION
## Summary

Bump `gram-newton-schulz` from `==0.1.2` to upstream commit `2763e8b` (\"pin to quack 0.4.1\") to fix a runtime crash when normuon runs with `use_gram_newton_schulz: true` **and** `use_triton: true` against newer quack releases.

## Problem

Both released versions of `gram-newton-schulz` (0.1.2 and 0.1.3) declare the kernel-backend lambda in `gram_newton_schulz/gram_newton_schulz.py` with **int** defaults:

\`\`\`python
sym_baddbmm=lambda A, B, C, alpha=1, beta=1: gemm_symmetric(A, B, C=C, alpha=alpha, beta=beta)
\`\`\`

Recent `quack` releases changed the schema of `quack::gemm_symmetric_out` to:

\`\`\`
Tensor A, Tensor B, Tensor(a2!) out, Tensor? C=None, bool dynamic_scheduler=False,
float alpha=1., float beta=1., Tensor? alpha_tensor=None, Tensor? beta_tensor=None
\`\`\`

TorchScript dispatch can no longer cast Python `int 1` into the `float alpha` slot and falls through to `alpha_tensor` (`Tensor?`), producing:

\`\`\`
RuntimeError: quack::gemm_symmetric_out() Expected a value of type 'Optional[Tensor]'
for argument 'alpha_tensor' but instead found type 'int'.
Cast error details: Unable to cast 1 to Tensor.
\`\`\`

This crashed both 1b-1b and 1b-10b benchmarks the moment normuon's first optimizer step ran ([microsoft/aifsdk PR #853](https://github.com/microsoft/aifsdk/pull/853) added `use_triton: true` to `mixformer-1b.yaml`, exposing the latent bug).

## Fix

Upstream commit [Dao-AILab/gram-newton-schulz@2763e8b](https://github.com/Dao-AILab/gram-newton-schulz/commit/2763e8b) (\"pin to quack 0.4.1\") changes the lambda defaults to `alpha=1., beta=1.` (floats) in both the torch and kernel backends. The change is unreleased on PyPI, so this PR pins via git. Switch back to a `>=0.1.4` constraint once Dao-AILab cuts a release containing the fix.

## Test plan

- [ ] After this lands, bump dion's git-pin in `phitrain/pyproject.toml` (microsoft/aifsdk) to the new dion sha and re-run the 1b-10m smoke test on `semantic/control` — should no longer crash in `quack::gemm_symmetric_out`
- [ ] Run dion's existing test suite (`pytest tests/`) to confirm no regression in the gns code path