### PR TITLE
dion2: restore single-rounding post-ortho for tensor-subclass params

### DIFF
--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -445,6 +445,49 @@ def dion2_post_orthogonalize(
         x.scatter_add_(dim=select_dim, index=idx_exp, src=u_scaled)
 
 
+@torch.compile(fullgraph=True)
+def dion2_post_orthogonalize_fused(
+    X: List[Tensor],
+    U: List[Tensor],
+    indices: List[Tensor],
+    base_lr: Tensor,
+    adjusted_lr: Tensor,
+    weight_decay: Tensor,
+    select_dim: int,
+):
+    """
+    Single-rounding weight decay + weight update after orthogonalization.
+
+    Computes the new value of the selected rows/columns as
+    ``(1 - base_lr*weight_decay)*x - adjusted_lr*u`` in float32 and writes it
+    once, matching the single-rounding numerics of the fused Triton kernel
+    (dion2_post_orthogonalize_triton). Unselected entries get the weight decay
+    in place, also a single rounding. This differs from dion2_post_orthogonalize,
+    which writes the weight-decayed weight and then accumulates the update in a
+    second pass, rounding the selected slices twice.
+
+    Only the selected slices are gathered into float32, so the extra work over
+    the in-place weight decay is small. Uses only ``__torch_dispatch__``-routed
+    ops (no raw data_ptr writes), so it is safe for traceable wrapper subclasses
+    such as the MXFP8 training weight wrapper, for which the Triton kernel cannot
+    be used. Inputs should be lists of regular Tensor, not DTensor.
+    """
+    a = 1 - base_lr * weight_decay
+    neg_lr = -adjusted_lr
+    for x, u, idx in zip(X, U, indices):
+        if select_dim == -2:
+            idx_exp = idx.unsqueeze(-1).expand_as(u)
+        else:
+            idx_exp = idx.unsqueeze(-2).expand_as(u)
+        # Fused single-rounding value for the selected slices, computed in float32
+        # from the original weight before any in-place modification.
+        x_sel = a * torch.gather(x, select_dim, idx_exp).float() + neg_lr * u.float()
+        # Weight decay for the unselected entries (single rounding); the selected
+        # slices are overwritten with the fused value below.
+        x.mul_(a)
+        x.scatter_(dim=select_dim, index=idx_exp, src=x_sel.to(x.dtype))
+
+
 # A helper function to print selection choice for each matrix
 # It only prints once `verbose` is set True
 _printed_configs: set = set()

--- a/dion/dion2_triton.py
+++ b/dion/dion2_triton.py
@@ -167,15 +167,18 @@ def dion2_post_orthogonalize_triton(
     # wrapper subclasses (e.g. the quantized-weight wrappers used by MXFP8 training,
     # or DTensor) hold their data in wrapped inner tensors and do not expose such a
     # buffer at data_ptr(), so a raw write corrupts memory and triggers an illegal
-    # memory access. Fall back to the eager implementation, which routes through
-    # __torch_dispatch__ and updates the wrapped weight correctly. Plain dense
+    # memory access. Fall back to dion2_post_orthogonalize_fused, which routes
+    # through __torch_dispatch__ and updates the wrapped weight correctly while
+    # preserving the kernel's single-rounding numerics (computes a*x - b*u in
+    # float32 for the selected slices and writes once); the plain eager
+    # dion2_post_orthogonalize would round the selected slices twice. Plain dense
     # subclasses such as nn.Parameter are not wrapper subclasses and stay on the
     # kernel, so the single-GPU/DDP path (where params are not converted by
     # to_local) keeps the fast path.
     if any(is_traceable_wrapper_subclass(x) for x in X):
-        from .dion2 import dion2_post_orthogonalize
+        from .dion2 import dion2_post_orthogonalize_fused
 
-        dion2_post_orthogonalize(
+        dion2_post_orthogonalize_fused(
             X, U, indices, base_lr, adjusted_lr, weight_decay, select_dim
         )
         return

--- a/tests/test_dion2_post_ortho_triton.py
+++ b/tests/test_dion2_post_ortho_triton.py
@@ -20,7 +20,7 @@ from torch.utils._python_dispatch import (
 )
 from torch.utils._pytree import tree_map
 
-from dion.dion2 import dion2_post_orthogonalize
+from dion.dion2 import dion2_post_orthogonalize, dion2_post_orthogonalize_fused
 from dion.dion2_triton import TRITON_AVAILABLE, dion2_post_orthogonalize_triton
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
@@ -133,16 +133,20 @@ class _MockWrapperTensor(torch.Tensor):
         return return_and_correct_aliasing(func, args, kwargs, out)
 
 
+@pytest.mark.parametrize("shape", [(64, 128), (4, 32, 128)])
 @pytest.mark.parametrize("select_dim", [-2, -1])
-def test_post_ortho_triton_falls_back_for_wrapper_subclass(select_dim):
-    M, N, k = 64, 128, 16
-    X, U, indices = _make_test_data((M, N), k, select_dim)
+@pytest.mark.parametrize("x_dtype", [torch.float32, torch.bfloat16])
+def test_post_ortho_triton_falls_back_for_wrapper_subclass(shape, select_dim, x_dtype):
+    k = 16
+    X, U, indices = _make_test_data(shape, k, select_dim, x_dtype=x_dtype)
     base_lr = torch.tensor(0.1, device=DEVICE)
     adjusted_lr = torch.tensor(0.05, device=DEVICE)
     weight_decay = torch.tensor(0.01, device=DEVICE)
 
+    # A wrapper subclass routes to the single-rounding dion2_post_orthogonalize_fused
+    # (dispatch-safe), not the raw kernel and not the two-rounding eager path.
     x_ref = X.clone()
-    dion2_post_orthogonalize(
+    dion2_post_orthogonalize_fused(
         [x_ref], [U], [indices], base_lr, adjusted_lr, weight_decay, select_dim
     )
 
@@ -152,7 +156,35 @@ def test_post_ortho_triton_falls_back_for_wrapper_subclass(select_dim):
     )
 
     assert type(x_sub) is _MockWrapperTensor
-    torch.testing.assert_close(x_sub._inner, x_ref, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(x_sub._inner, x_ref, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not TRITON_AND_CUDA, reason="CUDA and Triton required")
+@pytest.mark.parametrize("shape", [(64, 128), (4, 32, 128)])
+@pytest.mark.parametrize("select_dim", [-2, -1])
+def test_fused_eager_matches_kernel_single_rounding(shape, select_dim):
+    k = 16
+    X, U, indices = _make_test_data(shape, k, select_dim, x_dtype=torch.bfloat16)
+    base_lr = torch.tensor(0.1, device=DEVICE)
+    adjusted_lr = torch.tensor(0.05, device=DEVICE)
+    weight_decay = torch.tensor(0.01, device=DEVICE)
+    kwargs = dict(indices=[indices], base_lr=base_lr, adjusted_lr=adjusted_lr,
+                  weight_decay=weight_decay, select_dim=select_dim)
+
+    x_kernel = X.clone()
+    dion2_post_orthogonalize_triton(X=[x_kernel], U=[U.clone()], **kwargs)
+    x_fused = X.clone()
+    dion2_post_orthogonalize_fused(X=[x_fused], U=[U.clone()], **kwargs)
+    x_eager = X.clone()
+    dion2_post_orthogonalize(X=[x_eager], U=[U.clone()], **kwargs)
+
+    sel = _build_selected_mask(indices, select_dim, shape)
+    # The dispatch-safe fused path reproduces the kernel's single rounding:
+    # unselected entries are bit-identical, selected match within bf16 rounding.
+    torch.testing.assert_close(x_fused[~sel], x_kernel[~sel], rtol=0, atol=0)
+    torch.testing.assert_close(x_fused, x_kernel, rtol=5e-3, atol=5e-3)
+    # And it differs from the two-rounding eager path on the selected slices.
+    assert not torch.equal(x_fused[sel], x_eager[sel])
 
 
 def test_post_ortho_triton_keeps_kernel_for_nn_parameter():


### PR DESCRIPTION
Follow-up to #81 (fused Triton post-orthogonalize) and #84 (subclass fallback).

#84 fixed an illegal-memory-access crash by routing wrapper-subclass params (the MXFP8 training weight wrapper, DTensor) away from the raw-`data_ptr()` Triton kernel to the eager `dion2_post_orthogonalize`. But that eager path writes the weight-decayed weight and then accumulates the update in a **second pass** — two roundings on the selected rows/columns — whereas the kernel computes `a*x - b*u` in fp32 and writes **once**. So MXFP8 runs (which set `triton_post_ortho=true`, and whose params are wrapper subclasses) silently lost the kernel's single-rounding numerics.

### Change

`dion2_post_orthogonalize_fused`: gathers the selected slices, computes `(1 - base_lr*wd)*x - adjusted_lr*u` in float32, and writes them once (matching the kernel's single rounding); unselected entries get the weight decay in place. It uses only `__torch_dispatch__`-routed ops (`gather`, `mul_`, `scatter_`) — no raw `data_ptr()` writes — so it is subclass-safe and handles 3D batched params (per-row indices). The #84 wrapper-subclass fallback now routes here; plain dense tensors still take the Triton kernel.

### Why fp32 is not a regression (it's faster)

Single rounding requires a higher-than-storage intermediate — exactly what the Triton kernel already does. Only the `k` selected slices are materialized in fp32. The fused path is **one compiled kernel** vs the eager path's in-place `mul_` plus a per-parameter `scatter_add_` loop, so it is faster despite the fp32:

| post-ortho over full matrix set | eager (two-rounding) | fused (single-rounding) |
|---|---|---|
| 1b | 8.55 ms | 6.18 ms (**−28%**) |
| 4b | 35.8 ms | 26.4 ms (**−26%**) |

(single GPU, plain bf16 proxy; real MXFP8 adds dispatch + requantization overhead to both paths, but the fused path writes X once vs twice, so it should win by more.)

### Numerical benefit

The single-rounding update lowers selected-row update RMSE vs an fp32 reference by ~15% in bf16 (MXFP8 is coarser → larger).

### Tests

`test_post_ortho_triton_falls_back_for_wrapper_subclass` (2D+3D, fp32+bf16): subclass fallback matches `dion2_post_orthogonalize_fused` bit-exactly. `test_fused_eager_matches_kernel_single_rounding` (2D+3D): fused matches the Triton kernel — unselected bit-identical, selected within bf16 rounding — and differs from the two-rounding eager path on the selected slices.