### PR TITLE
Pin quack-kernels dependency and upgrade gram-newton-schulz to 0.1.4

### DIFF
--- a/requirements_dion.txt
+++ b/requirements_dion.txt
@@ -1,3 +1,4 @@
 numpy
 torch>=2.7.1
-gram-newton-schulz==0.1.2
+gram-newton-schulz==0.1.4
+quack-kernels==0.4.1


### PR DESCRIPTION
gram-newton-schulz doesn't pin its dependency on quack-kernels, so we pin it explicitly here to avoid unexpected breakage from unpinned transitive dependencies.

Also upgrades gram-newton-schulz from 0.1.2 to 0.1.4.