### PR TITLE
dion2: handle empty FSDP2 local shards in pre-orthogonalize

### DIFF
--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -349,6 +349,21 @@ def dion2_pre_orthogonalize(
     G = [g.to(dtype=dtype) for g in G]
     torch._foreach_add_(M, G)
 
+    # Empty local shard along select_dim: FSDP2 contiguous chunking leaves this
+    # rank with a size-0 shard when the param's sharded dim is smaller than
+    # world_size (or doesn't divide evenly to fill all ranks). There is nothing
+    # to select here, and topk(k>=1) over a size-0 dimension raises "k not in
+    # range for dimension". Short-circuit with empty submatrices (downstream
+    # megabatch_orthogonalize_async pads these to padded_local_size; the real
+    # orthogonalization runs on the gathered global tensor) and empty index
+    # tensors (post-orthogonalize scatter_add over an empty index is a no-op on
+    # this rank). num_select is a static int at trace time, so this branch is
+    # torch.compile-safe.
+    if num_select == 0:
+        U_selected = [m.to(dtype=torch.bfloat16) for m in M]
+        indices_list = [torch.empty(0, dtype=torch.long, device=M[0].device) for _ in M]
+        return U_selected, indices_list
+
     M_stacked = torch.stack(M, dim=0)
 
     # Compute L1 norm along norm_dim (sum of absolute values)

--- a/dion/dion2_triton.py
+++ b/dion/dion2_triton.py
@@ -169,6 +169,12 @@ def dion2_post_orthogonalize_triton(
     SELECT_ROWS = select_dim == -2
 
     for x, u, idx in zip(X, U, indices):
+        # Empty FSDP2 local shard (sharded dim < world_size or uneven chunking):
+        # nothing to write back on this rank. The non-triton path no-ops naturally
+        # via scatter_add_ over an empty index; here we must skip explicitly because
+        # B = x.numel() // (M * N) divides by zero when M or N is 0.
+        if x.numel() == 0:
+            continue
         if not x.is_contiguous():
             raise ValueError("dion2_post_orthogonalize_triton requires contiguous X tensors")
         orig_shape = x.shape

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -9,12 +9,14 @@ Tests cover:
 - Step timing: optimizer step takes measurable wall-clock time
 """
 
+import os
 import pytest
 import time
 import torch
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 CUDA_AVAILABLE = torch.cuda.is_available()
+CUDA_DEVICE_COUNT = torch.cuda.device_count() if CUDA_AVAILABLE else 0
 
 # Bump torch.compile cache size to avoid recompilation failures
 # when the same compiled function sees different input shapes across tests.
@@ -528,3 +530,101 @@ class TestTiming:
         t1 = time.perf_counter()
         # Should register nonzero time
         assert t1 > t0
+
+
+# ---------------------------------------------------------------------------
+# Empty FSDP2 local shards (Dion2 / NorDion2)
+# ---------------------------------------------------------------------------
+# FSDP2 contiguous chunking leaves some ranks with an empty (size-0) local
+# shard along the sharded dim when the param's sharded dim is smaller than
+# world_size (or doesn't divide evenly to fill all ranks). dion2_pre_orthogonalize
+# computes topk(k>=1) over that dim, which raised "k not in range for dimension"
+# under torch.compile's fake-tensor pass and deadlocked the remaining ranks at
+# the NCCL all-to-all. These tests pin the empty-shard short-circuit.
+
+def test_dion2_pre_orthogonalize_empty_row_shard():
+    from dion.dion2 import dion2_pre_orthogonalize
+    cols, n = 16, 4
+    M = [torch.zeros(0, cols) for _ in range(n)]
+    G = [torch.randn(0, cols) for _ in range(n)]
+    U, indices = dion2_pre_orthogonalize(
+        G=G, M=M, fraction=0.5, ef_decay=torch.tensor(0.95), select_dim=-2
+    )
+    assert len(U) == n and len(indices) == n
+    for u, idx in zip(U, indices):
+        assert tuple(u.shape) == (0, cols)
+        assert u.dtype == torch.bfloat16
+        assert tuple(idx.shape) == (0,)
+        assert idx.dtype == torch.long
+
+
+def test_dion2_pre_orthogonalize_empty_col_shard():
+    from dion.dion2 import dion2_pre_orthogonalize
+    rows, n = 16, 4
+    M = [torch.zeros(rows, 0) for _ in range(n)]
+    G = [torch.randn(rows, 0) for _ in range(n)]
+    U, indices = dion2_pre_orthogonalize(
+        G=G, M=M, fraction=0.5, ef_decay=torch.tensor(0.95), select_dim=-1
+    )
+    assert len(U) == n and len(indices) == n
+    for u, idx in zip(U, indices):
+        assert tuple(u.shape) == (rows, 0)
+        assert u.dtype == torch.bfloat16
+        assert tuple(idx.shape) == (0,)
+        assert idx.dtype == torch.long
+
+
+def _dion2_empty_shard_step_worker(rank, world_size, global_rows, cols, port):
+    import torch.distributed as dist
+    from torch.distributed.tensor import distribute_tensor, Shard, init_device_mesh
+    from dion import Dion2
+
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+    mesh = init_device_mesh("cuda", (world_size,))
+    device = torch.device(f"cuda:{rank}")
+
+    torch.manual_seed(0)
+    full = torch.randn(global_rows, cols, device=device)
+    # Row-sharded over world_size: ranks beyond ceil(global_rows / world_size)
+    # contiguous chunks hold an empty (0, cols) local shard.
+    param = torch.nn.Parameter(distribute_tensor(full, mesh, [Shard(0)]))
+    before = param.to_local().clone()
+
+    opt = Dion2([param], distributed_mesh=mesh, lr=0.01)
+    for step in range(3):
+        torch.manual_seed(step + 1)
+        g = torch.randn(global_rows, cols, device=device)
+        param.grad = distribute_tensor(g, mesh, [Shard(0)])
+        opt.step()
+
+    local_after = param.to_local()
+    if local_after.shape[0] > 0:
+        assert not torch.equal(local_after, before), f"rank {rank}: weights did not update"
+    else:
+        assert torch.equal(local_after, before), f"rank {rank}: empty shard mutated"
+    dist.destroy_process_group()
+
+
+@pytest.mark.parametrize(
+    "world_size, global_rows",
+    [
+        (2, 1),  # rank 1 holds an empty (0, cols) shard
+        (4, 2),  # ranks 2 and 3 empty
+        (4, 5),  # chunk sizes (2, 2, 1, 0): rank 3 empty (mirrors sparse-3b (18, D)/8)
+    ],
+)
+def test_dion2_optimizer_step_with_empty_shard(world_size, global_rows):
+    import torch.multiprocessing as mp
+
+    if CUDA_DEVICE_COUNT < world_size:
+        pytest.skip(f"needs >= {world_size} CUDA devices for NCCL alltoall")
+    port = 29800 + world_size * 10 + global_rows
+    mp.spawn(
+        _dion2_empty_shard_step_worker,
+        args=(world_size, global_rows, 16, port),
+        nprocs=world_size,
+        join=True,
+    )

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -574,7 +574,7 @@ def test_dion2_pre_orthogonalize_empty_col_shard():
         assert idx.dtype == torch.long
 
 
-def _dion2_empty_shard_step_worker(rank, world_size, global_rows, cols, port):
+def _dion2_empty_shard_step_worker(rank, world_size, global_rows, cols, port, triton_post_ortho):
     import torch.distributed as dist
     from torch.distributed.tensor import distribute_tensor, Shard, init_device_mesh
     from dion import Dion2
@@ -593,7 +593,7 @@ def _dion2_empty_shard_step_worker(rank, world_size, global_rows, cols, port):
     param = torch.nn.Parameter(distribute_tensor(full, mesh, [Shard(0)]))
     before = param.to_local().clone()
 
-    opt = Dion2([param], distributed_mesh=mesh, lr=0.01)
+    opt = Dion2([param], distributed_mesh=mesh, lr=0.01, triton_post_ortho=triton_post_ortho)
     for step in range(3):
         torch.manual_seed(step + 1)
         g = torch.randn(global_rows, cols, device=device)
@@ -608,6 +608,10 @@ def _dion2_empty_shard_step_worker(rank, world_size, global_rows, cols, port):
     dist.destroy_process_group()
 
 
+# triton_post_ortho=True exercises dion2_post_orthogonalize_triton, whose
+# B = x.numel() // (M * N) divides by zero on the empty (0, cols) shard unless
+# the empty rank is skipped; the default (False) path no-ops via scatter_add_.
+@pytest.mark.parametrize("triton_post_ortho", [False, True])
 @pytest.mark.parametrize(
     "world_size, global_rows",
     [
@@ -616,15 +620,20 @@ def _dion2_empty_shard_step_worker(rank, world_size, global_rows, cols, port):
         (4, 5),  # chunk sizes (2, 2, 1, 0): rank 3 empty (mirrors sparse-3b (18, D)/8)
     ],
 )
-def test_dion2_optimizer_step_with_empty_shard(world_size, global_rows):
+def test_dion2_optimizer_step_with_empty_shard(world_size, global_rows, triton_post_ortho):
     import torch.multiprocessing as mp
 
     if CUDA_DEVICE_COUNT < world_size:
         pytest.skip(f"needs >= {world_size} CUDA devices for NCCL alltoall")
-    port = 29800 + world_size * 10 + global_rows
+    if triton_post_ortho:
+        try:
+            import triton  # noqa: F401
+        except ImportError:
+            pytest.skip("triton not installed")
+    port = 29800 + world_size * 10 + global_rows + (1000 if triton_post_ortho else 0)
     mp.spawn(
         _dion2_empty_shard_step_worker,
-        args=(world_size, global_rows, 16, port),
+        args=(world_size, global_rows, 16, port, triton_post_ortho),
         nprocs=world_size,
         join=True,
     )


### PR DESCRIPTION
## Problem

FSDP2 contiguous chunking leaves some ranks with a size-0 local shard along the sharded dim when a param's sharded dim is smaller than `world_size` (or doesn't divide evenly to fill all ranks). For example, an `(18, D)` MoE weight sharded over 8 ranks gives ranks 6-7 a `(0, D)` shard.

`dion2_pre_orthogonalize` then computes `topk(slice_norms, k, dim=-1)` with `k = max(1, ...) >= 1` over that empty `select_dim`. With a size-0 dimension this raises `RuntimeError: k not in range for dimension` from `topk_meta` during torch.compile's fake-tensor pass. The crashing ranks then strand the remaining ranks at the megabatch all-to-all (NCCL watchdog timeout → SIGABRT). This was hit in production by a sparse-3b MoE config on 8 GPUs.

This bug predates the NorDion2 work; it affects every Dion2/NorDion2 caller. NorMuon is unaffected (Muon's pre-orthogonalize has no topk).

## Fix

Short-circuit `dion2_pre_orthogonalize` when the select dimension is empty: return empty (bf16) selected submatrices and empty index tensors on those ranks. `num_select = M[0].size(select_dim)` is a static int at trace time, so the guard is torch.compile-safe (no graph break).

This is correct end-to-end: `megabatch_orthogonalize_async` already pads each rank's shard to `padded_local_size = ceil(global / world_size)`, so the actual orthogonalization still runs on the gathered global tensor; and `dion2_post_orthogonalize`'s `scatter_add_` over an empty index is a no-op on an empty shard (nothing to write back on this rank).

## Tests

- `test_dion2_pre_orthogonalize_empty_row_shard` / `_empty_col_shard` — direct unit tests for the short-circuit (both `select_dim`).
- `test_dion2_optimizer_step_with_empty_shard` — multi-GPU regression: runs a full Dion2 step on a DTensor row-sharded so some ranks hold a `(0, cols)` local shard (configs `2/1`, `4/2`, `4/5`; the `4/5` case mirrors the production `(18, D)`/8 pattern). Skipped when fewer CUDA devices are available.

Verified the multi-GPU test crashes on `main` without the fix and passes with it.