### PR TITLE
dion2: fall back to eager post-orthogonalize for tensor-subclass params

### DIFF
--- a/dion/dion2_triton.py
+++ b/dion/dion2_triton.py
@@ -158,11 +158,25 @@ def dion2_post_orthogonalize_triton(
         base_lr, adjusted_lr, weight_decay: scalar tensors
         select_dim: -2 (row selection) or -1 (column selection)
     """
-    if not TRITON_AVAILABLE:
-        raise RuntimeError("Triton is required for dion2_post_orthogonalize_triton")
-
     if select_dim not in (-2, -1):
         raise ValueError(f"select_dim must be -2 or -1, got {select_dim}")
+
+    # The kernel writes X in-place through a raw data pointer, which is only valid
+    # for plain dense tensors. Tensor subclasses (e.g. the quantized-weight
+    # wrappers used by MXFP8 training) do not expose a dense buffer in the logical
+    # dtype/layout at data_ptr(), so a raw write corrupts memory and triggers an
+    # illegal memory access. Fall back to the eager implementation, which routes
+    # through __torch_dispatch__ and handles subclasses correctly.
+    if any(type(x) is not torch.Tensor for x in X):
+        from .dion2 import dion2_post_orthogonalize
+
+        dion2_post_orthogonalize(
+            X, U, indices, base_lr, adjusted_lr, weight_decay, select_dim
+        )
+        return
+
+    if not TRITON_AVAILABLE:
+        raise RuntimeError("Triton is required for dion2_post_orthogonalize_triton")
 
     a = (1 - base_lr * weight_decay).item()
     b = adjusted_lr.item()

--- a/dion/dion2_triton.py
+++ b/dion/dion2_triton.py
@@ -1,5 +1,6 @@
 import torch
 from torch import Tensor
+from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 from typing import List
 
 try:
@@ -162,12 +163,16 @@ def dion2_post_orthogonalize_triton(
         raise ValueError(f"select_dim must be -2 or -1, got {select_dim}")
 
     # The kernel writes X in-place through a raw data pointer, which is only valid
-    # for plain dense tensors. Tensor subclasses (e.g. the quantized-weight
-    # wrappers used by MXFP8 training) do not expose a dense buffer in the logical
-    # dtype/layout at data_ptr(), so a raw write corrupts memory and triggers an
-    # illegal memory access. Fall back to the eager implementation, which routes
-    # through __torch_dispatch__ and handles subclasses correctly.
-    if any(type(x) is not torch.Tensor for x in X):
+    # for tensors backed by a dense buffer in their logical dtype/layout. Traceable
+    # wrapper subclasses (e.g. the quantized-weight wrappers used by MXFP8 training,
+    # or DTensor) hold their data in wrapped inner tensors and do not expose such a
+    # buffer at data_ptr(), so a raw write corrupts memory and triggers an illegal
+    # memory access. Fall back to the eager implementation, which routes through
+    # __torch_dispatch__ and updates the wrapped weight correctly. Plain dense
+    # subclasses such as nn.Parameter are not wrapper subclasses and stay on the
+    # kernel, so the single-GPU/DDP path (where params are not converted by
+    # to_local) keeps the fast path.
+    if any(is_traceable_wrapper_subclass(x) for x in X):
         from .dion2 import dion2_post_orthogonalize
 
         dion2_post_orthogonalize(

--- a/tests/test_dion2_post_ortho_triton.py
+++ b/tests/test_dion2_post_ortho_triton.py
@@ -14,6 +14,11 @@ Two levels of testing:
 import math
 import pytest
 import torch
+from torch.utils._python_dispatch import (
+    is_traceable_wrapper_subclass,
+    return_and_correct_aliasing,
+)
+from torch.utils._pytree import tree_map
 
 from dion.dion2 import dion2_post_orthogonalize
 from dion.dion2_triton import TRITON_AVAILABLE, dion2_post_orthogonalize_triton
@@ -88,15 +93,48 @@ def _build_selected_mask(indices, select_dim, shape):
 
 
 class _MockWrapperTensor(torch.Tensor):
-    # Minimal tensor subclass standing in for a quantized-weight wrapper such as
-    # MXFP8 training's MXFP8TrainingWeightWrapperTensor. type(x) is not Tensor,
-    # so the raw Triton kernel must not write through its data_ptr().
-    pass
+    # Minimal traceable wrapper subclass standing in for a quantized-weight wrapper
+    # such as MXFP8 training's MXFP8TrainingWeightWrapperTensor: it holds its data in
+    # a wrapped inner tensor and exposes no dense buffer at data_ptr() (data_ptr() is
+    # 0). A raw Triton kernel writing through that pointer would fault, so the entry
+    # point must route through __torch_dispatch__ instead. is_traceable_wrapper_subclass
+    # returns True for this type but False for plain dense subclasses like nn.Parameter.
+    @staticmethod
+    def __new__(cls, inner):
+        return torch.Tensor._make_wrapper_subclass(
+            cls,
+            inner.shape,
+            dtype=inner.dtype,
+            device=inner.device,
+            layout=inner.layout,
+            strides=inner.stride(),
+            requires_grad=False,
+        )
+
+    def __init__(self, inner):
+        self._inner = inner
+
+    def __tensor_flatten__(self):
+        return ["_inner"], None
+
+    @staticmethod
+    def __tensor_unflatten__(inner_tensors, meta, outer_size, outer_stride):
+        return _MockWrapperTensor(inner_tensors["_inner"])
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+        kwargs = kwargs or {}
+        unwrap = lambda t: t._inner if isinstance(t, _MockWrapperTensor) else t
+        wrap = lambda t: _MockWrapperTensor(t) if isinstance(t, torch.Tensor) else t
+        out = func(
+            *tree_map(unwrap, args), **tree_map(unwrap, kwargs)
+        )
+        out = tree_map(wrap, out)
+        return return_and_correct_aliasing(func, args, kwargs, out)
 
 
-@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA required")
 @pytest.mark.parametrize("select_dim", [-2, -1])
-def test_post_ortho_triton_falls_back_for_tensor_subclass(select_dim):
+def test_post_ortho_triton_falls_back_for_wrapper_subclass(select_dim):
     M, N, k = 64, 128, 16
     X, U, indices = _make_test_data((M, N), k, select_dim)
     base_lr = torch.tensor(0.1, device=DEVICE)
@@ -108,15 +146,21 @@ def test_post_ortho_triton_falls_back_for_tensor_subclass(select_dim):
         [x_ref], [U], [indices], base_lr, adjusted_lr, weight_decay, select_dim
     )
 
-    x_sub = X.clone().as_subclass(_MockWrapperTensor)
+    x_sub = _MockWrapperTensor(X.clone())
     dion2_post_orthogonalize_triton(
         [x_sub], [U], [indices], base_lr, adjusted_lr, weight_decay, select_dim
     )
 
     assert type(x_sub) is _MockWrapperTensor
-    torch.testing.assert_close(
-        x_sub.as_subclass(torch.Tensor), x_ref, rtol=1e-5, atol=1e-6
-    )
+    torch.testing.assert_close(x_sub._inner, x_ref, rtol=1e-5, atol=1e-6)
+
+
+def test_post_ortho_triton_keeps_kernel_for_nn_parameter():
+    # nn.Parameter has type(p) is not torch.Tensor but is NOT a wrapper subclass:
+    # it must stay on the Triton kernel, not fall back. Guarding on
+    # is_traceable_wrapper_subclass (not type identity) preserves the fast path for
+    # the single-GPU/DDP case where params reach the kernel as nn.Parameter.
+    assert not is_traceable_wrapper_subclass(torch.nn.Parameter(torch.empty(2, 2)))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dion2_post_ortho_triton.py
+++ b/tests/test_dion2_post_ortho_triton.py
@@ -87,6 +87,38 @@ def _build_selected_mask(indices, select_dim, shape):
     return full_mask.reshape(shape)
 
 
+class _MockWrapperTensor(torch.Tensor):
+    # Minimal tensor subclass standing in for a quantized-weight wrapper such as
+    # MXFP8 training's MXFP8TrainingWeightWrapperTensor. type(x) is not Tensor,
+    # so the raw Triton kernel must not write through its data_ptr().
+    pass
+
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA required")
+@pytest.mark.parametrize("select_dim", [-2, -1])
+def test_post_ortho_triton_falls_back_for_tensor_subclass(select_dim):
+    M, N, k = 64, 128, 16
+    X, U, indices = _make_test_data((M, N), k, select_dim)
+    base_lr = torch.tensor(0.1, device=DEVICE)
+    adjusted_lr = torch.tensor(0.05, device=DEVICE)
+    weight_decay = torch.tensor(0.01, device=DEVICE)
+
+    x_ref = X.clone()
+    dion2_post_orthogonalize(
+        [x_ref], [U], [indices], base_lr, adjusted_lr, weight_decay, select_dim
+    )
+
+    x_sub = X.clone().as_subclass(_MockWrapperTensor)
+    dion2_post_orthogonalize_triton(
+        [x_sub], [U], [indices], base_lr, adjusted_lr, weight_decay, select_dim
+    )
+
+    assert type(x_sub) is _MockWrapperTensor
+    torch.testing.assert_close(
+        x_sub.as_subclass(torch.Tensor), x_ref, rtol=1e-5, atol=1e-6
+    )
+
+
 # ---------------------------------------------------------------------------
 # Function-level tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`dion2_post_orthogonalize_triton` applies the weight update in place with a raw Triton kernel — `tl.store` to `x.data_ptr()`. That is only valid for plain dense tensors. Under **MXFP8 training**, the optimizer parameter is an `MXFP8TrainingWeightWrapperTensor` — a `__torch_dispatch__` tensor **subclass** whose `data_ptr()` does not address a dense buffer in the logical dtype/layout. The raw kernel write therefore runs off into unrelated memory and triggers a **CUDA illegal memory access** on the first optimizer step.

This bites any Dion2/NorDion2 run with `triton_post_ortho=true` on quantized (MXFP8) weights. NorMuon is unaffected (it does not use this kernel), and `triton_post_ortho=false` already works because the eager path dispatches through the subclass.

## Fix

Guard the entry point: if any `X` is a tensor subclass (`type(x) is not torch.Tensor`), fall back to the eager `dion2_post_orthogonalize`, which routes through `__torch_dispatch__` and updates the wrapped weight correctly. Plain tensors are unaffected and still take the Triton kernel. No perf change for the non-quantized path.

## How it was diagnosed

On a sparse-3b + NorDion2 + MXFP8 run on 8 GPUs, every step-0 crash was an illegal memory access whose **async NCCL-watchdog** report pointed at the *later* Newton-Schulz `quack` GEMM (a red herring). `CUDA_LAUNCH_BLOCKING=1` relocated the fault to `dion2_post_orthogonalize_triton`, and logging tensor types showed the param was an `MXFP8TrainingWeightWrapperTensor` with valid, in-bounds `u`/`idx`. Disabling the triton post-ortho (eager path) trained cleanly.

## Test

`test_post_ortho_triton_falls_back_for_tensor_subclass` passes a tensor subclass through the triton entry point (both `select_dim`) and asserts the in-place result matches the eager reference — i.e. the kernel is not used and the update is correct.