### PR TITLE
Fix flaky fused-helper parity test (atol=0 across compile graphs)

### DIFF
--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -248,8 +248,14 @@ class TestNorDion2:
         for i in range(n):
             v_ref[i].scatter_(dim=-2, index=idx[i], src=v_sel_new[i].to(v_ref.dtype))
 
-        torch.testing.assert_close(u_fused, u_ref, atol=0, rtol=0)
-        torch.testing.assert_close(v_fused, v_ref, atol=0, rtol=0)
+        # The fused helper and the reference run through different inductor
+        # fusion groupings (gather/normalize/scatter fused into one graph vs
+        # eager gather/scatter around a separately compiled normalization), so
+        # they are not guaranteed bit-identical: inductor may reorder the fp32
+        # reductions/divisions, leaving last-ULP differences. Compare at the
+        # same fp tolerance as the sibling parity tests.
+        torch.testing.assert_close(u_fused, u_ref, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(v_fused, v_ref, atol=1e-5, rtol=1e-5)
 
 # ---------------------------------------------------------------------------
 # Dion2


### PR DESCRIPTION
Follow-up to #85.

`test_normalize_selected_stacked_matches_unfused` (added in #85) asserts `atol=0, rtol=0` equality between **two different inductor fusion graphs**: the fused helper (gather + normalize + scatter folded into one compiled graph) vs. the reference path (eager gather/scatter around a separately compiled `normuon_normalization_stacked`). Inductor does not guarantee bit-identical output across distinct fusion groupings — it may reorder the fp32 reductions/divisions — so the result differs by ~1 ULP depending on how the inner normalization was already compiled.

This makes the test **order-dependent**: it passes in isolation but fails under the full-suite ordering once `normuon_normalization_stacked` has been compiled for NorMuon's standalone path first.

```
Mismatched elements: 245 / 1024 (23.9%)
Greatest absolute difference: 2.384185791015625e-07 at index (3, 0, 15)
Greatest relative difference: 1.7449539768676914e-07 at index (3, 0, 1)
```

Relax both assertions to `atol=1e-5, rtol=1e-5`, matching the sibling `test_triton_post_ortho_parity`. The change is still a strong equivalence check — a real algorithmic regression would differ far beyond 1e-5 — while being robust to inductor fusion nondeterminism.

The underlying PR #85 code change is unaffected; this is a test-only fix.

### Verification
- Previously-failing ordering (`TestNorMuon` then the new test): now passes (6 passed).
- Full `tests/test_optimizers.py` suite: passes.