### PR TITLE
megabatch: env-gated NaN capture wrapper around newton_schulz_func

### DIFF
--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -1,4 +1,6 @@
 import math
+import os
+import time
 import torch
 import torch.distributed as dist
 from collections import defaultdict
@@ -349,6 +351,74 @@ class DistributedOrthoBase(Optimizer):
             )
 
 
+def _maybe_wrap_nan_capture(
+    newton_schulz_func: Callable, device_rank: int
+) -> Callable:
+    """Optionally wrap ``newton_schulz_func`` to dump non-finite outputs to disk.
+
+    Enabled by env var ``DION_NAN_CAPTURE in {"1","true"}``. Each rank that
+    sees a non-finite Newton-Schulz output writes its own
+    ``dion_nan_capture_rank{rank}_shape{...}_pid{...}_{ts_ms}.pt`` to
+    ``DION_NAN_CAPTURE_DIR`` (default ``./dion_nan_captures``), then raises
+    ``RuntimeError`` unless ``DION_NAN_CAPTURE_RAISE in {"0","false"}``.
+
+    The check is local to each rank: there is no extra collective. When the
+    guard is disabled, cost is one ``os.environ`` lookup per megabatch ortho
+    call.
+
+    Intended as a debug capture for issues like microsoft/dion#76, where a
+    Newton-Schulz backend (gram-newton-schulz / quack-kernels) intermittently
+    produces NaNs only on certain hardware/shapes. Capturing the actual input
+    that triggered the failure is the prerequisite for offline reproduction.
+    """
+    if os.environ.get("DION_NAN_CAPTURE", "").lower() not in ("1", "true"):
+        return newton_schulz_func
+
+    dump_dir = os.environ.get("DION_NAN_CAPTURE_DIR", "./dion_nan_captures")
+    raise_on_detect = os.environ.get(
+        "DION_NAN_CAPTURE_RAISE", "1"
+    ).lower() not in ("0", "false")
+    os.makedirs(dump_dir, exist_ok=True)
+
+    def _guarded(X: Tensor, epsilon: Optional[Tensor] = None) -> Tensor:
+        # Snapshot the input before NS runs so we have the offending tensor
+        # even if the kernel mutates X in-place or only the output goes NaN.
+        X_snapshot = X.detach().clone()
+        Y = newton_schulz_func(X, epsilon=epsilon)
+        if not torch.isfinite(Y).all():
+            shape = "x".join(str(s) for s in X_snapshot.shape)
+            ts_ms = int(time.time() * 1000)
+            path = os.path.join(
+                dump_dir,
+                f"dion_nan_capture_rank{device_rank}_shape{shape}"
+                f"_pid{os.getpid()}_{ts_ms}.pt",
+            )
+            payload = {
+                "input": X_snapshot.cpu(),
+                "output": Y.detach().cpu(),
+                "rank": device_rank,
+                "shape": tuple(X_snapshot.shape),
+                "dtype": str(X_snapshot.dtype),
+                "epsilon": (
+                    float(epsilon.item())
+                    if isinstance(epsilon, Tensor)
+                    else (float(epsilon) if epsilon is not None else None)
+                ),
+            }
+            torch.save(payload, path)
+            msg = (
+                f"[dion NaN capture] non-finite Newton-Schulz output on rank "
+                f"{device_rank}, shape {tuple(X_snapshot.shape)}; dumped to "
+                f"{path}"
+            )
+            if raise_on_detect:
+                raise RuntimeError(msg)
+            print(msg, flush=True)
+        return Y
+
+    return _guarded
+
+
 def megabatch_orthogonalize_async(
     U: List[Tensor],
     comm_dim: Optional[int],
@@ -386,6 +456,10 @@ def megabatch_orthogonalize_async(
             ``padded_local_size = ceil(global / world_size)`` so the
             alltoall sees uniform per-pair sizes across ranks.
     """
+    # Optionally swap newton_schulz_func with a wrapper that dumps non-finite
+    # outputs to disk (env-gated; no-op by default, no extra collectives).
+    newton_schulz_func = _maybe_wrap_nan_capture(newton_schulz_func, device_rank)
+
     N = len(U)
 
     # Pad to divisible by world_size (needed by both distributed paths)

--- a/tests/test_nan_capture.py
+++ b/tests/test_nan_capture.py
@@ -1,0 +1,166 @@
+"""Unit tests for the env-gated NaN capture wrapper in
+``megabatch_orthogonalize_async``.
+
+The wrapper exists so a user hitting a numerical blow-up in their Newton-
+Schulz backend (e.g. microsoft/dion#76, where quack-kernels 0.4.1 produces
+NaN params on certain hardware/shapes) can dump the offending input and
+output to disk for offline reproduction. The check is local per rank, so
+the tests below run single-rank without NCCL.
+"""
+
+import os
+import pytest
+import torch
+
+from dion.megabatch_base import megabatch_orthogonalize_async
+
+
+def _nan_ns(X, epsilon=None):
+    return torch.full_like(X, float("nan"))
+
+
+def _identity_ns(X, epsilon=None):
+    return X.clone()
+
+
+def _drive(gen):
+    # ``megabatch_orthogonalize_async`` is a generator; the sharded path yields
+    # at alltoall, but the ``N>1, no process_group`` path runs straight through
+    # via ``return value``. Iterating to completion exercises whichever path
+    # the args select; the StopIteration carries the result.
+    try:
+        while True:
+            next(gen)
+    except StopIteration as stop:
+        return stop.value
+
+
+def test_capture_disabled_by_default(tmp_path, monkeypatch):
+    monkeypatch.delenv("DION_NAN_CAPTURE", raising=False)
+    monkeypatch.setenv("DION_NAN_CAPTURE_DIR", str(tmp_path))
+
+    U = [torch.randn(3, 4) for _ in range(2)]
+    _drive(
+        megabatch_orthogonalize_async(
+            U,
+            comm_dim=None,
+            device_rank=0,
+            world_size=1,
+            process_group=None,
+            newton_schulz_func=_nan_ns,
+            flatten=False,
+            epsilon=torch.tensor(1e-7),
+            global_comm_dim_size=None,
+        )
+    )
+
+    # No env var set -> no dumps even though the NS func returned NaN.
+    assert list(tmp_path.glob("dion_nan_capture_*.pt")) == []
+
+
+def test_capture_dumps_on_non_finite_output(tmp_path, monkeypatch):
+    monkeypatch.setenv("DION_NAN_CAPTURE", "1")
+    monkeypatch.setenv("DION_NAN_CAPTURE_DIR", str(tmp_path))
+    # Don't raise; we want to inspect the dump.
+    monkeypatch.setenv("DION_NAN_CAPTURE_RAISE", "0")
+
+    U = [torch.randn(3, 4) for _ in range(2)]
+    _drive(
+        megabatch_orthogonalize_async(
+            U,
+            comm_dim=None,
+            device_rank=0,
+            world_size=1,
+            process_group=None,
+            newton_schulz_func=_nan_ns,
+            flatten=False,
+            epsilon=torch.tensor(1e-7),
+            global_comm_dim_size=None,
+        )
+    )
+
+    dumps = list(tmp_path.glob("dion_nan_capture_rank0_*.pt"))
+    assert len(dumps) == 1, f"expected 1 dump, got {dumps}"
+    payload = torch.load(dumps[0], weights_only=False)
+    assert payload["rank"] == 0
+    assert payload["shape"] == (2, 3, 4)  # stacked across N=2
+    assert torch.isfinite(payload["input"]).all()
+    assert torch.isnan(payload["output"]).all()
+    assert payload["epsilon"] == pytest.approx(1e-7)
+
+
+def test_capture_raises_by_default_when_enabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("DION_NAN_CAPTURE", "1")
+    monkeypatch.setenv("DION_NAN_CAPTURE_DIR", str(tmp_path))
+    monkeypatch.delenv("DION_NAN_CAPTURE_RAISE", raising=False)
+
+    U = [torch.randn(3, 4) for _ in range(2)]
+    with pytest.raises(RuntimeError, match="non-finite Newton-Schulz output"):
+        _drive(
+            megabatch_orthogonalize_async(
+                U,
+                comm_dim=None,
+                device_rank=0,
+                world_size=1,
+                process_group=None,
+                newton_schulz_func=_nan_ns,
+                flatten=False,
+                epsilon=torch.tensor(1e-7),
+                global_comm_dim_size=None,
+            )
+        )
+
+    # Even when raising, the dump should be written first.
+    assert len(list(tmp_path.glob("dion_nan_capture_rank0_*.pt"))) == 1
+
+
+def test_capture_no_dump_when_finite(tmp_path, monkeypatch):
+    monkeypatch.setenv("DION_NAN_CAPTURE", "1")
+    monkeypatch.setenv("DION_NAN_CAPTURE_DIR", str(tmp_path))
+    monkeypatch.setenv("DION_NAN_CAPTURE_RAISE", "0")
+
+    U = [torch.randn(3, 4) for _ in range(2)]
+    _drive(
+        megabatch_orthogonalize_async(
+            U,
+            comm_dim=None,
+            device_rank=0,
+            world_size=1,
+            process_group=None,
+            newton_schulz_func=_identity_ns,
+            flatten=False,
+            epsilon=torch.tensor(1e-7),
+            global_comm_dim_size=None,
+        )
+    )
+
+    # NS output was finite -> no dump regardless of env.
+    assert list(tmp_path.glob("dion_nan_capture_*.pt")) == []
+
+
+def test_capture_filename_includes_rank(tmp_path, monkeypatch):
+    monkeypatch.setenv("DION_NAN_CAPTURE", "1")
+    monkeypatch.setenv("DION_NAN_CAPTURE_DIR", str(tmp_path))
+    monkeypatch.setenv("DION_NAN_CAPTURE_RAISE", "0")
+
+    # device_rank=3 simulates a non-zero rank in a multi-rank job; each rank
+    # must write under its own filename so concurrent writes from different
+    # ranks don't collide on a shared filesystem.
+    U = [torch.randn(3, 4) for _ in range(2)]
+    _drive(
+        megabatch_orthogonalize_async(
+            U,
+            comm_dim=None,
+            device_rank=3,
+            world_size=1,
+            process_group=None,
+            newton_schulz_func=_nan_ns,
+            flatten=False,
+            epsilon=torch.tensor(1e-7),
+            global_comm_dim_size=None,
+        )
+    )
+
+    dumps = list(tmp_path.glob("dion_nan_capture_rank3_*.pt"))
+    assert len(dumps) == 1
+    assert "rank3" in os.path.basename(dumps[0])


### PR DESCRIPTION
## Summary

Re: #76. The reporter and maintainers cannot consistently reproduce the
NorMuon + gram-newton-schulz + quack-kernels 0.4.1 NaN bug, so the next
debugging step is to capture the actual NS input that triggers the failure
on the affected hardware (6x Blackwell RTX PRO 6000 + DDP).

This PR wraps ``newton_schulz_func`` inside ``megabatch_orthogonalize_async``
with an env-gated capture wrapper. When enabled, each rank that observes a
non-finite NS output writes its own .pt dump (input + output + rank +
shape + epsilon) and by default raises ``RuntimeError``. The check is
**local per rank — no extra collective** — and it short-circuits at one
``os.environ`` lookup when disabled.

## Usage

```bash
DION_NAN_CAPTURE=1 \
DION_NAN_CAPTURE_DIR=/some/scratch/dir \
DION_NAN_CAPTURE_RAISE=1 \  # default; set to 0 to keep training
torchrun ... train.py
```

Per-rank filenames are ``dion_nan_capture_rank{rank}_shape{...}_pid{...}_{ts_ms}.pt``
so concurrent writes from multiple ranks on a shared filesystem do not collide.

## Notes

- Disabled by default. Cost when off: one ``os.environ`` lookup per call.
- The input is ``.detach().clone()``-d up front so we still have the
  offending tensor even if a kernel mutates X in-place.
- Two new module-level imports (``os``, ``time``).

## Test plan

- [x] ``test_capture_disabled_by_default`` — no env, no dumps even when NS returns NaN
- [x] ``test_capture_dumps_on_non_finite_output`` — dump contains correct input/output/shape/rank/epsilon
- [x] ``test_capture_raises_by_default_when_enabled`` — ``RuntimeError`` after dump
- [x] ``test_capture_no_dump_when_finite`` — finite output -> no dump even with env on
- [x] ``test_capture_filename_includes_rank`` — non-zero rank reflected in filename

All five pass single-rank without GPU/NCCL.