### PR TITLE
megabatch: harden global_comm_dim_size contract

### DIFF
--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -229,10 +229,20 @@ def dion2_update_megabatch_async(
     # comm_dim for sharded communication: use select_dim (which equals normalized shard_dim)
     comm_dim = select_dim if is_sharded else None
 
-    # X[0] is still a DTensor here, so .shape[comm_dim] is the global
-    # (unsharded) size. The megabatch fn uses this to compute the rank-
-    # consistent pad size for its alltoall.
-    global_comm_dim_size = X[0].shape[comm_dim] if comm_dim is not None else None
+    # On the sharded path X[0] must still be a DTensor, so .shape[comm_dim]
+    # is the unsharded global size. The megabatch fn uses this to compute
+    # the rank-consistent pad size for its alltoall. Catch the case where a
+    # future refactor moves to_local(X) above this point and silently
+    # collapses .shape to the local size.
+    if comm_dim is not None:
+        if not isinstance(X[0], DTensor):
+            raise TypeError(
+                "Sharded path requires X[0] to be a DTensor so .shape gives "
+                f"the global size; got {type(X[0]).__name__}."
+            )
+        global_comm_dim_size = X[0].shape[comm_dim]
+    else:
+        global_comm_dim_size = None
 
     # Orthogonalize via shared megabatch communication
     U_ortho = yield from megabatch_orthogonalize_async(

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -358,7 +358,7 @@ def megabatch_orthogonalize_async(
     newton_schulz_func: Callable,
     flatten: bool,
     epsilon: Tensor,
-    global_comm_dim_size: Optional[int] = None,
+    global_comm_dim_size: Optional[int],
 ) -> Generator[None, None, List[Tensor]]:
     """
     Shared megabatch communication + Newton-Schulz orthogonalization.
@@ -379,10 +379,11 @@ def megabatch_orthogonalize_async(
         newton_schulz_func: Newton-Schulz orthogonalization function.
         flatten: Whether to flatten 3D+ tensors to 2D.
         epsilon: Small value for numerical stability.
-        global_comm_dim_size: Required when ``comm_dim is not None``. The
-            unsharded (global) size along ``comm_dim``, taken from the
-            DTensor's global shape (``param.shape[comm_dim]``). Used to
-            compute ``padded_local_size = ceil(global / world_size)`` so the
+        global_comm_dim_size: Required (non-None) when ``comm_dim is not
+            None``; pass ``None`` otherwise. The unsharded (global) size
+            along ``comm_dim``, taken from the DTensor's global shape
+            (``param.shape[comm_dim]``). Used to compute
+            ``padded_local_size = ceil(global / world_size)`` so the
             alltoall sees uniform per-pair sizes across ranks.
     """
     N = len(U)
@@ -413,18 +414,22 @@ def megabatch_orthogonalize_async(
         # NOTE: this assumes FSDP2-style contiguous chunking, where every rank
         # holds at most ceil(global / world_size) elements along comm_dim. If
         # FSDP2 ever switches to a non-contiguous strategy (e.g. block-cyclic),
-        # this derivation would be wrong; the assert below catches that case.
-        assert global_comm_dim_size is not None, (
-            "global_comm_dim_size must be passed when comm_dim is not None; "
-            "callers should pass the unsharded DTensor's global size along "
-            "comm_dim."
-        )
-        padded_local_size = -(-global_comm_dim_size // world_size)
+        # this derivation would be wrong; the size check below catches that.
+        if global_comm_dim_size is None:
+            raise ValueError(
+                "global_comm_dim_size must be passed when comm_dim is not "
+                "None; callers should pass the unsharded DTensor's global "
+                "size along comm_dim."
+            )
+        padded_local_size = (global_comm_dim_size + world_size - 1) // world_size
         original_local_size = U_work[0].size(comm_dim)
-        assert padded_local_size >= original_local_size, (
-            f"padded_local_size ({padded_local_size}) < this rank's local "
-            f"size ({original_local_size}); FSDP2 sharding assumption violated."
-        )
+        if padded_local_size < original_local_size:
+            raise RuntimeError(
+                f"padded_local_size ({padded_local_size}) < this rank's "
+                f"local size ({original_local_size}); FSDP2 contiguous-"
+                f"chunking assumption violated (global_comm_dim_size="
+                f"{global_comm_dim_size}, world_size={world_size})."
+            )
 
         if padded_local_size != original_local_size:
             # F.pad's pad-spec is built from the LAST dim backwards. comm_dim

--- a/dion/muon.py
+++ b/dion/muon.py
@@ -202,10 +202,20 @@ def muon_update_megabatch_async(
     # Convert shard_dim to negative for comm_dim
     comm_dim = (shard_dim - X[0].ndim) if shard_dim is not None else None
 
-    # X[0] is still a DTensor here, so .shape[comm_dim] is the global
-    # (unsharded) size. The megabatch fn uses this to compute the rank-
-    # consistent pad size for its alltoall.
-    global_comm_dim_size = X[0].shape[comm_dim] if comm_dim is not None else None
+    # On the sharded path X[0] must still be a DTensor, so .shape[comm_dim]
+    # is the unsharded global size. The megabatch fn uses this to compute
+    # the rank-consistent pad size for its alltoall. Catch the case where a
+    # future refactor moves to_local(X) above this point and silently
+    # collapses .shape to the local size.
+    if comm_dim is not None:
+        if not isinstance(X[0], DTensor):
+            raise TypeError(
+                "Sharded path requires X[0] to be a DTensor so .shape gives "
+                f"the global size; got {type(X[0]).__name__}."
+            )
+        global_comm_dim_size = X[0].shape[comm_dim]
+    else:
+        global_comm_dim_size = None
 
     # Orthogonalize via shared megabatch communication
     U = yield from megabatch_orthogonalize_async(

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -231,10 +231,20 @@ def normuon_update_megabatch_async(
     # Convert shard_dim to negative for comm_dim
     comm_dim = (shard_dim - X[0].ndim) if shard_dim is not None else None
 
-    # X[0] is still a DTensor here, so .shape[comm_dim] is the global
-    # (unsharded) size. The megabatch fn uses this to compute the rank-
-    # consistent pad size for its alltoall.
-    global_comm_dim_size = X[0].shape[comm_dim] if comm_dim is not None else None
+    # On the sharded path X[0] must still be a DTensor, so .shape[comm_dim]
+    # is the unsharded global size. The megabatch fn uses this to compute
+    # the rank-consistent pad size for its alltoall. Catch the case where a
+    # future refactor moves to_local(X) above this point and silently
+    # collapses .shape to the local size.
+    if comm_dim is not None:
+        if not isinstance(X[0], DTensor):
+            raise TypeError(
+                "Sharded path requires X[0] to be a DTensor so .shape gives "
+                f"the global size; got {type(X[0]).__name__}."
+            )
+        global_comm_dim_size = X[0].shape[comm_dim]
+    else:
+        global_comm_dim_size = None
 
     # Orthogonalize via shared megabatch communication
     U = yield from megabatch_orthogonalize_async(

--- a/tests/test_megabatch_empty_shard.py
+++ b/tests/test_megabatch_empty_shard.py
@@ -111,3 +111,33 @@ def test_megabatch_orthogonalize_async_handles_empty_shards(global_dim_0, world_
         nprocs=world_size,
         join=True,
     )
+
+
+def test_megabatch_orthogonalize_async_requires_global_comm_dim_size():
+    # Pins the explicit-exception contract: the sharded branch must raise
+    # ValueError when global_comm_dim_size is omitted, not assert (which
+    # vanishes under ``python -O``). Uses a single-rank gloo PG so this
+    # runs CPU-only and stays out of the GPU test budget.
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29401")
+    already_init = dist.is_initialized()
+    if not already_init:
+        dist.init_process_group(backend="gloo", rank=0, world_size=1)
+    try:
+        U = [torch.zeros(2, 4) for _ in range(4)]
+        gen = megabatch_orthogonalize_async(
+            U,
+            comm_dim=-2,
+            device_rank=0,
+            world_size=1,
+            process_group=dist.group.WORLD,
+            newton_schulz_func=_ns_func,
+            flatten=False,
+            epsilon=torch.tensor(1e-7),
+            global_comm_dim_size=None,
+        )
+        with pytest.raises(ValueError, match="global_comm_dim_size"):
+            next(gen)
+    finally:
+        if not already_init and dist.is_initialized():
+            dist.destroy_process_group()


### PR DESCRIPTION
Follow-up to #75 addressing three review nits without changing the perf win or the API contract.

## Changes

1. **`assert` → explicit `raise`** in `megabatch_orthogonalize_async`. Both the missing-arg check and the FSDP2 sharding-invariant check vanish under `python -O`; without them, a missing arg degenerates into a confusing `TypeError` deep inside the ceil-div, and a violated invariant silently produces the wrong pad size. Now `ValueError` / `RuntimeError` so the contract holds regardless of optimization level.

2. **Drop the `= None` default** on `global_comm_dim_size`. The signature said optional but the function requires it on the sharded path; all three production callers (`dion2`, `muon`, `normuon`) already pass it. Forcing explicit pass-through prevents silent regressions if a new caller forgets the arg.

3. **`isinstance(X[0], DTensor)` checks** at the three caller extraction sites. The comment *"X[0] is still a DTensor here"* is a load-bearing precondition — `.shape` returns the global size only for DTensor. A future refactor that moves `to_local(X)` above the extraction would silently produce a local-size-based pad target. The `RuntimeError` in `megabatch_base` would eventually catch it, but from a confusing site; the new `TypeError` at the caller fails fast with a clear message.

Also: switch the ceil-div from `-(-x // y)` to `(x + y - 1) // y` for readability, and update the NOTE comment that referenced the removed assert.

## Tests

Adds a CPU-only single-rank gloo test that drives the sharded branch with `global_comm_dim_size=None` and pins the new `ValueError`. Catches `python -O` / future-refactor regressions at the unit level without burning a GPU slot.

Existing test_megabatch_empty_shard tests remain unchanged.