### PR TITLE
Fix megabatch_orthogonalize_async hang on empty FSDP2 shards

### DIFF
--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -392,6 +392,29 @@ def megabatch_orthogonalize_async(
 
     if comm_dim is not None and process_group is not None:
         # --- Mega-batched sharded FSDP2 path ---
+
+        # Pad each rank's local shard along comm_dim to a rank-consistent
+        # ``padded_local_size`` so dist.all_to_all sees uniform per-pair
+        # sizes. FSDP2 contiguous chunking otherwise leaves some ranks with
+        # empty (numel=0) shards when the sharded global dim is smaller than
+        # world_size or doesn't divide evenly to fill all ranks (e.g. shape
+        # (18, D) over world_size=8: ranks 6 and 7 hold (0, D) shards). Without
+        # padding the alltoall has mismatched per-pair sizes and hangs.
+        # Newton-Schulz preserves zero rows (they contribute nothing to U^T U),
+        # so padding doesn't change the orthogonalization of the real rows.
+        original_local_size = U_work[0].size(comm_dim)
+        local_size_t = torch.tensor(
+            [original_local_size], device=U_work[0].device, dtype=torch.long
+        )
+        dist.all_reduce(local_size_t, op=dist.ReduceOp.MAX, group=process_group)
+        padded_local_size = int(local_size_t.item())
+
+        if padded_local_size != original_local_size:
+            # F.pad's pad-spec is built from the LAST dim backwards. comm_dim
+            # is negative; pad only the END of comm_dim.
+            pad_spec = [0, 0] * (-comm_dim - 1) + [0, padded_local_size - original_local_size]
+            U_work = [torch.nn.functional.pad(u, pad_spec) for u in U_work]
+
         input_chunks = [
             torch.stack(U_work[r * per_rank : (r + 1) * per_rank])
             for r in range(world_size)
@@ -425,7 +448,13 @@ def megabatch_orthogonalize_async(
         yield
         work.wait()
 
-        result = [recv_chunks[r][i] for r in range(world_size) for i in range(per_rank)]
+        # Narrow each per-rank result back to the rank's original local size.
+        # On padding-only ranks original_local_size == 0 and the slice is empty.
+        result = [
+            recv_chunks[r][i].narrow(comm_dim, 0, original_local_size).contiguous()
+            for r in range(world_size)
+            for i in range(per_rank)
+        ]
         return result[:N]
 
     elif N > 1 and process_group is not None:

--- a/tests/test_megabatch_empty_shard.py
+++ b/tests/test_megabatch_empty_shard.py
@@ -1,0 +1,106 @@
+"""Regression test: ``megabatch_orthogonalize_async`` must not hang when some
+ranks hold empty (numel=0) FSDP2 padding-only shards.
+
+Background. FSDP2's ``_chunk_with_empty(t, world_size, dim=shard_dim)`` produces
+fewer than ``world_size`` non-empty chunks when the sharded global dim is
+smaller than ``world_size`` or doesn't divide evenly to fill all ranks (e.g.
+shape ``(18, D)`` over ``world_size=8`` gives 6 real chunks of ``(3, D)`` plus
+2 empty ``(0, D)`` chunks). The optimizer step then sees per-rank local shards
+of differing sizes; ``torch.stack(...)`` and the subsequent
+``dist.all_to_all`` produce mismatched per-pair sizes and hang at NCCL.
+"""
+
+import os
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from dion.megabatch_base import megabatch_orthogonalize_async
+from dion.opt_utils import AsyncRuntime, AsyncTask
+from dion.polar_express import polar_express
+
+
+CUDA_DEVICE_COUNT = torch.cuda.device_count() if torch.cuda.is_available() else 0
+
+
+def _ns_func(x, epsilon=1e-7):
+    return polar_express(x, epsilon=epsilon)
+
+
+def _worker(rank: int, world_size: int, global_dim_0: int, dim_1: int, n_params: int, port: int) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+    pg = dist.group.WORLD
+    device = torch.device(f"cuda:{rank}")
+
+    # Mimic FSDP2 contiguous chunking on a (global_dim_0, dim_1) param.
+    # FSDP2 narrows the per-rank shard back to 2D shape (k, dim_1) where k>=0
+    # and k=0 for padding-only ranks (see _init_sharded_param in
+    # torch/distributed/fsdp/_fully_shard/_fsdp_param.py).
+    full = torch.arange(global_dim_0 * dim_1, device=device).view(global_dim_0, dim_1).float()
+    real_chunks = list(torch.chunk(full, world_size, dim=0))
+    if rank < len(real_chunks):
+        local_shape = real_chunks[rank].shape
+    else:
+        local_shape = torch.Size([0, dim_1])
+
+    U = []
+    for i in range(n_params):
+        if local_shape[0] == 0:
+            U.append(torch.zeros(local_shape, dtype=torch.float32, device=device))
+        else:
+            g = torch.Generator(device=device).manual_seed(rank * 17 + i)
+            U.append(torch.randn(local_shape, dtype=torch.float32, device=device, generator=g))
+
+    state = {}
+
+    def _task_gen():
+        result = yield from megabatch_orthogonalize_async(
+            U,
+            comm_dim=-2,
+            device_rank=rank,
+            world_size=world_size,
+            process_group=pg,
+            newton_schulz_func=_ns_func,
+            flatten=False,
+            epsilon=torch.tensor(1e-7, device=device),
+        )
+        state["result"] = result
+
+    runtime = AsyncRuntime((t for t in [AsyncTask(_task_gen())]), max_concurrent_tasks=1)
+    runtime.run()
+
+    assert len(state["result"]) == n_params
+    for t in state["result"]:
+        assert t.shape == local_shape, (
+            f"rank {rank}: expected {local_shape}, got {tuple(t.shape)}"
+        )
+
+    dist.destroy_process_group()
+
+
+@pytest.mark.skipif(CUDA_DEVICE_COUNT < 4, reason="needs >= 4 CUDA devices for NCCL alltoall")
+@pytest.mark.parametrize(
+    "global_dim_0, world_size, n_params",
+    [
+        # 5 rows over 4 ranks: ceil(5/4)=2 chunks of size 2 fill ranks 0..2, rank 3 empty.
+        # Mirrors the sparse-3b (18, D) over 8 ranks pattern at smaller scale.
+        (5, 4, 8),
+        # Smaller-than-world-size: 2 rows, 4 ranks: ranks 2 and 3 empty.
+        (2, 4, 8),
+        # Non-divisible, no empty ranks (sanity: still works after fix).
+        (15, 4, 8),
+    ],
+)
+def test_megabatch_orthogonalize_async_handles_empty_shards(global_dim_0, world_size, n_params):
+    # Unique port per parametrization to avoid bind collisions.
+    port = 29500 + global_dim_0 * 100 + world_size
+    mp.spawn(
+        _worker,
+        args=(world_size, global_dim_0, 16, n_params, port),
+        nprocs=world_size,
+        join=True,
+    )


### PR DESCRIPTION
## Summary

`megabatch_orthogonalize_async` hangs at NCCL `dist.all_to_all` whenever a managed 2D weight's sharded global dim is smaller than `world_size` or doesn't divide evenly to fill all ranks under FSDP2's contiguous chunking. Some ranks receive empty `(0, …)` padding-only shards; the per-rank `input_chunks` then have inconsistent sizes on the wire and the alltoall deadlocks after the first backward.

## Concrete repro (the case that surfaced this)

- 2D weight of shape `(num_attention_heads=18, hidden=2304)` (a sparse-3B model's per-head attention gate).
- FSDP2 `fully_shard` over `dp_shard_size=8`.
- NorMuon (or Dion2) — both hit the same path.

`_chunk_with_empty(t, 8, dim=0)` returns 6 real `(3, 2304)` chunks plus 2 empty `(0, 2304)` chunks. After init: ranks 0–5 hold `(3, 2304)` shards; ranks 6–7 hold `(0, 2304)`. Inside `megabatch_orthogonalize_async`:

\`\`\`python
input_chunks = [torch.stack(U_work[r * per_rank : (r + 1) * per_rank]) for r in range(world_size)]
dist.all_to_all(output_chunks, input_chunks, group=process_group)
\`\`\`

Each rank constructs `input_chunks` from its own local data, so per-target chunk shapes diverge across ranks (`(per_rank, 3, 2304)` vs `(per_rank, 0, 2304)`). `dist.all_to_all` requires per-pair sizes to match — they don't.

NCCL watchdog signature for 32 same-shape params packed under `per_rank=4`:

\`\`\`
Ranks 0–5: WorkNCCL(SeqNum=N,   ALLTOALL, NumelIn=8×4×3×2304   = 221184)
Ranks 6–7: WorkNCCL(SeqNum=N+1, ALLTOALL, NumelIn=8×7×96×2304  = 12386304)
\`\`\`

The 6/2 watchdog split exactly matches `torch.chunk(18, 8, dim=0)`. Padding-only ranks' zero-sized alltoall completes locally so they advance to the next pending collective and hang there.

Independent of optimizer (NorMuon and Dion2 both hit it) and of any upstream-loss specifics; it's a structural property of the megabatch sharded path.

## Fix

Pad each rank's local shard along `comm_dim` to a rank-consistent `padded_local_size = max(local_sizes)` before the alltoall (one extra `dist.all_reduce` MAX), then `narrow` the post-alltoall result back to the rank's original local size. Newton-Schulz preserves zero rows (they contribute nothing to UᵀU), so padding doesn't change the orthogonalization of the real rows. Mirrors what FSDP2 itself does for its own all-gather/reduce-scatter (`padded_sharded_param_size` in `torch/distributed/fsdp/_fully_shard/_fsdp_param.py`).

## Test plan

- New test `tests/test_megabatch_empty_shard.py` spawns 4 NCCL ranks via `torch.multiprocessing.spawn` and exercises three configurations:
  - `(global_dim=5, world_size=4)` — rank 3 holds `(0, …)`; analogous to the `(18, 8)` production case at smaller scale.
  - `(global_dim=2, world_size=4)` — ranks 2 and 3 both hold `(0, …)`.
  - `(global_dim=15, world_size=4)` — non-divisible but no empty ranks (sanity check that the padding logic stays a no-op when uniform).
- Verified the test hangs (and the timeout fires) on `main` without the fix and passes with it. All 3 cases pass with the fix; full existing suite (97 tests) continues to pass.
- End-to-end confirmation on a real cluster: a phitrain sparse-3B run that previously hung on the first optimizer step now trains 39 steps cleanly with loss decreasing smoothly (6.95 → 6.45).