### PR TITLE
Reduce NorDion2 optimizer-step overhead at small scale

### DIFF
--- a/dion/nordion2.py
+++ b/dion/nordion2.py
@@ -275,23 +275,22 @@ def nordion2_update_megabatch_async(
         global_comm_dim_size=global_comm_dim_size,
     )
 
-    # Update variance neuron buffer for each selected row and normalize orthonormalized update
-    # V is stored in param dtype (bf16) but compute is done in fp32
+    # Update variance neuron buffer for the selected rows and normalize the
+    # orthonormalized update. The gather of the selected variance rows, the
+    # NorMuon normalization (fp32 compute, V stored bf16), and the scatter of
+    # the updated rows back into the full buffer are fused into one compiled
+    # graph so the per-param Python scatter loop and the eager gather/normalize
+    # graph boundary collapse into a single launch per shape group.
     V_local = to_local(V)
     U_stacked = torch.stack(U_ortho)
     V_stacked = torch.stack(V_local)
-    
-    # Concatenate indices to match Dion2-style gather for selection
     indices = torch.stack(indices_list, dim=0)
-    indices_expanded = indices.unsqueeze(-1)
-    V_sel_stacked = torch.gather(V_stacked, dim=-2, index=indices_expanded).float() # upcast to fp32 for compute
 
-    U_stacked, V_stacked = normuon_normalization_stacked(U_stacked, V_sel_stacked, muon_beta2)
+    U_stacked, V_stacked = nordion2_normalize_selected_stacked(
+        U_stacked, V_stacked, indices, muon_beta2
+    )
     U_normed = [U_stacked[i] for i in range(N)]
-
-    for v, idx, v_sel in zip(V_local, indices_list, V_stacked):
-        idx_exp = idx.unsqueeze(-1)
-        v.scatter_(dim=-2, index=idx_exp, src=v_sel.to(v.dtype))
+    torch._foreach_copy_(V_local, list(V_stacked.unbind(0)))
 
     # Compute scaled learning rate
     # Do this before to_local(X) because we use the full tensor shape, not the shard shape
@@ -330,3 +329,24 @@ def nordion2_update_megabatch_async(
             weight_decay=weight_decay,
             select_dim=select_dim,
         )
+
+
+@torch.compile(fullgraph=True)
+def nordion2_normalize_selected_stacked(
+    U: Tensor,  # [N, k, cols]  orthogonalized selected rows
+    V_full: Tensor,  # [N, rows, 1]  full per-neuron variance buffer (param dtype)
+    indices: Tensor,  # [N, k]  selected row indices
+    muon_beta2: Tensor,
+) -> Tuple[Tensor, Tensor]:
+    """
+    Gather the selected variance rows, run NorMuon normalization on them, and
+    scatter the updated rows back into the full variance buffer, all in one
+    compiled graph. Compute is done in fp32 (V stored in param dtype); the
+    returned V_full has the same dtype as the input.
+    Returns (normalized_U, updated_V_full).
+    """
+    idx = indices.unsqueeze(-1)
+    V_sel = torch.gather(V_full, dim=-2, index=idx).float()
+    U_normed, V_sel_new = normuon_normalization_stacked(U, V_sel, muon_beta2)
+    V_full = V_full.scatter(dim=-2, index=idx, src=V_sel_new.to(V_full.dtype))
+    return U_normed, V_full

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -225,6 +225,32 @@ class TestNorDion2:
         r2 = _run_steps(NorDion2, p2, dict(lr=0.01, triton_post_ortho=True))
         torch.testing.assert_close(r1[0], r2[0], atol=1e-5, rtol=1e-5)
 
+    def test_normalize_selected_stacked_matches_unfused(self):
+        from dion.nordion2 import nordion2_normalize_selected_stacked
+        from dion.normuon import normuon_normalization_stacked
+        torch.manual_seed(3)
+        n, rows, cols, k = 4, 16, 32, 8
+        u = torch.randn(n, k, cols, device=DEVICE, dtype=torch.bfloat16)
+        v_full = torch.rand(n, rows, 1, device=DEVICE, dtype=torch.bfloat16)
+        indices = torch.stack(
+            [torch.randperm(rows, device=DEVICE)[:k] for _ in range(n)], dim=0
+        )
+        beta2 = torch.tensor(0.9)
+
+        u_fused, v_fused = nordion2_normalize_selected_stacked(
+            u.clone(), v_full.clone(), indices, beta2
+        )
+
+        idx = indices.unsqueeze(-1)
+        v_sel = torch.gather(v_full, dim=-2, index=idx).float()
+        u_ref, v_sel_new = normuon_normalization_stacked(u.clone(), v_sel, beta2)
+        v_ref = v_full.clone()
+        for i in range(n):
+            v_ref[i].scatter_(dim=-2, index=idx[i], src=v_sel_new[i].to(v_ref.dtype))
+
+        torch.testing.assert_close(u_fused, u_ref, atol=0, rtol=0)
+        torch.testing.assert_close(v_fused, v_ref, atol=0, rtol=0)
+
 # ---------------------------------------------------------------------------
 # Dion2
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #82. NorDion2's per-step optimizer tax over NorMuon at small scales came from the post-Newton-Schulz variance section, not the algorithm: the selected-row variance gather, the NorMuon normalization, and the per-parameter `scatter_` write-back ran as eager scaffolding around a compiled kernel, crossing a graph boundary and launching one scatter per parameter.

This folds the gather + normalization + a single batched scatter into one `torch.compile(fullgraph=True)` helper (`nordion2_normalize_selected_stacked`) and replaces the Python write-back loop with `torch._foreach_copy_`, collapsing the N per-param launches into one launch per shape group.

**Bit-exact** — no algorithm or dtype change (fp32 variance compute preserved; V still stored in param dtype). A profiler-guided check confirmed the fp32 upcast was *not* the real cost once the graph boundary is removed (dropping it saves ~1 ms but diverges updates ~30x relative), so fp32 is kept.

### Results (single-GPU H100, 1b mixformer shapes)

| | NorMuon | Dion2 (1/2) | NorDion2 (1/2) | variance piece (NorDion2 - Dion2) |
|---|---|---|---|---|
| before | 85.5 | 36.5 | 63.7 | +27.2 ms |
| after  | 85.5 | 36.5 | **47.6** | **+11.1 ms** (-59%) |

`dion2` and `normuon` are unchanged. At 7b (12-layer, memory-fit) the variance piece drops +109 -> +41 ms with `dion2` unchanged (94.8 -> 94.7) and still far below NorMuon (277), so the Newton-Schulz-on-half-rows crossover is preserved. `dion2.py` and `megabatch_base.py` are untouched.

### Tests

`test_normalize_selected_stacked_matches_unfused` pins the fused helper to the prior unfused gather/normalize/per-param-scatter path at `atol=0, rtol=0`. Full suite: 66 passed, 11 skipped (multi-GPU), 0 failed.