### PR TITLE
megabatch: precompute padded_local_size, drop per-step allreduce sync

### DIFF
--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -229,13 +229,10 @@ def dion2_update_megabatch_async(
     # comm_dim for sharded communication: use select_dim (which equals normalized shard_dim)
     comm_dim = select_dim if is_sharded else None
 
-    # Locally compute the rank-consistent padded local size from the unsharded
-    # global shape (X[0] is still a DTensor here). Avoids the per-step
-    # allreduce + .item() sync inside megabatch_orthogonalize_async.
-    if comm_dim is not None:
-        padded_local_size = -(-X[0].shape[comm_dim] // world_size)
-    else:
-        padded_local_size = None
+    # X[0] is still a DTensor here, so .shape[comm_dim] is the global
+    # (unsharded) size. The megabatch fn uses this to compute the rank-
+    # consistent pad size for its alltoall.
+    global_comm_dim_size = X[0].shape[comm_dim] if comm_dim is not None else None
 
     # Orthogonalize via shared megabatch communication
     U_ortho = yield from megabatch_orthogonalize_async(
@@ -247,7 +244,7 @@ def dion2_update_megabatch_async(
         newton_schulz_func=newton_schulz_func,
         flatten=flatten,
         epsilon=epsilon,
-        padded_local_size=padded_local_size,
+        global_comm_dim_size=global_comm_dim_size,
     )
 
     # Compute scaled learning rate

--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -229,6 +229,14 @@ def dion2_update_megabatch_async(
     # comm_dim for sharded communication: use select_dim (which equals normalized shard_dim)
     comm_dim = select_dim if is_sharded else None
 
+    # Locally compute the rank-consistent padded local size from the unsharded
+    # global shape (X[0] is still a DTensor here). Avoids the per-step
+    # allreduce + .item() sync inside megabatch_orthogonalize_async.
+    if comm_dim is not None:
+        padded_local_size = -(-X[0].shape[comm_dim] // world_size)
+    else:
+        padded_local_size = None
+
     # Orthogonalize via shared megabatch communication
     U_ortho = yield from megabatch_orthogonalize_async(
         U_selected,
@@ -239,6 +247,7 @@ def dion2_update_megabatch_async(
         newton_schulz_func=newton_schulz_func,
         flatten=flatten,
         epsilon=epsilon,
+        padded_local_size=padded_local_size,
     )
 
     # Compute scaled learning rate

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -358,6 +358,7 @@ def megabatch_orthogonalize_async(
     newton_schulz_func: Callable,
     flatten: bool,
     epsilon: Tensor,
+    padded_local_size: Optional[int] = None,
 ) -> Generator[None, None, List[Tensor]]:
     """
     Shared megabatch communication + Newton-Schulz orthogonalization.
@@ -378,6 +379,10 @@ def megabatch_orthogonalize_async(
         newton_schulz_func: Newton-Schulz orthogonalization function.
         flatten: Whether to flatten 3D+ tensors to 2D.
         epsilon: Small value for numerical stability.
+        padded_local_size: Required when ``comm_dim is not None``. The
+            rank-consistent padded local size along ``comm_dim``, computed by
+            the caller as ``ceil(global_dim / world_size)`` from the unsharded
+            DTensor's global shape. Avoids a per-step allreduce + GPU->CPU sync.
     """
     N = len(U)
 
@@ -393,21 +398,22 @@ def megabatch_orthogonalize_async(
     if comm_dim is not None and process_group is not None:
         # --- Mega-batched sharded FSDP2 path ---
 
-        # Pad each rank's local shard along comm_dim to a rank-consistent
-        # ``padded_local_size`` so dist.all_to_all sees uniform per-pair
-        # sizes. FSDP2 contiguous chunking otherwise leaves some ranks with
-        # empty (numel=0) shards when the sharded global dim is smaller than
-        # world_size or doesn't divide evenly to fill all ranks (e.g. shape
-        # (18, D) over world_size=8: ranks 6 and 7 hold (0, D) shards). Without
-        # padding the alltoall has mismatched per-pair sizes and hangs.
-        # Newton-Schulz preserves zero rows (they contribute nothing to U^T U),
-        # so padding doesn't change the orthogonalization of the real rows.
-        original_local_size = U_work[0].size(comm_dim)
-        local_size_t = torch.tensor(
-            [original_local_size], device=U_work[0].device, dtype=torch.long
+        # Pad each rank's local shard along comm_dim to ``padded_local_size``
+        # (passed by the caller, equal to ceil(global_dim / world_size)) so
+        # dist.all_to_all sees uniform per-pair sizes. FSDP2 contiguous chunking
+        # otherwise leaves some ranks with empty (numel=0) shards when the
+        # sharded global dim is smaller than world_size or doesn't divide
+        # evenly to fill all ranks (e.g. shape (18, D) over world_size=8: ranks
+        # 6 and 7 hold (0, D) shards). Without padding the alltoall has
+        # mismatched per-pair sizes and hangs. Newton-Schulz preserves zero
+        # rows (they contribute nothing to U^T U), so padding doesn't change
+        # the orthogonalization of the real rows.
+        assert padded_local_size is not None, (
+            "padded_local_size must be passed when comm_dim is not None; "
+            "callers should compute ceil(global_dim / world_size) from the "
+            "unsharded DTensor shape."
         )
-        dist.all_reduce(local_size_t, op=dist.ReduceOp.MAX, group=process_group)
-        padded_local_size = int(local_size_t.item())
+        original_local_size = U_work[0].size(comm_dim)
 
         if padded_local_size != original_local_size:
             # F.pad's pad-spec is built from the LAST dim backwards. comm_dim

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -358,7 +358,7 @@ def megabatch_orthogonalize_async(
     newton_schulz_func: Callable,
     flatten: bool,
     epsilon: Tensor,
-    padded_local_size: Optional[int] = None,
+    global_comm_dim_size: Optional[int] = None,
 ) -> Generator[None, None, List[Tensor]]:
     """
     Shared megabatch communication + Newton-Schulz orthogonalization.
@@ -379,10 +379,11 @@ def megabatch_orthogonalize_async(
         newton_schulz_func: Newton-Schulz orthogonalization function.
         flatten: Whether to flatten 3D+ tensors to 2D.
         epsilon: Small value for numerical stability.
-        padded_local_size: Required when ``comm_dim is not None``. The
-            rank-consistent padded local size along ``comm_dim``, computed by
-            the caller as ``ceil(global_dim / world_size)`` from the unsharded
-            DTensor's global shape. Avoids a per-step allreduce + GPU->CPU sync.
+        global_comm_dim_size: Required when ``comm_dim is not None``. The
+            unsharded (global) size along ``comm_dim``, taken from the
+            DTensor's global shape (``param.shape[comm_dim]``). Used to
+            compute ``padded_local_size = ceil(global / world_size)`` so the
+            alltoall sees uniform per-pair sizes across ranks.
     """
     N = len(U)
 
@@ -398,22 +399,32 @@ def megabatch_orthogonalize_async(
     if comm_dim is not None and process_group is not None:
         # --- Mega-batched sharded FSDP2 path ---
 
-        # Pad each rank's local shard along comm_dim to ``padded_local_size``
-        # (passed by the caller, equal to ceil(global_dim / world_size)) so
-        # dist.all_to_all sees uniform per-pair sizes. FSDP2 contiguous chunking
-        # otherwise leaves some ranks with empty (numel=0) shards when the
-        # sharded global dim is smaller than world_size or doesn't divide
-        # evenly to fill all ranks (e.g. shape (18, D) over world_size=8: ranks
-        # 6 and 7 hold (0, D) shards). Without padding the alltoall has
-        # mismatched per-pair sizes and hangs. Newton-Schulz preserves zero
-        # rows (they contribute nothing to U^T U), so padding doesn't change
-        # the orthogonalization of the real rows.
-        assert padded_local_size is not None, (
-            "padded_local_size must be passed when comm_dim is not None; "
-            "callers should compute ceil(global_dim / world_size) from the "
-            "unsharded DTensor shape."
+        # Pad each rank's local shard along comm_dim to a rank-consistent
+        # ``padded_local_size = ceil(global / world_size)`` so dist.all_to_all
+        # sees uniform per-pair sizes. FSDP2 contiguous chunking otherwise
+        # leaves some ranks with empty (numel=0) shards when the sharded
+        # global dim is smaller than world_size or doesn't divide evenly to
+        # fill all ranks (e.g. shape (18, D) over world_size=8: ranks 6 and 7
+        # hold (0, D) shards). Without padding the alltoall has mismatched
+        # per-pair sizes and hangs. Newton-Schulz preserves zero rows (they
+        # contribute nothing to U^T U), so padding doesn't change the
+        # orthogonalization of the real rows.
+        #
+        # NOTE: this assumes FSDP2-style contiguous chunking, where every rank
+        # holds at most ceil(global / world_size) elements along comm_dim. If
+        # FSDP2 ever switches to a non-contiguous strategy (e.g. block-cyclic),
+        # this derivation would be wrong; the assert below catches that case.
+        assert global_comm_dim_size is not None, (
+            "global_comm_dim_size must be passed when comm_dim is not None; "
+            "callers should pass the unsharded DTensor's global size along "
+            "comm_dim."
         )
+        padded_local_size = -(-global_comm_dim_size // world_size)
         original_local_size = U_work[0].size(comm_dim)
+        assert padded_local_size >= original_local_size, (
+            f"padded_local_size ({padded_local_size}) < this rank's local "
+            f"size ({original_local_size}); FSDP2 sharding assumption violated."
+        )
 
         if padded_local_size != original_local_size:
             # F.pad's pad-spec is built from the LAST dim backwards. comm_dim

--- a/dion/muon.py
+++ b/dion/muon.py
@@ -202,13 +202,10 @@ def muon_update_megabatch_async(
     # Convert shard_dim to negative for comm_dim
     comm_dim = (shard_dim - X[0].ndim) if shard_dim is not None else None
 
-    # Locally compute the rank-consistent padded local size from the unsharded
-    # global shape (X[0] is still a DTensor here). Avoids the per-step
-    # allreduce + .item() sync inside megabatch_orthogonalize_async.
-    if comm_dim is not None:
-        padded_local_size = -(-X[0].shape[comm_dim] // world_size)
-    else:
-        padded_local_size = None
+    # X[0] is still a DTensor here, so .shape[comm_dim] is the global
+    # (unsharded) size. The megabatch fn uses this to compute the rank-
+    # consistent pad size for its alltoall.
+    global_comm_dim_size = X[0].shape[comm_dim] if comm_dim is not None else None
 
     # Orthogonalize via shared megabatch communication
     U = yield from megabatch_orthogonalize_async(
@@ -220,7 +217,7 @@ def muon_update_megabatch_async(
         newton_schulz_func=newton_schulz_func,
         flatten=flatten,
         epsilon=epsilon,
-        padded_local_size=padded_local_size,
+        global_comm_dim_size=global_comm_dim_size,
     )
 
     # Compute scaled learning rate

--- a/dion/muon.py
+++ b/dion/muon.py
@@ -202,6 +202,14 @@ def muon_update_megabatch_async(
     # Convert shard_dim to negative for comm_dim
     comm_dim = (shard_dim - X[0].ndim) if shard_dim is not None else None
 
+    # Locally compute the rank-consistent padded local size from the unsharded
+    # global shape (X[0] is still a DTensor here). Avoids the per-step
+    # allreduce + .item() sync inside megabatch_orthogonalize_async.
+    if comm_dim is not None:
+        padded_local_size = -(-X[0].shape[comm_dim] // world_size)
+    else:
+        padded_local_size = None
+
     # Orthogonalize via shared megabatch communication
     U = yield from megabatch_orthogonalize_async(
         U,
@@ -212,6 +220,7 @@ def muon_update_megabatch_async(
         newton_schulz_func=newton_schulz_func,
         flatten=flatten,
         epsilon=epsilon,
+        padded_local_size=padded_local_size,
     )
 
     # Compute scaled learning rate

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -231,6 +231,14 @@ def normuon_update_megabatch_async(
     # Convert shard_dim to negative for comm_dim
     comm_dim = (shard_dim - X[0].ndim) if shard_dim is not None else None
 
+    # Locally compute the rank-consistent padded local size from the unsharded
+    # global shape (X[0] is still a DTensor here). Avoids the per-step
+    # allreduce + .item() sync inside megabatch_orthogonalize_async.
+    if comm_dim is not None:
+        padded_local_size = -(-X[0].shape[comm_dim] // world_size)
+    else:
+        padded_local_size = None
+
     # Orthogonalize via shared megabatch communication
     U = yield from megabatch_orthogonalize_async(
         U,
@@ -241,6 +249,7 @@ def normuon_update_megabatch_async(
         newton_schulz_func=newton_schulz_func,
         flatten=flatten,
         epsilon=epsilon,
+        padded_local_size=padded_local_size,
     )
 
     # NorMuon normalization using stacked tensors for fewer kernel launches

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -231,13 +231,10 @@ def normuon_update_megabatch_async(
     # Convert shard_dim to negative for comm_dim
     comm_dim = (shard_dim - X[0].ndim) if shard_dim is not None else None
 
-    # Locally compute the rank-consistent padded local size from the unsharded
-    # global shape (X[0] is still a DTensor here). Avoids the per-step
-    # allreduce + .item() sync inside megabatch_orthogonalize_async.
-    if comm_dim is not None:
-        padded_local_size = -(-X[0].shape[comm_dim] // world_size)
-    else:
-        padded_local_size = None
+    # X[0] is still a DTensor here, so .shape[comm_dim] is the global
+    # (unsharded) size. The megabatch fn uses this to compute the rank-
+    # consistent pad size for its alltoall.
+    global_comm_dim_size = X[0].shape[comm_dim] if comm_dim is not None else None
 
     # Orthogonalize via shared megabatch communication
     U = yield from megabatch_orthogonalize_async(
@@ -249,7 +246,7 @@ def normuon_update_megabatch_async(
         newton_schulz_func=newton_schulz_func,
         flatten=flatten,
         epsilon=epsilon,
-        padded_local_size=padded_local_size,
+        global_comm_dim_size=global_comm_dim_size,
     )
 
     # NorMuon normalization using stacked tensors for fewer kernel launches

--- a/tests/test_megabatch_empty_shard.py
+++ b/tests/test_megabatch_empty_shard.py
@@ -56,6 +56,7 @@ def _worker(rank: int, world_size: int, global_dim_0: int, dim_1: int, n_params:
             U.append(torch.randn(local_shape, dtype=torch.float32, device=device, generator=g))
 
     state = {}
+    padded_local_size = -(-global_dim_0 // world_size)
 
     def _task_gen():
         result = yield from megabatch_orthogonalize_async(
@@ -67,6 +68,7 @@ def _worker(rank: int, world_size: int, global_dim_0: int, dim_1: int, n_params:
             newton_schulz_func=_ns_func,
             flatten=False,
             epsilon=torch.tensor(1e-7, device=device),
+            padded_local_size=padded_local_size,
         )
         state["result"] = result
 
@@ -82,10 +84,14 @@ def _worker(rank: int, world_size: int, global_dim_0: int, dim_1: int, n_params:
     dist.destroy_process_group()
 
 
-@pytest.mark.skipif(CUDA_DEVICE_COUNT < 4, reason="needs >= 4 CUDA devices for NCCL alltoall")
 @pytest.mark.parametrize(
     "global_dim_0, world_size, n_params",
     [
+        # world_size=2 cases (run on 2-GPU dev boxes too):
+        # 1 row over 2 ranks: rank 0 has (1, D), rank 1 has (0, D) — empty shard.
+        (1, 2, 8),
+        # 3 rows over 2 ranks: (2, D) + (1, D) — non-divisible, no empty.
+        (3, 2, 8),
         # 5 rows over 4 ranks: ceil(5/4)=2 chunks of size 2 fill ranks 0..2, rank 3 empty.
         # Mirrors the sparse-3b (18, D) over 8 ranks pattern at smaller scale.
         (5, 4, 8),
@@ -96,6 +102,8 @@ def _worker(rank: int, world_size: int, global_dim_0: int, dim_1: int, n_params:
     ],
 )
 def test_megabatch_orthogonalize_async_handles_empty_shards(global_dim_0, world_size, n_params):
+    if CUDA_DEVICE_COUNT < world_size:
+        pytest.skip(f"needs >= {world_size} CUDA devices for NCCL alltoall")
     # Unique port per parametrization to avoid bind collisions.
     port = 29500 + global_dim_0 * 100 + world_size
     mp.spawn(

--- a/tests/test_megabatch_empty_shard.py
+++ b/tests/test_megabatch_empty_shard.py
@@ -56,7 +56,6 @@ def _worker(rank: int, world_size: int, global_dim_0: int, dim_1: int, n_params:
             U.append(torch.randn(local_shape, dtype=torch.float32, device=device, generator=g))
 
     state = {}
-    padded_local_size = -(-global_dim_0 // world_size)
 
     def _task_gen():
         result = yield from megabatch_orthogonalize_async(
@@ -68,7 +67,7 @@ def _worker(rank: int, world_size: int, global_dim_0: int, dim_1: int, n_params:
             newton_schulz_func=_ns_func,
             flatten=False,
             epsilon=torch.tensor(1e-7, device=device),
-            padded_local_size=padded_local_size,
+            global_comm_dim_size=global_dim_0,
         )
         state["result"] = result
 


### PR DESCRIPTION
The upstream empty-FSDP2-shard fix (#74) introduced an allreduce-MAX + .item() inside megabatch_orthogonalize_async to discover the rank- consistent padded local size, adding a CPU/GPU sync point on every sharded ortho task.

Compute the value locally instead: ceil(global_dim / world_size) from the still-DTensor X[0].shape in each *_update_megabatch_async caller, threaded through as a required arg when comm_dim is not None. Same correctness under FSDP2 contiguous chunking, no per-step collective.

Test: extend test_megabatch_empty_shard.py with world_size=2 cases ((1, D) empty-shard and (3, D) non-divisible) so the fast path is exercised on 2-GPU dev hosts; 4-GPU cases skip dynamically.

Before: 

<img width="1007" height="710" alt="Screenshot 2026-05-05 at 16 22 25" src="https://github.com/user-attachments/assets/6c2017f1-84d1-4933-b8dc-1b6898c7e081" />

After: 

<img width="1008" height="760" alt="Screenshot 2026-05-05 at 16 22 44" src="https://github.com/user-attachments/assets/8504ad5f-c9ef-493b-913e-3d09e246fb3a" />
