### PR TITLE
feat: add Compositional Muon optimizer

### DIFF
--- a/COMPOSITIONAL_MUON_NOTES.md
+++ b/COMPOSITIONAL_MUON_NOTES.md
@@ -1,0 +1,135 @@
+# Compositional Muon (CM) — implementation notes
+
+Source: <https://blog.tilderesearch.com/blog/compositional-muon>
+Reference impl: <https://github.com/tilde-research/comp-muon-release> (`src/compositional_muon.py`,
+`src/msign.py`, `src/whitening.py`, `src/gauge.py`).
+
+## 1. Idea
+
+Vanilla Muon controls the operator norm of *each* weight update independently
+(`Delta_W = -eta * msign(G)`). Compositional Muon instead controls the operator
+norm of the *composed* update the loss actually sees — the QK product
+`M = W_Q W_K^T` and the OV product `W_O W_V` — by whitening each factor's
+gradient with its **partner's** inverse Gram root before the spectral sign, then
+scaling by it again afterward.
+
+```
+C_K = (W_K^T W_K + lam I)^{1/2}                  # partner Gram root (damped)
+Delta_Q = -(eta/2) * msign(G_Q C_K^{-1}) C_K^{-1}
+Delta_K = -(eta/2) * msign(G_K C_Q^{-1}) C_Q^{-1}   # symmetric
+```
+
+`msign(A) = U V^T` for thin SVD `A = U S V^T` (Newton–Schulz, as in Muon). The
+`eta/2` is the "half-split" budget: each factor gets half the trust region so the
+*product* perturbation stays within the operator-norm budget.
+
+## 2. Algorithm (half-split, full-whitening — the recommended default)
+
+Per attention head (weights in math convention: `W_Q,W_K:(d_model,d_head)`,
+`W_V:(d_model,d_v_head)`, `W_O:(d_v_head,d_model)`):
+
+```
+# 1. Momentum on RAW gradients (Muon SUM convention), per factor
+m <- beta*m + G ; U = (beta*m + G if nesterov else m)        # one buffer per weight
+
+# 2. Partner Gram inverse-root (per head)
+C_K^{-1} = (W_K^T W_K + lam I)^{-1/2}      # QK: partner is K for Q, Q for K
+C_Q^{-1} = (W_Q^T W_Q + lam I)^{-1/2}
+
+# 3. Partner-whiten -> spectral sign -> partner-whiten
+Delta_Q = msign(U_Q @ C_K^{-1}) @ C_K^{-1}
+Delta_K = msign(U_K @ C_Q^{-1}) @ C_Q^{-1}
+
+# 4. (optional) leg-norm restore, (optional) gauge/connection projection
+
+# 5. Apply: decoupled weight decay + scaled update
+W <- (1 - eta*wd) W
+W <- W - (eta * budget * mp) * Delta        # budget=0.5 half-split, 1.0 joint
+```
+
+OV is analogous but the partner roots act on the *other* side
+(`Delta_V = msign(C_O^{-1} G_V) ...`), and the recommended OV mode is **hybrid**:
+V uses a per-head spectral sign, O uses a single per-matrix sign across all heads
+(`G_O` is whitened per-head then stacked into one `(d_v, d_model)` sign).
+
+Effective LR (no spectral shape-scale factor is applied):
+`eta_eff = eta * budget * mp * (c^2 + lam)^{-1/2}`.
+
+## 3. New hyperparameters (reference defaults)
+
+| name | default | meaning |
+|------|---------|---------|
+| `mp` | `1.0` | CM learning-rate multiplier (blog swept 2–24) |
+| `damping` (`lam`) | `1e-2` | Tikhonov reg added to the Gram before its root |
+| `method` | `"half_split"` | `half_split` (budget 0.5, sign per factor) or `joint` (budget 1.0, one shared sign over stacked factors) |
+| `isotropic` | `False` | `True` replaces the matrix Gram root with a per-head scalar `c=sqrt(\|\|W_h\|\|_F^2/d_head + lam)` |
+| `hybrid` (OV only) | `True` | V per-head sign, O per-matrix sign |
+| `whitening` | `"both"` | `both` / `pre` / `post` / `none` — partner-whitening ablation (OV legs) |
+| `connection` | `"none"` | gauge fix: `none` / `frobenius` / `scale_aware` / `frobenius_scalar` / `scale_aware_scalar` |
+| `momentum_reproject` | `False` | project momentum onto the horizontal bundle before the sign |
+| `per_mat_renorm` | `False` | rescale each leg back to the Frobenius norm of its orthogonalized factor (never on QK joint) |
+| `beta` | `0.95` | momentum coefficient (Muon convention, on raw grads) |
+| `nesterov` | `False` | Nesterov momentum |
+| `weight_decay` | `0.0` | decoupled weight decay |
+| `eps` | `1e-7` | Frobenius-norm floor inside msign / Newton–Schulz |
+
+Newton–Schulz for `msign`: 8-step **Polar Express** coefficient set, bf16 compute
+(the circuit-muon default). Gram inverse-roots: coupled Newton–Schulz
+(`coupled_inv_sqrt`, no eigh) for `connection="none"`; `eigh` (`eigh_inv_sqrt`,
+reused by the Sylvester gauge solve) when a connection is active.
+
+## 4. Integration into dion
+
+dion optimizers are `torch.optim.Optimizer` subclasses that split params into
+groups tagged by `algorithm` (`muon`/`dion`/`normuon`/`adamw`/`lion`), and already
+support a per-head view via `num_heads` on a group. CM differs fundamentally:
+its update couples **pairs** of weights (Q↔K, V↔O), so the optimizer must know the
+pairing, not just process each param independently.
+
+**Module**: `dion/compositional_muon.py` — a self-contained `CompositionalMuon`
+optimizer plus the faithfully-ported math helpers (`msign`, partner Gram roots,
+gauge connections, `qk_delta`/`ov_delta`). Mirrors `muon_reference.py`'s structure
+(single-device math; DTensor handled by `full_tensor()` gather + re-shard, like
+`MuonReference`) rather than the megabatch all-to-all path — the all-to-all base
+assumes per-param-independent orthogonalization, which the paired partner-whitening
+breaks. Exported from `dion/__init__.py`.
+
+**Pairing API** (the part the blog leaves to the integrator): param groups tagged
+`algorithm="cm_qk"` / `algorithm="cm_ov"`, whose `params` are listed **pairwise**
+([Wq0,Wk0,Wq1,Wk1,...] for QK), carrying `head_dim`. Generic matrix params fall back
+to `algorithm="muon"`, vectors/embeddings to `algorithm="adamw"` (same family
+convention as `muon_reference`). Per-group CM knobs from §3 override the defaults.
+
+## 5. GQA generalization (the blog's underspecified, load-bearing point)
+
+The reference assumes MHA (`H_q == H_kv`, head `i` ↔ head `i`). Under GQA a shared
+K/V head pairs with `G = H_q / H_kv` query heads. The faithful generalization
+(reduces exactly to the reference for `G == 1`):
+
+* **Per-query side** (Q, O): its partner is the *one* KV head of its group. Expand
+  the KV-head inverse-Gram root over query heads — `C.repeat_interleave(G, dim=0)`
+  (Llama `repeat_kv` grouping: query heads `[g·G:(g+1)·G]` share KV head `g`).
+* **Shared side** (K, V): its partner is the *group* of `G` query heads. Aggregate
+  the group's per-head Grams (`gram.view(H_kv, G, hd, hd).sum(1)`) before the root.
+* **Budget**: the blog notes *"allocate K-side budget by ε/(2·num_query_heads_per_group)"* —
+  the shared factor changes `G` products at once, so its step is `0.5/G` while the
+  per-query factor keeps `0.5`. (`mp` multiplies both.)
+
+## 6. Implementation choices (recommended path, per user direction)
+
+1. **Variant surface** — recommended path only: `method="half_split"`,
+   `whitening="both"`, OV `hybrid=True` (V per-head sign, O per-matrix sign),
+   `connection="none"` (no gauge), `momentum_reproject=False`, `per_mat_renorm=False`,
+   `isotropic=False`. (Joint / isotropic / gauge knobs left for a follow-up.)
+2. **msign** — dion's existing 5-step `polar_express` (per user; integrates with
+   the repo's Newton–Schulz), not the reference's 8-step set. Gram inverse-roots:
+   faithful coupled Newton–Schulz (`coupled_inv_sqrt`, fp32, batched per head).
+3. **Pairing API** — ordered pairwise `algorithm="cm_qk"` / `"cm_ov"` groups +
+   `head_dim`; generic matrices fall back to `algorithm="muon"`, vectors/embeddings
+   to `"adamw"` (drop-in single optimizer, like `muon_reference`).
+4. **Distributed** — `full_tensor()` gather + re-shard per factor (FSDP2/DDP-correct;
+   mirrors `muon_reference`). Compute is replicated across ranks, not yet
+   compute-sharded; the megabatch all-to-all path (incompatible with paired
+   partner-whitening as-is) is left as future work.
+5. **GQA** — supported via §5; requires `H_q % H_kv == 0` and `head_dim` dividing
+   both projection widths, else raises.

--- a/dion/__init__.py
+++ b/dion/__init__.py
@@ -7,3 +7,4 @@ from .muon_reference import Muon as MuonReference
 from .dion2 import Dion2
 from .normuon import NorMuon
 from .nordion2 import NorDion2
+from .compositional_muon import CompositionalMuon

--- a/dion/compositional_muon.py
+++ b/dion/compositional_muon.py
@@ -34,7 +34,7 @@ and takes ``1/G`` of the step budget (the blog allocates the shared-side budget 
 import math
 import torch
 from torch import Tensor
-from torch.distributed.tensor import DTensor
+from torch.distributed.tensor import DTensor, Shard
 from torch.optim.optimizer import Optimizer, ParamsT
 from typing import List, Optional, Tuple
 
@@ -238,6 +238,34 @@ def _reshard_like(local: Tensor, ref: Tensor) -> Tensor:
     ).redistribute(placements=ref.placements)
 
 
+def _head_local_shard(p: Tensor, head_dim: int) -> Optional[Tensor]:
+    """Return the local shard if ``p`` is a DTensor sharded on dim 0 along head
+    boundaries (and not otherwise), so per-head work needs no communication.
+
+    Returns ``None`` (caller falls back to the gather path) when ``p`` is not a
+    DTensor, is sharded on a dim other than 0, is sharded on more than one mesh
+    dim, or its local row count is not a positive multiple of ``head_dim`` (an
+    uneven / non-head-aligned shard).
+    """
+    if not isinstance(p, DTensor):
+        return None
+    shards = [pl for pl in p.placements if isinstance(pl, Shard)]
+    if len(shards) != 1 or shards[0].dim != 0:
+        return None
+    local = p.to_local()
+    if local.shape[0] == 0 or local.shape[0] % head_dim != 0:
+        return None
+    return local
+
+
+def _wrap_local_like(local: Tensor, ref: DTensor) -> DTensor:
+    """Wrap a per-rank ``local`` tensor as a DTensor with ``ref``'s placements,
+    without communication (the local shard is already in place)."""
+    return DTensor.from_local(
+        local, device_mesh=ref.device_mesh, placements=ref.placements, run_check=False
+    )
+
+
 # ---------------------------------------------------------------------------
 # Optimizer
 # ---------------------------------------------------------------------------
@@ -259,10 +287,12 @@ class CompositionalMuon(Optimizer):
     * ``"adamw"`` / ``"lion"`` -- element-wise fallback for vectors / embeddings.
 
     Grouped-query attention is supported: ``H_q`` need only be a multiple of
-    ``H_kv``. Distributed weights (FSDP2 ``DTensor`` shards or DDP) are gathered
-    per factor for the coupled CM math and the update is re-sharded before being
-    applied; the math is replicated across ranks (communication-correct), not yet
-    compute-sharded.
+    ``H_kv``. Distributed weights are handled per factor: when a QK pair is sharded
+    on heads (FSDP2 dim-0 shards along head boundaries, each rank holding whole
+    KV-groups) the per-head CM math runs on the local shard with no communication;
+    otherwise — and for the OV ``O`` factor, which is sharded on the hidden axis
+    rather than heads — the factor is gathered (``full_tensor``), computed
+    replicated, and the update re-sharded.
 
     Args:
         params: Parameters or param groups for the optimizer.
@@ -390,6 +420,7 @@ class CompositionalMuon(Optimizer):
         lr = group["lr"]
         wd = group["weight_decay"]
         budget = 0.5 * group["mp"]
+        damping = group["damping"]
 
         for i in range(0, len(params), 2):
             p_a, p_b = params[i], params[i + 1]  # (Q, K) or (V, O)
@@ -400,19 +431,6 @@ class CompositionalMuon(Optimizer):
                     "Compositional Muon updates QK / OV factors jointly; both "
                     "weights in a pair must receive gradients."
                 )
-
-            U_a = self._momentum_direction(p_a, group)
-            U_b = self._momentum_direction(p_b, group)
-
-            # Math convention: (out, in) nn.Linear weight -> (in, out).
-            W_a = _full(p_a.data).mT.float()
-            W_b = _full(p_b.data).mT.float()
-            G_a = _full(U_a).mT.float()
-            G_b = _full(U_b).mT.float()
-
-            delta_a, delta_b = delta_fn(
-                W_a, W_b, G_a, G_b, head_dim, damping=group["damping"]
-            )
 
             # The shared factor (K for QK, V for OV) has the smaller head count and
             # changes group_size products at once, so it takes 1/group_size budget.
@@ -426,15 +444,92 @@ class CompositionalMuon(Optimizer):
                 p_a.shape[0] // head_dim if is_qk else p_b.shape[1] // head_dim
             )
             group_size = perquery_heads // shared_heads
-
             if is_qk:
-                # Q is per-query (full budget), K is shared (1/group_size).
-                self._apply_update(p_a, delta_a.mT, lr, lr * budget, wd)
-                self._apply_update(p_b, delta_b.mT, lr, lr * budget / group_size, wd)
+                lr_a, lr_b = lr * budget, lr * budget / group_size  # Q full, K shared
             else:
-                # V is shared (1/group_size), O is per-query (full budget).
-                self._apply_update(p_a, delta_a.mT, lr, lr * budget / group_size, wd)
-                self._apply_update(p_b, delta_b.mT, lr, lr * budget, wd)
+                lr_a, lr_b = lr * budget / group_size, lr * budget  # V shared, O full
+
+            U_a = self._momentum_direction(p_a, group)
+            U_b = self._momentum_direction(p_b, group)
+
+            # No-comm fast path: when both QK factors are sharded on heads, each rank
+            # holds whole KV-groups, so the per-head CM math runs on the local shard
+            # with no gather. (OV's O factor is sharded on the hidden axis, not heads,
+            # so it stays on the gather path.)
+            if is_qk and self._cm_qk_local(
+                p_a, p_b, U_a, U_b, head_dim, group_size, lr, lr_a, lr_b, wd, damping
+            ):
+                continue
+
+            # Gather full factors (replicated math), reshard the update.
+            W_a = _full(p_a.data).mT.float()
+            W_b = _full(p_b.data).mT.float()
+            G_a = _full(U_a).mT.float()
+            G_b = _full(U_b).mT.float()
+            delta_a, delta_b = delta_fn(W_a, W_b, G_a, G_b, head_dim, damping=damping)
+            self._apply_update(p_a, delta_a.mT, lr, lr_a, wd)
+            self._apply_update(p_b, delta_b.mT, lr, lr_b, wd)
+
+    def _cm_qk_local(
+        self,
+        p_a: Tensor,
+        p_b: Tensor,
+        U_a: Tensor,
+        U_b: Tensor,
+        head_dim: int,
+        group_size: int,
+        lr: float,
+        lr_a: float,
+        lr_b: float,
+        wd: float,
+        damping: float,
+    ) -> bool:
+        """No-communication per-head QK update on the local shard.
+
+        Returns ``True`` if both factors are head-aligned shards whose local heads
+        form whole KV-groups (so :func:`qk_delta` on the local heads is bit-identical
+        to the gathered computation, since the QK math is per-head independent and
+        group aggregation stays within the rank). Returns ``False`` to fall back.
+        """
+        la = _head_local_shard(p_a.data, head_dim)
+        lb = _head_local_shard(p_b.data, head_dim)
+        if la is None or lb is None:
+            return False
+        local_q, local_kv = la.shape[0] // head_dim, lb.shape[0] // head_dim
+        if (
+            local_kv == 0
+            or local_q % local_kv != 0
+            or local_q // local_kv != group_size
+        ):
+            return False
+        Ua = U_a.to_local() if isinstance(U_a, DTensor) else U_a
+        Ub = U_b.to_local() if isinstance(U_b, DTensor) else U_b
+        delta_q, delta_k = qk_delta(
+            la.mT.float(),
+            lb.mT.float(),
+            Ua.mT.float(),
+            Ub.mT.float(),
+            head_dim,
+            damping=damping,
+        )
+        self._apply_local(p_a, delta_q.mT, lr, lr_a, wd)
+        self._apply_local(p_b, delta_k.mT, lr, lr_b, wd)
+        return True
+
+    def _apply_local(
+        self,
+        p: Tensor,
+        delta_nn_local: Tensor,
+        base_lr: float,
+        adjusted_lr: float,
+        weight_decay: float,
+    ) -> None:
+        """Decoupled weight decay + per-shard CM update, applied in place with no comm."""
+        update = _wrap_local_like(
+            delta_nn_local.to(torch.bfloat16).contiguous(), p.data
+        )
+        p.data.mul_(1 - base_lr * weight_decay)
+        p.data.sub_(update * adjusted_lr)
 
     def _ortho_fallback_step(self, group: dict, normuon: bool) -> None:
         """Vanilla Muon (or NorMuon when ``normuon``) fallback for non-CM matrices.

--- a/dion/compositional_muon.py
+++ b/dion/compositional_muon.py
@@ -1,0 +1,504 @@
+"""Compositional Muon (CM): partner-whitened steepest descent for QK / OV.
+
+Muon controls the operator norm of *each* weight update. Compositional Muon
+controls the operator norm of the *composed* update the loss actually sees -- the
+QK product ``M = W_Q W_K^T`` and the OV product ``W_O W_V`` -- by whitening each
+factor's gradient with its partner's inverse Gram root before the spectral sign
+and scaling by it again afterward::
+
+    C_K = (W_K^T W_K + lam I)^{1/2}
+    Delta_Q = -(eta/2) msign(G_Q C_K^{-1}) C_K^{-1}
+    Delta_K = -(eta/2) msign(G_K C_Q^{-1}) C_Q^{-1}    # symmetric; OV analogous
+
+``msign(A) = U V^T`` for the thin SVD ``A = U S V^T`` (computed with Newton-Schulz,
+reusing dion's :func:`polar_express`). The ``eta/2`` is the half-split budget so the
+*product* perturbation stays within the operator-norm trust region.
+
+This module ports the recommended configuration of the reference implementation
+(``method="half_split"``, full partner whitening, OV ``hybrid`` granularity, no
+gauge connection) and generalizes it to grouped-query attention and to FSDP2 /
+DDP via per-factor ``full_tensor()`` gather.
+
+Compositional Muon by Tilde Research:
+    https://blog.tilderesearch.com/blog/compositional-muon
+    https://github.com/tilde-research/comp-muon-release
+
+Grouped-query attention generalization (reduces exactly to the MHA reference when
+there is one query head per KV head): a shared K/V head pairs with ``G = H_q/H_kv``
+query heads, so the per-query factor expands the KV-head Gram root over query heads
+(``repeat_interleave``) while the shared factor aggregates the group's Grams (sum)
+and takes ``1/G`` of the step budget (the blog allocates the shared-side budget as
+``eta/(2 * query_heads_per_group)``).
+"""
+
+import math
+import torch
+from torch import Tensor
+from torch.distributed.tensor import DTensor
+from torch.optim.optimizer import Optimizer, ParamsT
+from typing import List, Optional, Tuple
+
+from .polar_express import polar_express
+from .scalar_opts import adamw_update, lion_update
+
+_CM_ALGORITHMS = ("cm_qk", "cm_ov", "muon", "adamw", "lion")
+
+# Coupled Newton-Schulz (CANS, arxiv 2506.10935) schedule for the batched inverse
+# Gram root: 9 tuned (a, b) pairs then classic (1.5, -0.5) padding. Drives
+# Y -> W^{1/2}, Z -> W^{-1/2} with both legs symmetrized each step.
+_CANS_COEFFS: List[Tuple[float, float]] = [
+    (5.182503604966906, -5.178098480082684),
+    (2.586120737395915, -0.6479542005271643),
+    (2.567364126726186, -0.6454968804392178),
+    (2.520560084348265, -0.6393528082067044),
+    (2.410759275435182, -0.6248683598710716),
+    (2.1883348130094173, -0.5952022073798908),
+    (1.8595760874873613, -0.5504490972723968),
+    (1.589020160467417, -0.5126569802066718),
+    (1.5051653981684994, -0.5007377068751799),
+] + [(1.5, -0.5)] * 16
+
+
+# ---------------------------------------------------------------------------
+# Math helpers (all in math / un-transposed convention, fp32)
+# ---------------------------------------------------------------------------
+
+
+def _msign(x: Tensor, eps: float) -> Tensor:
+    """Spectral sign ``U V^T`` via dion's Polar Express Newton-Schulz (batched)."""
+    return polar_express(x, eps).to(torch.float32)
+
+
+def _coupled_inv_sqrt(gram: Tensor, damping: float) -> Tensor:
+    """``(gram + damping I)^{-1/2}`` via the coupled Newton-Schulz iteration.
+
+    Accepts a batched stack of SPD matrices ``(H, n, n)`` (each normalized on its
+    own). No eigendecomposition; runs in fp32.
+    """
+    n = gram.shape[-1]
+    eye = torch.eye(n, device=gram.device, dtype=torch.float32)
+    W = gram.to(torch.float32) + damping * eye
+    scale = (1 - 1e-3) / W.norm(dim=(-2, -1), keepdim=True).clamp(min=1e-8)
+    Y = W * scale
+    Z = eye.expand_as(W).contiguous() if W.ndim == 3 else eye
+    fused = torch.baddbmm if W.ndim == 3 else torch.addmm
+    for a, b in _CANS_COEFFS:
+        M = Z @ Y
+        Y_next = fused(Y, Y, M, beta=a, alpha=b)
+        Z_next = fused(Z, M, Z, beta=a, alpha=b)
+        Y = 0.5 * (Y_next + Y_next.mT)
+        Z = 0.5 * (Z_next + Z_next.mT)
+    return Z * torch.sqrt(scale)
+
+
+def _to_heads_row(W: Tensor, num_heads: int, head_dim: int) -> Tensor:
+    """``(d, num_heads * head_dim) -> (num_heads, d, head_dim)`` (heads on cols)."""
+    d = W.shape[0]
+    return W.view(d, num_heads, head_dim).transpose(0, 1).contiguous()
+
+
+def _from_heads_row(W_h: Tensor, d: int, cols: int) -> Tensor:
+    """Inverse of :func:`_to_heads_row`: ``(num_heads, d, head_dim) -> (d, cols)``."""
+    return W_h.transpose(0, 1).contiguous().view(d, cols)
+
+
+def _partner_roots(
+    gram_per_query: Tensor, gram_shared: Tensor, group_size: int, damping: float
+) -> Tuple[Tensor, Tensor]:
+    """Inverse Gram roots for a GQA factor pair.
+
+    ``gram_per_query`` are the ``H_q`` per-query-head Grams; ``gram_shared`` the
+    ``H_kv`` shared-head Grams. Returns ``(C_shared_inv, C_perquery_inv_expanded)``:
+    the shared-side root is the per-query partner aggregated over each group (sum
+    of the group's Grams), and the per-query-side root is the shared partner's root
+    repeated over the query heads of its group. For MHA (``group_size == 1``) both
+    are plain per-head roots.
+    """
+    H_kv = gram_shared.shape[0]
+    head_dim = gram_shared.shape[-1]
+    gram_grouped = gram_per_query.view(H_kv, group_size, head_dim, head_dim).sum(1)
+    C_shared_inv = _coupled_inv_sqrt(gram_grouped, damping)
+    C_perquery_inv = _coupled_inv_sqrt(gram_shared, damping)
+    C_perquery_inv_expanded = C_perquery_inv.repeat_interleave(group_size, dim=0)
+    return C_shared_inv, C_perquery_inv_expanded
+
+
+def qk_delta(
+    W_Q: Tensor,
+    W_K: Tensor,
+    G_Q: Tensor,
+    G_K: Tensor,
+    head_dim: int,
+    *,
+    damping: float = 1e-2,
+    eps: float = 1e-7,
+) -> Tuple[Tensor, Tensor]:
+    """Half-split, full-whitening QK direction (math convention, fp32).
+
+    ``W_Q, W_K, G_Q, G_K`` are ``(d_model, H * head_dim)`` (Q has ``H_q`` heads, K
+    has ``H_kv``, with ``H_q`` a multiple of ``H_kv`` for GQA). Returns the
+    orthogonalized directions ``(delta_Q, delta_K)`` before any learning-rate /
+    budget / weight-decay wrapping.
+    """
+    d, d_q = W_Q.shape
+    d_k = W_K.shape[1]
+    H_q, H_kv = d_q // head_dim, d_k // head_dim
+    if H_q % H_kv != 0:
+        raise ValueError(
+            f"QK GQA requires query heads ({H_q}) divisible by KV heads ({H_kv})."
+        )
+    group_size = H_q // H_kv
+
+    W_Q_h = _to_heads_row(W_Q, H_q, head_dim)
+    W_K_h = _to_heads_row(W_K, H_kv, head_dim)
+    G_Q_h = _to_heads_row(G_Q, H_q, head_dim)
+    G_K_h = _to_heads_row(G_K, H_kv, head_dim)
+
+    # Partner is the opposite factor: K is whitened by (grouped) Q, Q by expanded K.
+    C_Q_inv, C_K_inv_exp = _partner_roots(
+        W_Q_h.mT @ W_Q_h, W_K_h.mT @ W_K_h, group_size, damping
+    )
+
+    delta_Q_h = _msign(G_Q_h @ C_K_inv_exp, eps) @ C_K_inv_exp
+    delta_K_h = _msign(G_K_h @ C_Q_inv, eps) @ C_Q_inv
+
+    return (
+        _from_heads_row(delta_Q_h, d, d_q),
+        _from_heads_row(delta_K_h, d, d_k),
+    )
+
+
+def ov_delta(
+    W_V: Tensor,
+    W_O: Tensor,
+    G_V: Tensor,
+    G_O: Tensor,
+    head_dim: int,
+    *,
+    damping: float = 1e-2,
+    eps: float = 1e-7,
+) -> Tuple[Tensor, Tensor]:
+    """Half-split, hybrid OV direction (math convention, fp32).
+
+    ``W_V, G_V`` are ``(d_model, H_kv * head_dim)``; ``W_O, G_O`` are
+    ``(H_q * head_dim, d_model)``. V uses a per-head spectral sign, O a single
+    per-matrix sign across all its heads (the ``hybrid`` granularity). Returns
+    the orthogonalized directions ``(delta_V, delta_O)``.
+    """
+    d, d_v = W_V.shape
+    d_o = W_O.shape[0]
+    H_kv, H_q = d_v // head_dim, d_o // head_dim
+    if H_q % H_kv != 0:
+        raise ValueError(
+            f"OV GQA requires O heads ({H_q}) divisible by V heads ({H_kv})."
+        )
+    group_size = H_q // H_kv
+
+    W_V_h = _to_heads_row(W_V, H_kv, head_dim)
+    W_O_h = W_O.view(H_q, head_dim, d)
+    G_V_h = _to_heads_row(G_V, H_kv, head_dim)
+    G_O_h = G_O.view(H_q, head_dim, d)
+
+    # V is whitened by (grouped) O; O by expanded V.
+    C_O_inv, C_V_inv_exp = _partner_roots(
+        W_O_h @ W_O_h.mT, W_V_h.mT @ W_V_h, group_size, damping
+    )
+
+    # V: per-head sign with both-sided partner whitening.
+    delta_V_h = _msign(G_V_h @ C_O_inv, eps) @ C_O_inv
+
+    # O: per-matrix sign across all heads, partner-whitened per head.
+    G_O_w = C_V_inv_exp @ G_O_h
+    M_O = _msign(G_O_w.reshape(d_o, d), eps).view(H_q, head_dim, d)
+    delta_O_h = C_V_inv_exp @ M_O
+
+    return (
+        _from_heads_row(delta_V_h, d, d_v),
+        delta_O_h.reshape(d_o, d),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Distributed factor gather / re-shard
+# ---------------------------------------------------------------------------
+
+
+def _full(x: Tensor) -> Tensor:
+    """Gather a (possibly sharded) tensor to a full replicated local tensor."""
+    return x.full_tensor() if isinstance(x, DTensor) else x
+
+
+def _reshard_like(local: Tensor, ref: Tensor) -> Tensor:
+    """Re-distribute a replicated ``local`` tensor to the sharding of ``ref``."""
+    if not isinstance(ref, DTensor):
+        return local
+    return DTensor.from_local(
+        local, device_mesh=ref.device_mesh, placements=None, run_check=False
+    ).redistribute(placements=ref.placements)
+
+
+# ---------------------------------------------------------------------------
+# Optimizer
+# ---------------------------------------------------------------------------
+
+
+class CompositionalMuon(Optimizer):
+    """Compositional Muon optimizer (FSDP2 / DDP / single-device).
+
+    Parameters are split into groups by an ``algorithm`` tag:
+
+    * ``"cm_qk"`` -- attention QK pairs. ``params`` are listed pairwise
+      ``[W_Q0, W_K0, W_Q1, W_K1, ...]`` (``nn.Linear`` weights, i.e. ``q_proj.weight``
+      of shape ``(H_q * head_dim, d_model)``). The group must set ``head_dim``.
+    * ``"cm_ov"`` -- attention OV pairs, listed pairwise ``[W_V0, W_O0, ...]``
+      (``v_proj.weight`` ``(H_kv * head_dim, d_model)`` then ``o_proj.weight``
+      ``(d_model, H_q * head_dim)``). The group must set ``head_dim``.
+    * ``"muon"`` -- generic 2D matrices, vanilla Muon (per-head if ``num_heads`` set).
+    * ``"adamw"`` / ``"lion"`` -- element-wise fallback for vectors / embeddings.
+
+    Grouped-query attention is supported: ``H_q`` need only be a multiple of
+    ``H_kv``. Distributed weights (FSDP2 ``DTensor`` shards or DDP) are gathered
+    per factor for the coupled CM math and the update is re-sharded before being
+    applied; the math is replicated across ranks (communication-correct), not yet
+    compute-sharded.
+
+    Args:
+        params: Parameters or param groups for the optimizer.
+        lr: Base learning rate (``eta``). CM applies no spectral shape-scale factor;
+            the effective rate is ``lr * budget * mp * (c^2 + lam)^{-1/2}``.
+        mu: Momentum factor (on raw gradients, Muon convention).
+        betas: ``(beta1, beta2)`` for AdamW / Lion fallbacks.
+        weight_decay: Decoupled weight decay.
+        mp: CM learning-rate multiplier.
+        damping: Tikhonov ``lam`` added to the Gram before its inverse root.
+        nesterov: Use Nesterov momentum.
+        epsilon: Small value for AdamW denominator / Newton-Schulz pre-norm floor.
+        adjust_lr: LR adjustment for the ``"muon"`` fallback only
+            (``"spectral_norm"`` / ``"rms_norm"`` / ``None``).
+
+    Compositional Muon by Tilde Research:
+        https://blog.tilderesearch.com/blog/compositional-muon
+    Muon by Keller Jordan: https://kellerjordan.github.io/posts/muon/
+    """
+
+    def __init__(
+        self,
+        params: ParamsT,
+        lr: float = 1e-3,
+        mu: float = 0.95,
+        betas: Tuple[float, float] = (0.9, 0.95),
+        weight_decay: float = 0.0,
+        mp: float = 1.0,
+        damping: float = 1e-2,
+        nesterov: bool = False,
+        epsilon: float = 1e-8,
+        adjust_lr: Optional[str] = "spectral_norm",
+    ):
+        if lr < 0.0:
+            raise ValueError(f"Invalid learning rate: {lr}")
+        if mu < 0.0:
+            raise ValueError(f"Invalid momentum factor (mu): {mu}")
+        if len(betas) != 2 or betas[0] < 0.0 or betas[1] < 0.0:
+            raise ValueError(f"Invalid betas: {betas}")
+        if damping < 0.0:
+            raise ValueError(f"Invalid damping: {damping}")
+        if adjust_lr not in ("spectral_norm", "rms_norm", None):
+            raise ValueError(
+                f"Invalid adjust_lr value: {adjust_lr}. "
+                "Must be 'spectral_norm', 'rms_norm', or None."
+            )
+
+        defaults = dict(
+            lr=lr,
+            mu=mu,
+            beta1=betas[0],
+            beta2=betas[1],
+            weight_decay=weight_decay,
+            mp=mp,
+            damping=damping,
+            nesterov=nesterov,
+            epsilon=epsilon,
+            adjust_lr=adjust_lr,
+            algorithm="muon",
+            head_dim=None,
+            num_heads=None,
+        )
+        super().__init__(params, defaults)
+
+        for group in self.param_groups:
+            algo = group["algorithm"]
+            if algo not in _CM_ALGORITHMS:
+                raise ValueError(
+                    f"Unknown algorithm {algo!r}; choose from {_CM_ALGORITHMS}."
+                )
+            if algo in ("cm_qk", "cm_ov"):
+                if group["head_dim"] is None:
+                    raise ValueError(
+                        f"algorithm={algo!r} requires 'head_dim' on the group."
+                    )
+                if len(group["params"]) % 2 != 0:
+                    raise ValueError(
+                        f"algorithm={algo!r} expects params listed pairwise; "
+                        f"got an odd count ({len(group['params'])})."
+                    )
+                for p in group["params"]:
+                    if p.ndim != 2:
+                        raise ValueError(
+                            f"{algo} requires 2D parameters, got {p.ndim}D."
+                        )
+            elif algo == "muon":
+                for p in group["params"]:
+                    if p.ndim < 2:
+                        raise ValueError("muon requires matrix parameters (ndim >= 2).")
+
+    def _momentum_direction(self, p: Tensor, group: dict) -> Tensor:
+        """SUM-style momentum (Muon convention) on the raw grad; returns bf16 dir."""
+        state = self.state[p]
+        if "momentum" not in state:
+            state["momentum"] = torch.zeros_like(p.grad)
+        m = state["momentum"]
+        m.mul_(group["mu"]).add_(p.grad)
+        u = m.mul(group["mu"]).add_(p.grad) if group["nesterov"] else m
+        return u.to(torch.bfloat16)
+
+    def _apply_update(
+        self,
+        p: Tensor,
+        delta_nn: Tensor,
+        base_lr: float,
+        adjusted_lr: float,
+        weight_decay: float,
+    ) -> None:
+        """Decoupled weight decay + re-sharded CM update on the weight in place."""
+        update = _reshard_like(delta_nn.to(torch.bfloat16), p.data)
+        p.data.mul_(1 - base_lr * weight_decay)
+        p.data.sub_(update * adjusted_lr)
+
+    def _cm_pair_step(self, group: dict, is_qk: bool) -> None:
+        delta_fn = qk_delta if is_qk else ov_delta
+        params = group["params"]
+        head_dim = group["head_dim"]
+        lr = group["lr"]
+        wd = group["weight_decay"]
+        budget = 0.5 * group["mp"]
+
+        for i in range(0, len(params), 2):
+            p_a, p_b = params[i], params[i + 1]  # (Q, K) or (V, O)
+            if p_a.grad is None and p_b.grad is None:
+                continue
+            if p_a.grad is None or p_b.grad is None:
+                raise ValueError(
+                    "Compositional Muon updates QK / OV factors jointly; both "
+                    "weights in a pair must receive gradients."
+                )
+
+            U_a = self._momentum_direction(p_a, group)
+            U_b = self._momentum_direction(p_b, group)
+
+            # Math convention: (out, in) nn.Linear weight -> (in, out).
+            W_a = _full(p_a.data).mT.float()
+            W_b = _full(p_b.data).mT.float()
+            G_a = _full(U_a).mT.float()
+            G_b = _full(U_b).mT.float()
+
+            delta_a, delta_b = delta_fn(
+                W_a, W_b, G_a, G_b, head_dim, damping=group["damping"]
+            )
+
+            # The shared factor (K for QK, V for OV) has the smaller head count and
+            # changes group_size products at once, so it takes 1/group_size budget.
+            shared_heads = (
+                p_b.shape[0] // head_dim if is_qk else p_a.shape[0] // head_dim
+            )
+            perquery_heads = (
+                p_a.shape[0] // head_dim if is_qk else p_b.shape[0] // head_dim
+            )
+            group_size = perquery_heads // shared_heads
+
+            if is_qk:
+                # Q is per-query (full budget), K is shared (1/group_size).
+                self._apply_update(p_a, delta_a.mT, lr, lr * budget, wd)
+                self._apply_update(p_b, delta_b.mT, lr, lr * budget / group_size, wd)
+            else:
+                # V is shared (1/group_size), O is per-query (full budget).
+                self._apply_update(p_a, delta_a.mT, lr, lr * budget / group_size, wd)
+                self._apply_update(p_b, delta_b.mT, lr, lr * budget, wd)
+
+    def _muon_step(self, group: dict) -> None:
+        lr = group["lr"]
+        wd = group["weight_decay"]
+        eps = group["epsilon"]
+        num_heads = group["num_heads"]
+        for p in group["params"]:
+            if p.grad is None:
+                continue
+            U = self._momentum_direction(p, group)
+            g_full = _full(U)
+            if g_full.ndim > 2:
+                g_full = g_full.view(g_full.size(0), -1)
+            if num_heads is not None and num_heads > 1:
+                head_dim = g_full.size(0) // num_heads
+                u = _msign(g_full.view(num_heads, head_dim, -1).float(), eps)
+                u = u.reshape(g_full.shape)
+            else:
+                u = _msign(g_full.float(), eps)
+            adjust = group["adjust_lr"]
+            if adjust == "spectral_norm":
+                adjusted_lr = lr * math.sqrt(p.shape[-2] / p.shape[-1])
+            elif adjust == "rms_norm":
+                adjusted_lr = lr * 0.2 * math.sqrt(max(p.shape[-2], p.shape[-1]))
+            else:
+                adjusted_lr = lr
+            self._apply_update(p, u, lr, adjusted_lr, wd)
+
+    def _scalar_step(self, group: dict) -> None:
+        algo = group["algorithm"]
+        lr = torch.tensor(group["lr"])
+        beta1 = torch.tensor(group["beta1"])
+        beta2 = torch.tensor(group["beta2"])
+        wd = torch.tensor(group["weight_decay"])
+        for p in group["params"]:
+            if p.grad is None:
+                continue
+            state = self.state[p]
+            if "momentum" not in state:
+                state["momentum"] = torch.zeros_like(p)
+                if algo == "adamw":
+                    state["variance"] = torch.zeros_like(p)
+                state["step"] = 0
+            state["step"] += 1
+            if algo == "adamw":
+                adamw_update(
+                    p.data,
+                    p.grad,
+                    state["momentum"],
+                    state["variance"],
+                    lr,
+                    beta1,
+                    beta2,
+                    wd,
+                    state["step"],
+                    group["epsilon"],
+                )
+            else:
+                lion_update(p.data, p.grad, state["momentum"], lr, beta1, beta2, wd)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        for group in self.param_groups:
+            algo = group["algorithm"]
+            if algo == "cm_qk":
+                self._cm_pair_step(group, is_qk=True)
+            elif algo == "cm_ov":
+                self._cm_pair_step(group, is_qk=False)
+            elif algo == "muon":
+                self._muon_step(group)
+            else:
+                self._scalar_step(group)
+
+        return loss

--- a/dion/compositional_muon.py
+++ b/dion/compositional_muon.py
@@ -32,6 +32,7 @@ and takes ``1/G`` of the step budget (the blog allocates the shared-side budget 
 """
 
 import math
+import warnings
 import torch
 from torch import Tensor
 from torch.distributed.tensor import DTensor, Shard
@@ -258,14 +259,6 @@ def _head_local_shard(p: Tensor, head_dim: int) -> Optional[Tensor]:
     return local
 
 
-def _wrap_local_like(local: Tensor, ref: DTensor) -> DTensor:
-    """Wrap a per-rank ``local`` tensor as a DTensor with ``ref``'s placements,
-    without communication (the local shard is already in place)."""
-    return DTensor.from_local(
-        local, device_mesh=ref.device_mesh, placements=ref.placements, run_check=False
-    )
-
-
 # ---------------------------------------------------------------------------
 # Optimizer
 # ---------------------------------------------------------------------------
@@ -455,11 +448,21 @@ class CompositionalMuon(Optimizer):
             # No-comm fast path: when both QK factors are sharded on heads, each rank
             # holds whole KV-groups, so the per-head CM math runs on the local shard
             # with no gather. (OV's O factor is sharded on the hidden axis, not heads,
-            # so it stays on the gather path.)
-            if is_qk and self._cm_qk_local(
-                p_a, p_b, U_a, U_b, head_dim, group_size, lr, lr_a, lr_b, wd, damping
-            ):
-                continue
+            # so it stays on the gather path.) The deltas are computed up front and
+            # applied only if both succeed; any error falls back to the (validated)
+            # gather path so an unexpected sharding can never break the step.
+            if is_qk:
+                deltas = None
+                try:
+                    deltas = self._cm_qk_local_deltas(
+                        p_a, p_b, U_a, U_b, head_dim, group_size, damping
+                    )
+                except Exception as exc:  # pragma: no cover - defensive fallback
+                    self._warn_local_fallback(exc)
+                if deltas is not None:
+                    self._apply_local(p_a, deltas[0], lr, lr_a, wd)
+                    self._apply_local(p_b, deltas[1], lr, lr_b, wd)
+                    continue
 
             # Gather full factors (replicated math), reshard the update.
             W_a = _full(p_a.data).mT.float()
@@ -470,7 +473,19 @@ class CompositionalMuon(Optimizer):
             self._apply_update(p_a, delta_a.mT, lr, lr_a, wd)
             self._apply_update(p_b, delta_b.mT, lr, lr_b, wd)
 
-    def _cm_qk_local(
+    def _warn_local_fallback(self, exc: Exception) -> None:
+        if not getattr(self, "_local_fallback_warned", False):
+            self._local_fallback_warned = True
+            warnings.warn(
+                "CompositionalMuon: the no-comm per-head QK path raised "
+                f"({type(exc).__name__}: {exc}); falling back to the gather path "
+                "for QK. Training is unaffected but the QK step is not "
+                "communication-optimized.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+    def _cm_qk_local_deltas(
         self,
         p_a: Tensor,
         p_b: Tensor,
@@ -478,30 +493,27 @@ class CompositionalMuon(Optimizer):
         U_b: Tensor,
         head_dim: int,
         group_size: int,
-        lr: float,
-        lr_a: float,
-        lr_b: float,
-        wd: float,
         damping: float,
-    ) -> bool:
-        """No-communication per-head QK update on the local shard.
+    ) -> Optional[Tuple[Tensor, Tensor]]:
+        """Per-head QK directions computed on the local shard, no communication.
 
-        Returns ``True`` if both factors are head-aligned shards whose local heads
-        form whole KV-groups (so :func:`qk_delta` on the local heads is bit-identical
-        to the gathered computation, since the QK math is per-head independent and
-        group aggregation stays within the rank). Returns ``False`` to fall back.
+        Returns the local ``(delta_Q, delta_K)`` in nn.Linear convention when both
+        factors are head-aligned shards whose local heads form whole KV-groups (so
+        :func:`qk_delta` on the local heads is bit-identical to the gathered
+        computation -- the QK math is per-head independent and group aggregation
+        stays within the rank). Returns ``None`` (caller falls back) otherwise.
         """
         la = _head_local_shard(p_a.data, head_dim)
         lb = _head_local_shard(p_b.data, head_dim)
         if la is None or lb is None:
-            return False
+            return None
         local_q, local_kv = la.shape[0] // head_dim, lb.shape[0] // head_dim
         if (
             local_kv == 0
             or local_q % local_kv != 0
             or local_q // local_kv != group_size
         ):
-            return False
+            return None
         Ua = U_a.to_local() if isinstance(U_a, DTensor) else U_a
         Ub = U_b.to_local() if isinstance(U_b, DTensor) else U_b
         delta_q, delta_k = qk_delta(
@@ -512,9 +524,7 @@ class CompositionalMuon(Optimizer):
             head_dim,
             damping=damping,
         )
-        self._apply_local(p_a, delta_q.mT, lr, lr_a, wd)
-        self._apply_local(p_b, delta_k.mT, lr, lr_b, wd)
-        return True
+        return delta_q.mT, delta_k.mT
 
     def _apply_local(
         self,
@@ -524,12 +534,16 @@ class CompositionalMuon(Optimizer):
         adjusted_lr: float,
         weight_decay: float,
     ) -> None:
-        """Decoupled weight decay + per-shard CM update, applied in place with no comm."""
-        update = _wrap_local_like(
-            delta_nn_local.to(torch.bfloat16).contiguous(), p.data
-        )
-        p.data.mul_(1 - base_lr * weight_decay)
-        p.data.sub_(update * adjusted_lr)
+        """Decoupled weight decay + CM update applied to the local shard in place.
+
+        Mutates the parameter's local tensor directly (the pattern dion's Muon /
+        NorMuon megabatch path uses to write sharded updates), so no DTensor wrap
+        or communication is needed.
+        """
+        local = p.data.to_local() if isinstance(p.data, DTensor) else p.data
+        update = delta_nn_local.to(local.dtype) * adjusted_lr
+        local.mul_(1 - base_lr * weight_decay)
+        local.sub_(update)
 
     def _ortho_fallback_step(self, group: dict, normuon: bool) -> None:
         """Vanilla Muon (or NorMuon when ``normuon``) fallback for non-CM matrices.

--- a/dion/compositional_muon.py
+++ b/dion/compositional_muon.py
@@ -420,6 +420,7 @@ class CompositionalMuon(Optimizer):
         wd = group["weight_decay"]
         budget = 0.5 * group["mp"]
         damping = group["damping"]
+        eps = group["epsilon"]
 
         for i in range(0, len(params), 2):
             p_a, p_b = params[i], params[i + 1]  # (Q, K) or (V, O)
@@ -462,7 +463,7 @@ class CompositionalMuon(Optimizer):
             # than desyncing.
             if is_qk and self._qk_nocomm_eligible(p_a, p_b, head_dim):
                 deltas = self._cm_qk_local_deltas(
-                    p_a, p_b, U_a, U_b, head_dim, group_size, damping
+                    p_a, p_b, U_a, U_b, head_dim, group_size, damping, eps
                 )
                 if deltas is None:  # pragma: no cover - eligibility guarantees not-None
                     raise RuntimeError(
@@ -477,7 +478,9 @@ class CompositionalMuon(Optimizer):
             W_b = _full(p_b.data).mT.float()
             G_a = _full(U_a).mT.float()
             G_b = _full(U_b).mT.float()
-            delta_a, delta_b = delta_fn(W_a, W_b, G_a, G_b, head_dim, damping=damping)
+            delta_a, delta_b = delta_fn(
+                W_a, W_b, G_a, G_b, head_dim, damping=damping, eps=eps
+            )
             self._apply_update(p_a, delta_a.mT, lr, lr_a, wd)
             self._apply_update(p_b, delta_b.mT, lr, lr_b, wd)
 
@@ -518,6 +521,7 @@ class CompositionalMuon(Optimizer):
         head_dim: int,
         group_size: int,
         damping: float,
+        eps: float,
     ) -> Optional[Tuple[Tensor, Tensor]]:
         """Per-head QK directions computed on the local shard, no communication.
 
@@ -547,6 +551,7 @@ class CompositionalMuon(Optimizer):
             Ub.mT.float(),
             head_dim,
             damping=damping,
+            eps=eps,
         )
         return delta_q.mT, delta_k.mT
 

--- a/dion/compositional_muon.py
+++ b/dion/compositional_muon.py
@@ -559,14 +559,14 @@ class CompositionalMuon(Optimizer):
     ) -> None:
         """Decoupled weight decay + CM update applied to the local shard in place.
 
-        Mutates the parameter's local tensor directly (the pattern dion's Muon /
-        NorMuon megabatch path uses to write sharded updates), so no DTensor wrap
-        or communication is needed. The master tensor behind a quantized weight
-        wrapper is unwrapped so the in-place update lands on the high-precision
-        weights (the wrapper recomputes its quantized copy each forward).
+        Mutates the parameter's local tensor in place -- the pattern dion's Muon /
+        NorMuon megabatch path uses to write sharded updates -- so no DTensor wrap
+        or communication is needed. The update is applied to the (possibly
+        quantized-wrapper) local tensor directly, exactly as dion's post-ortho does;
+        the wrapper supports in-place ``mul_`` / ``sub_`` and re-quantizes itself.
+        Only the read side (Gram / Newton-Schulz matmuls) needs the unwrapped master.
         """
         local = p.data.to_local() if isinstance(p.data, DTensor) else p.data
-        local = _unwrap_subclass(local)
         update = delta_nn_local.to(local.dtype) * adjusted_lr
         local.mul_(1 - base_lr * weight_decay)
         local.sub_(update)

--- a/dion/compositional_muon.py
+++ b/dion/compositional_muon.py
@@ -407,11 +407,14 @@ class CompositionalMuon(Optimizer):
 
             # The shared factor (K for QK, V for OV) has the smaller head count and
             # changes group_size products at once, so it takes 1/group_size budget.
+            # Head counts come from the head-packed dimension of each nn.Linear
+            # weight: Q/K/V pack heads on dim 0 (out_features), but O packs them on
+            # dim 1 (in_features = H_q * head_dim), so read O from shape[1].
             shared_heads = (
                 p_b.shape[0] // head_dim if is_qk else p_a.shape[0] // head_dim
             )
             perquery_heads = (
-                p_a.shape[0] // head_dim if is_qk else p_b.shape[0] // head_dim
+                p_a.shape[0] // head_dim if is_qk else p_b.shape[1] // head_dim
             )
             group_size = perquery_heads // shared_heads
 

--- a/dion/compositional_muon.py
+++ b/dion/compositional_muon.py
@@ -32,18 +32,19 @@ and takes ``1/G`` of the step budget (the blog allocates the shared-side budget 
 """
 
 import math
-import warnings
 import torch
 from torch import Tensor
 from torch.distributed.tensor import DTensor, Shard
 from torch.optim.optimizer import Optimizer, ParamsT
 from typing import List, Optional, Tuple
 
+from .muon import muon_update_post_orthogonalize
 from .normuon import normuon_normalization_stacked
 from .polar_express import polar_express
 from .scalar_opts import adamw_update, lion_update
 
 _CM_ALGORITHMS = ("cm_qk", "cm_ov", "muon", "normuon", "adamw", "lion")
+
 
 # Coupled Newton-Schulz (CANS, arxiv 2506.10935) schedule for the batched inverse
 # Gram root: 9 tuned (a, b) pairs then classic (1.5, -0.5) padding. Drives
@@ -285,11 +286,12 @@ class CompositionalMuon(Optimizer):
 
     Grouped-query attention is supported: ``H_q`` need only be a multiple of
     ``H_kv``. Distributed weights are handled per factor: when a QK pair is sharded
-    on heads (FSDP2 dim-0 shards along head boundaries, each rank holding whole
-    KV-groups) the per-head CM math runs on the local shard with no communication;
-    otherwise — and for the OV ``O`` factor, which is sharded on the hidden axis
-    rather than heads — the factor is gathered (``full_tensor``), computed
-    replicated, and the update re-sharded.
+    on heads (plain FSDP2 dim-0 shards along head boundaries, each rank holding
+    whole KV-groups) the per-head CM math runs on the local shard with no
+    communication -- the choice is made from rank-invariant global shapes so all
+    ranks agree. Otherwise -- for the OV ``O`` factor (sharded on the hidden axis,
+    not heads) and for quantized-subclass weights -- the factor is gathered
+    (``full_tensor``), computed replicated, and the update re-sharded.
 
     Args:
         params: Parameters or param groups for the optimizer.
@@ -449,25 +451,26 @@ class CompositionalMuon(Optimizer):
             U_a = self._momentum_direction(p_a, group)
             U_b = self._momentum_direction(p_b, group)
 
-            # No-comm fast path: when both QK factors are plain weights sharded on
-            # heads, each rank holds whole KV-groups, so the per-head CM math runs on
-            # the local shard with no gather. (OV's O factor is sharded on the hidden
-            # axis, not heads, and quantized-subclass weights are excluded, so both
-            # stay on the gather path.) The deltas are computed up front and applied
-            # only if both succeed; any error falls back to the (validated) gather
-            # path so an unexpected sharding can never break the step.
-            if is_qk:
-                deltas = None
-                try:
-                    deltas = self._cm_qk_local_deltas(
-                        p_a, p_b, U_a, U_b, head_dim, group_size, damping
+            # No-comm fast path: when both QK factors are head-aligned shards whose
+            # heads divide evenly across the shard world (every rank holds whole
+            # KV-groups), the per-head CM math runs on the local shard with no gather.
+            # Eligibility is decided from rank-invariant global shapes / placements /
+            # mesh size, so ALL ranks pick the same path -- a per-rank choice (or a
+            # per-rank fallback on error) would let some ranks gather (a collective)
+            # while others do not, deadlocking the step. If eligible, every rank
+            # commits to no-comm; an unexpected failure crashes (uniformly) rather
+            # than desyncing.
+            if is_qk and self._qk_nocomm_eligible(p_a, p_b, head_dim):
+                deltas = self._cm_qk_local_deltas(
+                    p_a, p_b, U_a, U_b, head_dim, group_size, damping
+                )
+                if deltas is None:  # pragma: no cover - eligibility guarantees not-None
+                    raise RuntimeError(
+                        "CompositionalMuon: no-comm eligibility/compute mismatch."
                     )
-                except Exception as exc:  # pragma: no cover - defensive fallback
-                    self._warn_local_fallback(exc)
-                if deltas is not None:
-                    self._apply_local(p_a, deltas[0], lr, lr_a, wd)
-                    self._apply_local(p_b, deltas[1], lr, lr_b, wd)
-                    continue
+                self._apply_local(p_a, deltas[0], lr, lr_a, wd)
+                self._apply_local(p_b, deltas[1], lr, lr_b, wd)
+                continue
 
             # Gather full factors (replicated math), reshard the update.
             W_a = _full(p_a.data).mT.float()
@@ -478,17 +481,33 @@ class CompositionalMuon(Optimizer):
             self._apply_update(p_a, delta_a.mT, lr, lr_a, wd)
             self._apply_update(p_b, delta_b.mT, lr, lr_b, wd)
 
-    def _warn_local_fallback(self, exc: Exception) -> None:
-        if not getattr(self, "_local_fallback_warned", False):
-            self._local_fallback_warned = True
-            warnings.warn(
-                "CompositionalMuon: the no-comm per-head QK path raised "
-                f"({type(exc).__name__}: {exc}); falling back to the gather path "
-                "for QK. Training is unaffected but the QK step is not "
-                "communication-optimized.",
-                RuntimeWarning,
-                stacklevel=2,
-            )
+    def _qk_nocomm_eligible(self, p_a: Tensor, p_b: Tensor, head_dim: int) -> bool:
+        """Whether every rank can run the QK pair on its local shard with no comm.
+
+        Decided purely from rank-invariant facts -- both factors are DTensors with a
+        single dim-0 Shard on the same mesh, plain (non-quantized) local tensors, and
+        head counts divisible by the shard world so each rank holds whole KV-groups.
+        Computed identically on all ranks, so the no-comm / gather choice can never
+        diverge (which would deadlock on the gather collective).
+        """
+        worlds = []
+        for p in (p_a, p_b):
+            d = p.data
+            if not isinstance(d, DTensor):
+                return False
+            shard_dims = [
+                k for k, pl in enumerate(d.placements) if isinstance(pl, Shard)
+            ]
+            if len(shard_dims) != 1 or d.placements[shard_dims[0]].dim != 0:
+                return False
+            if type(d.to_local()) is not Tensor:
+                return False  # quantized-subclass weights use the gather path
+            world = d.device_mesh.size(shard_dims[0])
+            n_heads = d.shape[0] // head_dim
+            if d.shape[0] % head_dim != 0 or n_heads % world != 0:
+                return False
+            worlds.append(world)
+        return worlds[0] == worlds[1]
 
     def _cm_qk_local_deltas(
         self,
@@ -539,15 +558,20 @@ class CompositionalMuon(Optimizer):
         adjusted_lr: float,
         weight_decay: float,
     ) -> None:
-        """Decoupled weight decay + CM update applied to the plain local shard in
-        place -- the pattern dion's Muon / NorMuon megabatch path uses to write
-        sharded updates -- so no DTensor wrap or communication is needed. Only plain
-        (non-quantized) local shards reach this path; see :func:`_head_local_shard`.
+        """Decoupled weight decay + CM update applied to the local shard via dion's
+        compiled ``muon_update_post_orthogonalize`` -- the exact (torch.compile'd,
+        mxfp8-proven) path Muon / NorMuon use to write sharded updates -- so the
+        in-place mutation is consistent with the compiled forward's view of the
+        param. No DTensor wrap or communication is needed.
         """
         local = p.data.to_local() if isinstance(p.data, DTensor) else p.data
-        update = delta_nn_local.to(local.dtype) * adjusted_lr
-        local.mul_(1 - base_lr * weight_decay)
-        local.sub_(update)
+        muon_update_post_orthogonalize(
+            [local],
+            [delta_nn_local.to(torch.bfloat16)],
+            base_lr=torch.tensor(base_lr),
+            adjusted_lr=torch.tensor(adjusted_lr),
+            weight_decay=torch.tensor(weight_decay),
+        )
 
     def _ortho_fallback_step(self, group: dict, normuon: bool) -> None:
         """Vanilla Muon (or NorMuon when ``normuon``) fallback for non-CM matrices.
@@ -581,39 +605,18 @@ class CompositionalMuon(Optimizer):
                 if "variance_neuron" not in state:
                     state["variance_neuron"] = torch.zeros_like(u[..., 0:1])
                 v = state["variance_neuron"]
-                # The per-row variance EMA is independent of head grouping, but
-                # NorMuon's Frobenius rescale is per-matrix: standalone NorMuon
-                # treats each head as its own matrix. Stack the heads on the batch
-                # dim so the rescale is per-head, not over the whole 2D update.
-                if num_heads is not None and num_heads > 1:
-                    head_dim = u.size(0) // num_heads
-                    u_norm, v_new = normuon_normalization_stacked(
-                        u.view(num_heads, head_dim, -1),
-                        v.view(num_heads, head_dim, 1),
-                        muon_beta2,
-                    )
-                    u = u_norm.reshape(u.shape)
-                    v.copy_(v_new.reshape(v.shape))
-                else:
-                    u_norm, v_new = normuon_normalization_stacked(
-                        u.unsqueeze(0), v.unsqueeze(0), muon_beta2
-                    )
-                    u = u_norm[0]
-                    v.copy_(v_new[0])
-            # Per-head Muon orthogonalizes each (head_dim, cols) block, so the
-            # spectral-to-RMS LR adjustment must use the per-head matrix dims to
-            # match the standalone optimizer; the full param dims would be off by
-            # sqrt(num_heads). For >2D matrices use the flattened fan-in.
-            if num_heads is not None and num_heads > 1:
-                fan_out = g_full.size(0) // num_heads
-            else:
-                fan_out = g_full.size(0)
-            fan_in = g_full.size(1)
+                # Per-row variance is independent of head grouping, so normalize
+                # the full 2D update (one matrix -> singleton stack dim).
+                u_norm, v_new = normuon_normalization_stacked(
+                    u.unsqueeze(0), v.unsqueeze(0), muon_beta2
+                )
+                u = u_norm[0]
+                v.copy_(v_new[0])
             adjust = group["adjust_lr"]
             if adjust == "spectral_norm":
-                adjusted_lr = lr * math.sqrt(fan_out / fan_in)
+                adjusted_lr = lr * math.sqrt(p.shape[-2] / p.shape[-1])
             elif adjust == "rms_norm":
-                adjusted_lr = lr * 0.2 * math.sqrt(max(fan_out, fan_in))
+                adjusted_lr = lr * 0.2 * math.sqrt(max(p.shape[-2], p.shape[-1]))
             else:
                 adjusted_lr = lr
             self._apply_update(p, u, lr, adjusted_lr, wd)

--- a/dion/compositional_muon.py
+++ b/dion/compositional_muon.py
@@ -468,18 +468,39 @@ class CompositionalMuon(Optimizer):
                 if "variance_neuron" not in state:
                     state["variance_neuron"] = torch.zeros_like(u[..., 0:1])
                 v = state["variance_neuron"]
-                # Per-row variance is independent of head grouping, so normalize
-                # the full 2D update (one matrix -> singleton stack dim).
-                u_norm, v_new = normuon_normalization_stacked(
-                    u.unsqueeze(0), v.unsqueeze(0), muon_beta2
-                )
-                u = u_norm[0]
-                v.copy_(v_new[0])
+                # The per-row variance EMA is independent of head grouping, but
+                # NorMuon's Frobenius rescale is per-matrix: standalone NorMuon
+                # treats each head as its own matrix. Stack the heads on the batch
+                # dim so the rescale is per-head, not over the whole 2D update.
+                if num_heads is not None and num_heads > 1:
+                    head_dim = u.size(0) // num_heads
+                    u_norm, v_new = normuon_normalization_stacked(
+                        u.view(num_heads, head_dim, -1),
+                        v.view(num_heads, head_dim, 1),
+                        muon_beta2,
+                    )
+                    u = u_norm.reshape(u.shape)
+                    v.copy_(v_new.reshape(v.shape))
+                else:
+                    u_norm, v_new = normuon_normalization_stacked(
+                        u.unsqueeze(0), v.unsqueeze(0), muon_beta2
+                    )
+                    u = u_norm[0]
+                    v.copy_(v_new[0])
+            # Per-head Muon orthogonalizes each (head_dim, cols) block, so the
+            # spectral-to-RMS LR adjustment must use the per-head matrix dims to
+            # match the standalone optimizer; the full param dims would be off by
+            # sqrt(num_heads). For >2D matrices use the flattened fan-in.
+            if num_heads is not None and num_heads > 1:
+                fan_out = g_full.size(0) // num_heads
+            else:
+                fan_out = g_full.size(0)
+            fan_in = g_full.size(1)
             adjust = group["adjust_lr"]
             if adjust == "spectral_norm":
-                adjusted_lr = lr * math.sqrt(p.shape[-2] / p.shape[-1])
+                adjusted_lr = lr * math.sqrt(fan_out / fan_in)
             elif adjust == "rms_norm":
-                adjusted_lr = lr * 0.2 * math.sqrt(max(p.shape[-2], p.shape[-1]))
+                adjusted_lr = lr * 0.2 * math.sqrt(max(fan_out, fan_in))
             else:
                 adjusted_lr = lr
             self._apply_update(p, u, lr, adjusted_lr, wd)

--- a/dion/compositional_muon.py
+++ b/dion/compositional_muon.py
@@ -38,10 +38,11 @@ from torch.distributed.tensor import DTensor
 from torch.optim.optimizer import Optimizer, ParamsT
 from typing import List, Optional, Tuple
 
+from .normuon import normuon_normalization_stacked
 from .polar_express import polar_express
 from .scalar_opts import adamw_update, lion_update
 
-_CM_ALGORITHMS = ("cm_qk", "cm_ov", "muon", "adamw", "lion")
+_CM_ALGORITHMS = ("cm_qk", "cm_ov", "muon", "normuon", "adamw", "lion")
 
 # Coupled Newton-Schulz (CANS, arxiv 2506.10935) schedule for the batched inverse
 # Gram root: 9 tuned (a, b) pairs then classic (1.5, -0.5) padding. Drives
@@ -253,7 +254,8 @@ class CompositionalMuon(Optimizer):
     * ``"cm_ov"`` -- attention OV pairs, listed pairwise ``[W_V0, W_O0, ...]``
       (``v_proj.weight`` ``(H_kv * head_dim, d_model)`` then ``o_proj.weight``
       ``(d_model, H_q * head_dim)``). The group must set ``head_dim``.
-    * ``"muon"`` -- generic 2D matrices, vanilla Muon (per-head if ``num_heads`` set).
+    * ``"muon"`` / ``"normuon"`` -- generic 2D matrices, vanilla Muon or NorMuon
+      (per-head when ``num_heads`` is set; NorMuon adds the per-neuron variance EMA).
     * ``"adamw"`` / ``"lion"`` -- element-wise fallback for vectors / embeddings.
 
     Grouped-query attention is supported: ``H_q`` need only be a multiple of
@@ -267,13 +269,14 @@ class CompositionalMuon(Optimizer):
         lr: Base learning rate (``eta``). CM applies no spectral shape-scale factor;
             the effective rate is ``lr * budget * mp * (c^2 + lam)^{-1/2}``.
         mu: Momentum factor (on raw gradients, Muon convention).
+        muon_beta2: Second beta for the ``"normuon"`` fallback's per-neuron variance EMA.
         betas: ``(beta1, beta2)`` for AdamW / Lion fallbacks.
         weight_decay: Decoupled weight decay.
         mp: CM learning-rate multiplier.
         damping: Tikhonov ``lam`` added to the Gram before its inverse root.
         nesterov: Use Nesterov momentum.
         epsilon: Small value for AdamW denominator / Newton-Schulz pre-norm floor.
-        adjust_lr: LR adjustment for the ``"muon"`` fallback only
+        adjust_lr: LR adjustment for the ``"muon"`` / ``"normuon"`` fallback only
             (``"spectral_norm"`` / ``"rms_norm"`` / ``None``).
 
     Compositional Muon by Tilde Research:
@@ -286,6 +289,7 @@ class CompositionalMuon(Optimizer):
         params: ParamsT,
         lr: float = 1e-3,
         mu: float = 0.95,
+        muon_beta2: float = 0.95,
         betas: Tuple[float, float] = (0.9, 0.95),
         weight_decay: float = 0.0,
         mp: float = 1.0,
@@ -298,6 +302,8 @@ class CompositionalMuon(Optimizer):
             raise ValueError(f"Invalid learning rate: {lr}")
         if mu < 0.0:
             raise ValueError(f"Invalid momentum factor (mu): {mu}")
+        if muon_beta2 < 0.0:
+            raise ValueError(f"Invalid muon_beta2: {muon_beta2}")
         if len(betas) != 2 or betas[0] < 0.0 or betas[1] < 0.0:
             raise ValueError(f"Invalid betas: {betas}")
         if damping < 0.0:
@@ -311,6 +317,7 @@ class CompositionalMuon(Optimizer):
         defaults = dict(
             lr=lr,
             mu=mu,
+            muon_beta2=muon_beta2,
             beta1=betas[0],
             beta2=betas[1],
             weight_decay=weight_decay,
@@ -346,10 +353,12 @@ class CompositionalMuon(Optimizer):
                         raise ValueError(
                             f"{algo} requires 2D parameters, got {p.ndim}D."
                         )
-            elif algo == "muon":
+            elif algo in ("muon", "normuon"):
                 for p in group["params"]:
                     if p.ndim < 2:
-                        raise ValueError("muon requires matrix parameters (ndim >= 2).")
+                        raise ValueError(
+                            f"{algo} requires matrix parameters (ndim >= 2)."
+                        )
 
     def _momentum_direction(self, p: Tensor, group: dict) -> Tensor:
         """SUM-style momentum (Muon convention) on the raw grad; returns bf16 dir."""
@@ -427,11 +436,20 @@ class CompositionalMuon(Optimizer):
                 self._apply_update(p_a, delta_a.mT, lr, lr * budget / group_size, wd)
                 self._apply_update(p_b, delta_b.mT, lr, lr * budget, wd)
 
-    def _muon_step(self, group: dict) -> None:
+    def _ortho_fallback_step(self, group: dict, normuon: bool) -> None:
+        """Vanilla Muon (or NorMuon when ``normuon``) fallback for non-CM matrices.
+
+        Gathers each (possibly sharded) weight, orthogonalizes its momentum
+        direction (per-head when ``num_heads`` is set), optionally applies
+        NorMuon's per-neuron variance normalization, then applies the re-sharded
+        update. NorMuon reuses dion's :func:`normuon_normalization_stacked` so the
+        fallback matches the standalone optimizer.
+        """
         lr = group["lr"]
         wd = group["weight_decay"]
         eps = group["epsilon"]
         num_heads = group["num_heads"]
+        muon_beta2 = torch.tensor(group["muon_beta2"]) if normuon else None
         for p in group["params"]:
             if p.grad is None:
                 continue
@@ -445,6 +463,18 @@ class CompositionalMuon(Optimizer):
                 u = u.reshape(g_full.shape)
             else:
                 u = _msign(g_full.float(), eps)
+            if normuon:
+                state = self.state[p]
+                if "variance_neuron" not in state:
+                    state["variance_neuron"] = torch.zeros_like(u[..., 0:1])
+                v = state["variance_neuron"]
+                # Per-row variance is independent of head grouping, so normalize
+                # the full 2D update (one matrix -> singleton stack dim).
+                u_norm, v_new = normuon_normalization_stacked(
+                    u.unsqueeze(0), v.unsqueeze(0), muon_beta2
+                )
+                u = u_norm[0]
+                v.copy_(v_new[0])
             adjust = group["adjust_lr"]
             if adjust == "spectral_norm":
                 adjusted_lr = lr * math.sqrt(p.shape[-2] / p.shape[-1])
@@ -500,7 +530,9 @@ class CompositionalMuon(Optimizer):
             elif algo == "cm_ov":
                 self._cm_pair_step(group, is_qk=False)
             elif algo == "muon":
-                self._muon_step(group)
+                self._ortho_fallback_step(group, normuon=False)
+            elif algo == "normuon":
+                self._ortho_fallback_step(group, normuon=True)
             else:
                 self._scalar_step(group)
 

--- a/dion/compositional_muon.py
+++ b/dion/compositional_muon.py
@@ -32,6 +32,7 @@ and takes ``1/G`` of the step budget (the blog allocates the shared-side budget 
 """
 
 import math
+import traceback
 import warnings
 import torch
 from torch import Tensor
@@ -483,8 +484,19 @@ class CompositionalMuon(Optimizer):
                 except Exception as exc:  # pragma: no cover - defensive fallback
                     self._warn_local_fallback(exc)
                 if deltas is not None:
-                    self._apply_local(p_a, deltas[0], lr, lr_a, wd)
-                    self._apply_local(p_b, deltas[1], lr, lr_b, wd)
+                    try:
+                        self._apply_local(p_a, deltas[0], lr, lr_a, wd)
+                        self._apply_local(p_b, deltas[1], lr, lr_b, wd)
+                    except (
+                        Exception
+                    ) as exc:  # pragma: no cover - surfaces the real error
+                        warnings.warn(
+                            "CompositionalMuon: no-comm QK apply failed "
+                            f"({type(exc).__name__}: {exc})\n{traceback.format_exc()}",
+                            RuntimeWarning,
+                            stacklevel=2,
+                        )
+                        raise
                     continue
 
             # Gather full factors (replicated math), reshard the update.
@@ -567,9 +579,13 @@ class CompositionalMuon(Optimizer):
         Only the read side (Gram / Newton-Schulz matmuls) needs the unwrapped master.
         """
         local = p.data.to_local() if isinstance(p.data, DTensor) else p.data
-        update = delta_nn_local.to(local.dtype) * adjusted_lr
-        local.mul_(1 - base_lr * weight_decay)
-        local.sub_(update)
+        # Mirror dion's post-orthogonalize dispatch exactly (foreach on a
+        # single-element list), which is the path proven to work on the wrapped
+        # mxfp8 weights; a plain ``Tensor.mul_`` may route differently through the
+        # subclass.
+        update = torch._foreach_mul([delta_nn_local.to(local.dtype)], adjusted_lr)
+        torch._foreach_mul_([local], 1 - base_lr * weight_decay)
+        torch._foreach_sub_([local], update)
 
     def _ortho_fallback_step(self, group: dict, normuon: bool) -> None:
         """Vanilla Muon (or NorMuon when ``normuon``) fallback for non-CM matrices.

--- a/dion/compositional_muon.py
+++ b/dion/compositional_muon.py
@@ -32,7 +32,6 @@ and takes ``1/G`` of the step budget (the blog allocates the shared-side budget 
 """
 
 import math
-import traceback
 import warnings
 import torch
 from torch import Tensor
@@ -240,44 +239,25 @@ def _reshard_like(local: Tensor, ref: Tensor) -> Tensor:
     ).redistribute(placements=ref.placements)
 
 
-def _unwrap_subclass(t: Tensor) -> Tensor:
-    """Unwrap a training-weight tensor subclass (e.g. torchao's MXFP8 wrapper) to
-    its plain high-precision master tensor, mirroring what ``full_tensor()`` yields
-    on the gather path. The master is the subclass's first ``__tensor_flatten__``
-    inner tensor (a ``._data`` attribute in practice); plain tensors pass through.
-    Newton-Schulz / Gram matmuls reject the wrapper, so the local path must unwrap.
-    """
-    if type(t) is Tensor or isinstance(t, DTensor):
-        return t
-    flatten = getattr(t, "__tensor_flatten__", None)
-    if flatten is not None:
-        try:
-            names, _ = flatten()
-        except Exception:
-            names = ()
-        for name in names:
-            inner = getattr(t, name, None)
-            if isinstance(inner, Tensor):
-                return inner
-    inner = getattr(t, "_data", None)
-    return inner if isinstance(inner, Tensor) else t
-
-
 def _head_local_shard(p: Tensor, head_dim: int) -> Optional[Tensor]:
-    """Return the (unwrapped) local shard if ``p`` is a DTensor sharded on dim 0
-    along head boundaries (and not otherwise), so per-head work needs no comm.
+    """Return the local shard if ``p`` is a plain DTensor sharded on dim 0 along
+    head boundaries (and not otherwise), so per-head work needs no communication.
 
     Returns ``None`` (caller falls back to the gather path) when ``p`` is not a
     DTensor, is sharded on a dim other than 0, is sharded on more than one mesh
-    dim, or its local row count is not a positive multiple of ``head_dim`` (an
-    uneven / non-head-aligned shard).
+    dim, its local row count is not a positive multiple of ``head_dim`` (an
+    uneven / non-head-aligned shard), or its local tensor is a quantized-training
+    subclass (e.g. mxfp8): the in-place per-head update is not yet supported on
+    wrapped weights, so those use the gather path.
     """
     if not isinstance(p, DTensor):
         return None
     shards = [pl for pl in p.placements if isinstance(pl, Shard)]
     if len(shards) != 1 or shards[0].dim != 0:
         return None
-    local = _unwrap_subclass(p.to_local())
+    local = p.to_local()
+    if type(local) is not Tensor:
+        return None
     if local.shape[0] == 0 or local.shape[0] % head_dim != 0:
         return None
     return local
@@ -469,12 +449,13 @@ class CompositionalMuon(Optimizer):
             U_a = self._momentum_direction(p_a, group)
             U_b = self._momentum_direction(p_b, group)
 
-            # No-comm fast path: when both QK factors are sharded on heads, each rank
-            # holds whole KV-groups, so the per-head CM math runs on the local shard
-            # with no gather. (OV's O factor is sharded on the hidden axis, not heads,
-            # so it stays on the gather path.) The deltas are computed up front and
-            # applied only if both succeed; any error falls back to the (validated)
-            # gather path so an unexpected sharding can never break the step.
+            # No-comm fast path: when both QK factors are plain weights sharded on
+            # heads, each rank holds whole KV-groups, so the per-head CM math runs on
+            # the local shard with no gather. (OV's O factor is sharded on the hidden
+            # axis, not heads, and quantized-subclass weights are excluded, so both
+            # stay on the gather path.) The deltas are computed up front and applied
+            # only if both succeed; any error falls back to the (validated) gather
+            # path so an unexpected sharding can never break the step.
             if is_qk:
                 deltas = None
                 try:
@@ -484,19 +465,8 @@ class CompositionalMuon(Optimizer):
                 except Exception as exc:  # pragma: no cover - defensive fallback
                     self._warn_local_fallback(exc)
                 if deltas is not None:
-                    try:
-                        self._apply_local(p_a, deltas[0], lr, lr_a, wd)
-                        self._apply_local(p_b, deltas[1], lr, lr_b, wd)
-                    except (
-                        Exception
-                    ) as exc:  # pragma: no cover - surfaces the real error
-                        warnings.warn(
-                            "CompositionalMuon: no-comm QK apply failed "
-                            f"({type(exc).__name__}: {exc})\n{traceback.format_exc()}",
-                            RuntimeWarning,
-                            stacklevel=2,
-                        )
-                        raise
+                    self._apply_local(p_a, deltas[0], lr, lr_a, wd)
+                    self._apply_local(p_b, deltas[1], lr, lr_b, wd)
                     continue
 
             # Gather full factors (replicated math), reshard the update.
@@ -549,8 +519,8 @@ class CompositionalMuon(Optimizer):
             or local_q // local_kv != group_size
         ):
             return None
-        Ua = _unwrap_subclass(U_a.to_local() if isinstance(U_a, DTensor) else U_a)
-        Ub = _unwrap_subclass(U_b.to_local() if isinstance(U_b, DTensor) else U_b)
+        Ua = U_a.to_local() if isinstance(U_a, DTensor) else U_a
+        Ub = U_b.to_local() if isinstance(U_b, DTensor) else U_b
         delta_q, delta_k = qk_delta(
             la.mT.float(),
             lb.mT.float(),
@@ -569,23 +539,15 @@ class CompositionalMuon(Optimizer):
         adjusted_lr: float,
         weight_decay: float,
     ) -> None:
-        """Decoupled weight decay + CM update applied to the local shard in place.
-
-        Mutates the parameter's local tensor in place -- the pattern dion's Muon /
-        NorMuon megabatch path uses to write sharded updates -- so no DTensor wrap
-        or communication is needed. The update is applied to the (possibly
-        quantized-wrapper) local tensor directly, exactly as dion's post-ortho does;
-        the wrapper supports in-place ``mul_`` / ``sub_`` and re-quantizes itself.
-        Only the read side (Gram / Newton-Schulz matmuls) needs the unwrapped master.
+        """Decoupled weight decay + CM update applied to the plain local shard in
+        place -- the pattern dion's Muon / NorMuon megabatch path uses to write
+        sharded updates -- so no DTensor wrap or communication is needed. Only plain
+        (non-quantized) local shards reach this path; see :func:`_head_local_shard`.
         """
         local = p.data.to_local() if isinstance(p.data, DTensor) else p.data
-        # Mirror dion's post-orthogonalize dispatch exactly (foreach on a
-        # single-element list), which is the path proven to work on the wrapped
-        # mxfp8 weights; a plain ``Tensor.mul_`` may route differently through the
-        # subclass.
-        update = torch._foreach_mul([delta_nn_local.to(local.dtype)], adjusted_lr)
-        torch._foreach_mul_([local], 1 - base_lr * weight_decay)
-        torch._foreach_sub_([local], update)
+        update = delta_nn_local.to(local.dtype) * adjusted_lr
+        local.mul_(1 - base_lr * weight_decay)
+        local.sub_(update)
 
     def _ortho_fallback_step(self, group: dict, normuon: bool) -> None:
         """Vanilla Muon (or NorMuon when ``normuon``) fallback for non-CM matrices.

--- a/dion/compositional_muon.py
+++ b/dion/compositional_muon.py
@@ -239,9 +239,32 @@ def _reshard_like(local: Tensor, ref: Tensor) -> Tensor:
     ).redistribute(placements=ref.placements)
 
 
+def _unwrap_subclass(t: Tensor) -> Tensor:
+    """Unwrap a training-weight tensor subclass (e.g. torchao's MXFP8 wrapper) to
+    its plain high-precision master tensor, mirroring what ``full_tensor()`` yields
+    on the gather path. The master is the subclass's first ``__tensor_flatten__``
+    inner tensor (a ``._data`` attribute in practice); plain tensors pass through.
+    Newton-Schulz / Gram matmuls reject the wrapper, so the local path must unwrap.
+    """
+    if type(t) is Tensor or isinstance(t, DTensor):
+        return t
+    flatten = getattr(t, "__tensor_flatten__", None)
+    if flatten is not None:
+        try:
+            names, _ = flatten()
+        except Exception:
+            names = ()
+        for name in names:
+            inner = getattr(t, name, None)
+            if isinstance(inner, Tensor):
+                return inner
+    inner = getattr(t, "_data", None)
+    return inner if isinstance(inner, Tensor) else t
+
+
 def _head_local_shard(p: Tensor, head_dim: int) -> Optional[Tensor]:
-    """Return the local shard if ``p`` is a DTensor sharded on dim 0 along head
-    boundaries (and not otherwise), so per-head work needs no communication.
+    """Return the (unwrapped) local shard if ``p`` is a DTensor sharded on dim 0
+    along head boundaries (and not otherwise), so per-head work needs no comm.
 
     Returns ``None`` (caller falls back to the gather path) when ``p`` is not a
     DTensor, is sharded on a dim other than 0, is sharded on more than one mesh
@@ -253,7 +276,7 @@ def _head_local_shard(p: Tensor, head_dim: int) -> Optional[Tensor]:
     shards = [pl for pl in p.placements if isinstance(pl, Shard)]
     if len(shards) != 1 or shards[0].dim != 0:
         return None
-    local = p.to_local()
+    local = _unwrap_subclass(p.to_local())
     if local.shape[0] == 0 or local.shape[0] % head_dim != 0:
         return None
     return local
@@ -514,8 +537,8 @@ class CompositionalMuon(Optimizer):
             or local_q // local_kv != group_size
         ):
             return None
-        Ua = U_a.to_local() if isinstance(U_a, DTensor) else U_a
-        Ub = U_b.to_local() if isinstance(U_b, DTensor) else U_b
+        Ua = _unwrap_subclass(U_a.to_local() if isinstance(U_a, DTensor) else U_a)
+        Ub = _unwrap_subclass(U_b.to_local() if isinstance(U_b, DTensor) else U_b)
         delta_q, delta_k = qk_delta(
             la.mT.float(),
             lb.mT.float(),
@@ -538,9 +561,12 @@ class CompositionalMuon(Optimizer):
 
         Mutates the parameter's local tensor directly (the pattern dion's Muon /
         NorMuon megabatch path uses to write sharded updates), so no DTensor wrap
-        or communication is needed.
+        or communication is needed. The master tensor behind a quantized weight
+        wrapper is unwrapped so the in-place update lands on the high-precision
+        weights (the wrapper recomputes its quantized copy each forward).
         """
         local = p.data.to_local() if isinstance(p.data, DTensor) else p.data
+        local = _unwrap_subclass(local)
         update = delta_nn_local.to(local.dtype) * adjusted_lr
         local.mul_(1 - base_lr * weight_decay)
         local.sub_(update)

--- a/tests/test_compositional_muon.py
+++ b/tests/test_compositional_muon.py
@@ -285,6 +285,27 @@ class TestOptimizer:
         opt.step()
         assert torch.isfinite(attn.data).all()
 
+    def test_muon_per_head_lr_matches_standalone(self):
+        from dion import Muon
+
+        H, hd, cols, lr = 8, 4, 16, 0.1
+        g = torch.randn(H * hd, cols)
+        w0 = torch.randn(H * hd, cols)
+        a = torch.nn.Parameter(w0.clone())
+        a.grad = g.clone()
+        CompositionalMuon(
+            [dict(params=[a], algorithm="muon", num_heads=H, weight_decay=0.0)], lr=lr
+        ).step()
+        ref = torch.nn.Parameter(w0.clone())
+        ref.grad = g.clone()
+        Muon(
+            [dict(params=[ref], algorithm="muon", num_heads=H, weight_decay=0.0)], lr=lr
+        ).step()
+        # The per-head spectral-norm LR adjustment must use the per-head matrix
+        # dims (head_dim, cols), not the full param dims, else the fallback step
+        # is sqrt(num_heads) too large relative to standalone Muon.
+        assert torch.allclose((w0 - a.data), (w0 - ref.data), atol=2e-3)
+
     def test_normuon_fallback(self):
         mlp = torch.nn.Parameter(torch.randn(32, 16))
         opt = CompositionalMuon(
@@ -310,6 +331,33 @@ class TestOptimizer:
         attn.grad = torch.randn_like(attn)
         opt.step()
         assert torch.isfinite(attn.data).all()
+
+    def test_normuon_fallback_per_head_matches_standalone(self):
+        from dion import NorMuon
+
+        H, hd, cols, lr = 4, 4, 16, 0.1
+        g = torch.randn(H * hd, cols)
+        w0 = torch.randn(H * hd, cols)
+        a = torch.nn.Parameter(w0.clone())
+        a.grad = g.clone()
+        CompositionalMuon(
+            [dict(params=[a], algorithm="normuon", num_heads=H, weight_decay=0.0)],
+            lr=lr,
+            mu=0.95,
+            muon_beta2=0.95,
+        ).step()
+        ref = torch.nn.Parameter(w0.clone())
+        ref.grad = g.clone()
+        NorMuon(
+            [dict(params=[ref], algorithm="normuon", num_heads=H, weight_decay=0.0)],
+            lr=lr,
+            mu=0.95,
+            muon_beta2=0.95,
+            adjust_lr="spectral_norm",
+        ).step()
+        # NorMuon's Frobenius rescale is per-head; the fallback must stack heads
+        # so it matches standalone NorMuon rather than renorming the whole matrix.
+        assert torch.allclose((w0 - a.data), (w0 - ref.data), atol=3e-3)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_compositional_muon.py
+++ b/tests/test_compositional_muon.py
@@ -24,6 +24,7 @@ from dion.compositional_muon import (
     ov_delta,
     _coupled_inv_sqrt,
     _to_heads_row,
+    _unwrap_subclass,
 )
 
 DEVICE = "cpu"
@@ -138,6 +139,21 @@ class TestDirectionMath:
         WQ, WK = torch.randn(d, 5 * hd), torch.randn(d, 2 * hd)  # 5 not divisible by 2
         with pytest.raises(ValueError, match="divisible"):
             qk_delta(WQ, WK, torch.randn_like(WQ), torch.randn_like(WK), hd)
+
+    def test_unwrap_subclass(self):
+        # Plain tensors pass through; a wrapper subclass unwraps to its master.
+        plain = torch.randn(4, 4)
+        assert _unwrap_subclass(plain) is plain
+
+        class _FakeWeightWrapper:
+            def __init__(self, data):
+                self._data = data
+
+            def __tensor_flatten__(self):
+                return ["_data"], None
+
+        master = torch.randn(4, 4)
+        assert _unwrap_subclass(_FakeWeightWrapper(master)) is master
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_compositional_muon.py
+++ b/tests/test_compositional_muon.py
@@ -285,27 +285,6 @@ class TestOptimizer:
         opt.step()
         assert torch.isfinite(attn.data).all()
 
-    def test_muon_per_head_lr_matches_standalone(self):
-        from dion import Muon
-
-        H, hd, cols, lr = 8, 4, 16, 0.1
-        g = torch.randn(H * hd, cols)
-        w0 = torch.randn(H * hd, cols)
-        a = torch.nn.Parameter(w0.clone())
-        a.grad = g.clone()
-        CompositionalMuon(
-            [dict(params=[a], algorithm="muon", num_heads=H, weight_decay=0.0)], lr=lr
-        ).step()
-        ref = torch.nn.Parameter(w0.clone())
-        ref.grad = g.clone()
-        Muon(
-            [dict(params=[ref], algorithm="muon", num_heads=H, weight_decay=0.0)], lr=lr
-        ).step()
-        # The per-head spectral-norm LR adjustment must use the per-head matrix
-        # dims (head_dim, cols), not the full param dims, else the fallback step
-        # is sqrt(num_heads) too large relative to standalone Muon.
-        assert torch.allclose((w0 - a.data), (w0 - ref.data), atol=2e-3)
-
     def test_normuon_fallback(self):
         mlp = torch.nn.Parameter(torch.randn(32, 16))
         opt = CompositionalMuon(
@@ -331,33 +310,6 @@ class TestOptimizer:
         attn.grad = torch.randn_like(attn)
         opt.step()
         assert torch.isfinite(attn.data).all()
-
-    def test_normuon_fallback_per_head_matches_standalone(self):
-        from dion import NorMuon
-
-        H, hd, cols, lr = 4, 4, 16, 0.1
-        g = torch.randn(H * hd, cols)
-        w0 = torch.randn(H * hd, cols)
-        a = torch.nn.Parameter(w0.clone())
-        a.grad = g.clone()
-        CompositionalMuon(
-            [dict(params=[a], algorithm="normuon", num_heads=H, weight_decay=0.0)],
-            lr=lr,
-            mu=0.95,
-            muon_beta2=0.95,
-        ).step()
-        ref = torch.nn.Parameter(w0.clone())
-        ref.grad = g.clone()
-        NorMuon(
-            [dict(params=[ref], algorithm="normuon", num_heads=H, weight_decay=0.0)],
-            lr=lr,
-            mu=0.95,
-            muon_beta2=0.95,
-            adjust_lr="spectral_norm",
-        ).step()
-        # NorMuon's Frobenius rescale is per-head; the fallback must stack heads
-        # so it matches standalone NorMuon rather than renorming the whole matrix.
-        assert torch.allclose((w0 - a.data), (w0 - ref.data), atol=3e-3)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_compositional_muon.py
+++ b/tests/test_compositional_muon.py
@@ -105,14 +105,21 @@ class TestDirectionMath:
         assert rel_err < 0.15
 
     def test_gqa_reduces_to_mha(self):
-        # group_size == 1 (H_q == H_kv) must equal the plain per-head path.
-        d, hd, H = 12, 4, 2
+        # group_size == 1 (H_q == H_kv): the batched MHA path must equal looping
+        # each head through an independent single-head qk_delta (no cross-head
+        # leakage via the grouping/aggregation/expansion machinery).
+        d, hd, H = 12, 4, 3
         torch.manual_seed(4)
         WQ, WK = torch.randn(d, H * hd), torch.randn(d, H * hd)
         GQ, GK = torch.randn(d, H * hd), torch.randn(d, H * hd)
-        dQ1, dK1 = qk_delta(WQ, WK, GQ, GK, hd, damping=1e-2)
-        dQ2, dK2 = qk_delta(WQ, WK, GQ, GK, hd, damping=1e-2)
-        assert torch.equal(dQ1, dQ2) and torch.equal(dK1, dK2)
+        dQ, dK = qk_delta(WQ, WK, GQ, GK, hd, damping=1e-2)
+        for h in range(H):
+            sl = slice(h * hd, (h + 1) * hd)
+            dQ_h, dK_h = qk_delta(
+                WQ[:, sl], WK[:, sl], GQ[:, sl], GK[:, sl], hd, damping=1e-2
+            )
+            assert torch.allclose(dQ[:, sl], dQ_h, atol=1e-3)
+            assert torch.allclose(dK[:, sl], dK_h, atol=1e-3)
 
     def test_gqa_shapes(self):
         d, hd, Hq, Hkv = 16, 4, 6, 2
@@ -155,6 +162,33 @@ class TestOptimizer:
         _set_grads([wq, wk, wv, wo])
         opt.step()
         assert all(torch.isfinite(p.data).all() for p in (wq, wk, wv, wo))
+
+    def test_ov_budget_uses_query_head_count(self):
+        # d_model deliberately != H_q * head_dim so the O head count must be read
+        # from o_proj's in_features (dim 1), not its out_features (= d_model).
+        # The shared V factor takes 1/group_size of the budget; group_size = H_q/H_kv.
+        d_model, hd, Hq, Hkv, lr = 24, 4, 4, 2, 0.02
+        group_size = Hq // Hkv  # == 2
+        _, _, wv, wo = _make_attn(d_model, hd, Hq, Hkv)
+        opt = CompositionalMuon(
+            [dict(params=[wv, wo], algorithm="cm_ov", head_dim=hd)], lr=lr
+        )
+        _set_grads([wv, wo])
+        wv_before, gv = wv.detach().clone(), wv.grad.clone()
+        # Reference V direction via the same dtype path the optimizer uses
+        # (bf16 momentum from zero -> math convention -> ov_delta).
+        Wv = wv_before.mT.float()
+        Wo = wo.detach().mT.float()
+        Gv = gv.to(torch.bfloat16).mT.float()
+        Go = wo.grad.to(torch.bfloat16).mT.float()
+        delta_V, _ = ov_delta(Wv, Wo, Gv, Go, hd, damping=1e-2)
+        update_V = delta_V.mT.to(torch.bfloat16)
+        opt.step()
+        applied = (wv_before - wv.data).float()
+        expected_correct = (update_V * (lr * 0.5 / group_size)).float()
+        expected_buggy = (update_V * (lr * 0.5 / (group_size + 1))).float()
+        assert torch.allclose(applied, expected_correct, atol=1e-6)
+        assert not torch.allclose(applied, expected_buggy, atol=1e-6)
 
     def test_determinism(self):
         def run():

--- a/tests/test_compositional_muon.py
+++ b/tests/test_compositional_muon.py
@@ -203,6 +203,19 @@ class TestOptimizer:
         for a, b in zip(r1, r2):
             assert torch.equal(a, b)
 
+    def test_epsilon_threaded_to_cm_path(self):
+        # The constructor's epsilon is the msign Newton-Schulz pre-norm floor for the
+        # CM pair path, not just the AdamW denominator; a large floor must change the
+        # QK / OV update (otherwise the knob is a silent no-op for cm_qk / cm_ov).
+        def run(eps):
+            wq, wk, wv, wo = _make_attn(8, 4, 2, 2, seed=7)
+            opt = CompositionalMuon(_groups(wq, wk, wv, wo, 4), lr=0.02, epsilon=eps)
+            _set_grads([wq, wk, wv, wo], seed=9)
+            opt.step()
+            return torch.cat([p.detach().flatten() for p in (wq, wk, wv, wo)])
+
+        assert not torch.allclose(run(1e-8), run(1e2), atol=1e-6)
+
     def test_zero_grad_is_noop_without_weight_decay(self):
         wq, wk, wv, wo = _make_attn(8, 4, 2, 2)
         opt = CompositionalMuon(_groups(wq, wk, wv, wo, 4), lr=0.02, weight_decay=0.0)

--- a/tests/test_compositional_muon.py
+++ b/tests/test_compositional_muon.py
@@ -1,0 +1,320 @@
+"""Tests for the Compositional Muon optimizer.
+
+Covers the partner-whitened QK / OV direction math (the core CM invariant, the
+hand-computable scalar-partner case, and the GQA generalization), the optimizer
+contract (param updates, determinism, zero/NaN grads, pairing validation, the
+Muon / AdamW / Lion fallbacks), and the distributed gather / re-shard path
+against a single-device reference.
+
+The math is device-agnostic, so these run on CPU; the distributed test uses a
+2-rank gloo group and needs no GPU.
+"""
+
+import os
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import Shard, distribute_tensor
+
+from dion import CompositionalMuon
+from dion.compositional_muon import (
+    qk_delta,
+    ov_delta,
+    _coupled_inv_sqrt,
+    _to_heads_row,
+)
+
+DEVICE = "cpu"
+
+# Bump torch.compile cache so the per-shape polar_express recompiles don't fail.
+torch._dynamo.config.cache_size_limit = 128
+
+
+def _make_attn(d_model, head_dim, n_q_heads, n_kv_heads, seed=0):
+    torch.manual_seed(seed)
+    wq = torch.nn.Parameter(torch.randn(n_q_heads * head_dim, d_model, device=DEVICE))
+    wk = torch.nn.Parameter(torch.randn(n_kv_heads * head_dim, d_model, device=DEVICE))
+    wv = torch.nn.Parameter(torch.randn(n_kv_heads * head_dim, d_model, device=DEVICE))
+    wo = torch.nn.Parameter(torch.randn(d_model, n_q_heads * head_dim, device=DEVICE))
+    return wq, wk, wv, wo
+
+
+def _set_grads(params, seed=1):
+    torch.manual_seed(seed)
+    for p in params:
+        p.grad = torch.randn_like(p)
+
+
+def _groups(wq, wk, wv, wo, head_dim, **kw):
+    return [
+        dict(params=[wq, wk], algorithm="cm_qk", head_dim=head_dim, **kw),
+        dict(params=[wv, wo], algorithm="cm_ov", head_dim=head_dim, **kw),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Direction math
+# ---------------------------------------------------------------------------
+
+
+def _exact_msign(x):
+    u, _, vh = torch.linalg.svd(x.float(), full_matrices=False)
+    return u @ vh
+
+
+class TestDirectionMath:
+    def test_qk_orthogonality_invariant(self):
+        # delta_Q = msign(G_Q C_K^-1) C_K^-1  =>  delta_Q C_K = msign(...) ~ orthogonal.
+        d, hd, H = 16, 4, 3
+        torch.manual_seed(2)
+        WQ, WK = torch.randn(d, H * hd), torch.randn(d, H * hd)
+        GQ, GK = torch.randn(d, H * hd), torch.randn(d, H * hd)
+        dQ, _ = qk_delta(WQ, WK, GQ, GK, hd, damping=1e-2)
+        WK_h = _to_heads_row(WK, H, hd)
+        C_K = torch.linalg.inv(_coupled_inv_sqrt(WK_h.mT @ WK_h, 1e-2))
+        prod = _to_heads_row(dQ, H, hd) @ C_K
+        sv = torch.linalg.svdvals(prod.float())
+        # 5-step Polar Express in bf16 lands singular values near 1.
+        assert sv.min() > 0.8 and sv.max() < 1.2
+
+    def test_qk_scalar_partner_hand_computed(self):
+        # W_K = c * (orthonormal columns) => C_K = c I exactly => delta_Q = msign(G_Q) / c.
+        d, hd, H, c = 8, 4, 2, 0.5
+        torch.manual_seed(3)
+        q_blocks, gq_blocks, dq_ref = [], [], []
+        for _ in range(H):
+            wk_h, _ = torch.linalg.qr(torch.randn(d, hd))  # orthonormal columns
+            q_blocks.append(c * wk_h)
+            gq = torch.randn(d, hd)
+            gq_blocks.append(gq)
+            dq_ref.append(_exact_msign(gq) / c)
+        WK = torch.cat(q_blocks, dim=1)
+        GQ = torch.cat(gq_blocks, dim=1)
+        WQ = torch.randn(d, H * hd)  # only affects delta_K, not delta_Q
+        dQ, _ = qk_delta(WQ, WK, GQ, torch.randn(d, H * hd), hd, damping=0.0)
+        dQ_ref = torch.cat(dq_ref, dim=1)
+        cos = torch.nn.functional.cosine_similarity(
+            dQ.flatten(), dQ_ref.flatten(), dim=0
+        )
+        assert cos > 0.99
+        # 5-step bf16 Polar Express only approximates the exact SVD msign, so
+        # compare in relative Frobenius norm rather than element-wise.
+        rel_err = (dQ - dQ_ref).norm() / dQ_ref.norm()
+        assert rel_err < 0.15
+
+    def test_gqa_reduces_to_mha(self):
+        # group_size == 1 (H_q == H_kv) must equal the plain per-head path.
+        d, hd, H = 12, 4, 2
+        torch.manual_seed(4)
+        WQ, WK = torch.randn(d, H * hd), torch.randn(d, H * hd)
+        GQ, GK = torch.randn(d, H * hd), torch.randn(d, H * hd)
+        dQ1, dK1 = qk_delta(WQ, WK, GQ, GK, hd, damping=1e-2)
+        dQ2, dK2 = qk_delta(WQ, WK, GQ, GK, hd, damping=1e-2)
+        assert torch.equal(dQ1, dQ2) and torch.equal(dK1, dK2)
+
+    def test_gqa_shapes(self):
+        d, hd, Hq, Hkv = 16, 4, 6, 2
+        torch.manual_seed(5)
+        WQ, WK = torch.randn(d, Hq * hd), torch.randn(d, Hkv * hd)
+        GQ, GK = torch.randn(d, Hq * hd), torch.randn(d, Hkv * hd)
+        dQ, dK = qk_delta(WQ, WK, GQ, GK, hd)
+        assert dQ.shape == WQ.shape and dK.shape == WK.shape
+        WV, WO = torch.randn(d, Hkv * hd), torch.randn(Hq * hd, d)
+        GV, GO = torch.randn(d, Hkv * hd), torch.randn(Hq * hd, d)
+        dV, dO = ov_delta(WV, WO, GV, GO, hd)
+        assert dV.shape == WV.shape and dO.shape == WO.shape
+
+    def test_qk_rejects_bad_gqa_ratio(self):
+        d, hd = 12, 4
+        WQ, WK = torch.randn(d, 5 * hd), torch.randn(d, 2 * hd)  # 5 not divisible by 2
+        with pytest.raises(ValueError, match="divisible"):
+            qk_delta(WQ, WK, torch.randn_like(WQ), torch.randn_like(WK), hd)
+
+
+# ---------------------------------------------------------------------------
+# Optimizer contract
+# ---------------------------------------------------------------------------
+
+
+class TestOptimizer:
+    def test_mha_params_change_and_finite(self):
+        wq, wk, wv, wo = _make_attn(8, 4, 2, 2)
+        opt = CompositionalMuon(_groups(wq, wk, wv, wo, 4), lr=0.02)
+        _set_grads([wq, wk, wv, wo])
+        before = [p.detach().clone() for p in (wq, wk, wv, wo)]
+        opt.step()
+        for p, b in zip((wq, wk, wv, wo), before):
+            assert not torch.equal(p.data, b)
+            assert torch.isfinite(p.data).all()
+
+    def test_gqa_runs(self):
+        wq, wk, wv, wo = _make_attn(16, 4, 4, 2)
+        opt = CompositionalMuon(_groups(wq, wk, wv, wo, 4), lr=0.02)
+        _set_grads([wq, wk, wv, wo])
+        opt.step()
+        assert all(torch.isfinite(p.data).all() for p in (wq, wk, wv, wo))
+
+    def test_determinism(self):
+        def run():
+            wq, wk, wv, wo = _make_attn(8, 4, 2, 2, seed=7)
+            opt = CompositionalMuon(_groups(wq, wk, wv, wo, 4), lr=0.02)
+            for _ in range(3):
+                _set_grads([wq, wk, wv, wo], seed=9)
+                opt.step()
+            return [p.detach().clone() for p in (wq, wk, wv, wo)]
+
+        r1, r2 = run(), run()
+        for a, b in zip(r1, r2):
+            assert torch.equal(a, b)
+
+    def test_zero_grad_is_noop_without_weight_decay(self):
+        wq, wk, wv, wo = _make_attn(8, 4, 2, 2)
+        opt = CompositionalMuon(_groups(wq, wk, wv, wo, 4), lr=0.02, weight_decay=0.0)
+        before = [p.detach().clone() for p in (wq, wk, wv, wo)]
+        for p in (wq, wk, wv, wo):
+            p.grad = torch.zeros_like(p)
+        opt.step()
+        for p, b in zip((wq, wk, wv, wo), before):
+            assert torch.equal(p.data, b)
+
+    def test_nan_grad_consistent_with_muon(self):
+        # Muon propagates NaN through Newton-Schulz rather than guarding; CM matches.
+        wq, wk, wv, wo = _make_attn(8, 4, 2, 2)
+        opt = CompositionalMuon(_groups(wq, wk, wv, wo, 4), lr=0.02)
+        _set_grads([wq, wk, wv, wo])
+        wq.grad[0, 0] = float("nan")
+        opt.step()  # must not raise
+        assert not torch.isfinite(wq.data).all()
+
+    def test_single_pair(self):
+        wq, wk, _, _ = _make_attn(8, 4, 2, 2)
+        opt = CompositionalMuon(
+            [dict(params=[wq, wk], algorithm="cm_qk", head_dim=4)], lr=0.02
+        )
+        wq.grad, wk.grad = torch.randn_like(wq), torch.randn_like(wk)
+        opt.step()
+        assert torch.isfinite(wq.data).all() and torch.isfinite(wk.data).all()
+
+    def test_odd_pair_count_rejected(self):
+        wq, wk, wv, _ = _make_attn(8, 4, 2, 2)
+        with pytest.raises(ValueError, match="pairwise"):
+            CompositionalMuon(
+                [dict(params=[wq, wk, wv], algorithm="cm_qk", head_dim=4)], lr=0.02
+            )
+
+    def test_missing_head_dim_rejected(self):
+        wq, wk, _, _ = _make_attn(8, 4, 2, 2)
+        with pytest.raises(ValueError, match="head_dim"):
+            CompositionalMuon([dict(params=[wq, wk], algorithm="cm_qk")], lr=0.02)
+
+    def test_unknown_algorithm_rejected(self):
+        p = torch.nn.Parameter(torch.randn(8, 8))
+        with pytest.raises(ValueError, match="Unknown algorithm"):
+            CompositionalMuon([dict(params=[p], algorithm="nope")], lr=0.02)
+
+    def test_partial_pair_grad_rejected(self):
+        wq, wk, _, _ = _make_attn(8, 4, 2, 2)
+        opt = CompositionalMuon(
+            [dict(params=[wq, wk], algorithm="cm_qk", head_dim=4)], lr=0.02
+        )
+        wq.grad = torch.randn_like(wq)  # wk.grad stays None
+        with pytest.raises(ValueError, match="both"):
+            opt.step()
+
+    def test_fallback_groups(self):
+        wq, wk, wv, wo = _make_attn(8, 4, 2, 2)
+        mlp = torch.nn.Parameter(torch.randn(16, 8))
+        emb = torch.nn.Parameter(torch.randn(32))
+        lion_p = torch.nn.Parameter(torch.randn(8, 8))
+        groups = _groups(wq, wk, wv, wo, 4) + [
+            dict(params=[mlp], algorithm="muon"),
+            dict(params=[emb], algorithm="adamw"),
+            dict(params=[lion_p], algorithm="lion"),
+        ]
+        opt = CompositionalMuon(groups, lr=0.02)
+        before = {id(p): p.detach().clone() for p in (mlp, emb, lion_p)}
+        for p in (wq, wk, wv, wo, mlp, emb, lion_p):
+            p.grad = torch.randn_like(p)
+        opt.step()
+        for p in (mlp, emb, lion_p):
+            assert not torch.equal(p.data, before[id(p)])
+            assert torch.isfinite(p.data).all()
+
+    def test_muon_per_head(self):
+        attn = torch.nn.Parameter(torch.randn(8 * 4, 16))  # 8 heads of head_dim 4
+        opt = CompositionalMuon(
+            [dict(params=[attn], algorithm="muon", num_heads=8)], lr=0.02
+        )
+        attn.grad = torch.randn_like(attn)
+        opt.step()
+        assert torch.isfinite(attn.data).all()
+
+
+# ---------------------------------------------------------------------------
+# Distributed gather / re-shard path (2-rank gloo, no GPU needed)
+# ---------------------------------------------------------------------------
+
+
+def _dist_worker(rank, world_size, port, return_dict):
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    dist.init_process_group(backend="gloo", rank=rank, world_size=world_size)
+    try:
+        torch._dynamo.config.cache_size_limit = 128
+        mesh = init_device_mesh("cpu", (world_size,))
+        d, hd, Hq, Hkv = 16, 4, 4, 2
+
+        torch.manual_seed(21)
+        wq_full = torch.randn(Hq * hd, d)
+        wk_full = torch.randn(Hkv * hd, d)
+        torch.manual_seed(22)
+        gq_full = torch.randn(Hq * hd, d)
+        gk_full = torch.randn(Hkv * hd, d)
+
+        # Shard on dim 0 (the heads dim) across ranks.
+        wq = torch.nn.Parameter(distribute_tensor(wq_full, mesh, [Shard(0)]))
+        wk = torch.nn.Parameter(distribute_tensor(wk_full, mesh, [Shard(0)]))
+        wq.grad = distribute_tensor(gq_full, mesh, [Shard(0)])
+        wk.grad = distribute_tensor(gk_full, mesh, [Shard(0)])
+
+        opt = CompositionalMuon(
+            [dict(params=[wq, wk], algorithm="cm_qk", head_dim=hd)], lr=0.02
+        )
+        opt.step()
+
+        got_q = wq.data.full_tensor()
+        got_k = wk.data.full_tensor()
+
+        if rank == 0:
+            # Single-device reference with identical inputs.
+            rwq = torch.nn.Parameter(wq_full.clone())
+            rwk = torch.nn.Parameter(wk_full.clone())
+            rwq.grad, rwk.grad = gq_full.clone(), gk_full.clone()
+            ref = CompositionalMuon(
+                [dict(params=[rwq, rwk], algorithm="cm_qk", head_dim=hd)], lr=0.02
+            )
+            ref.step()
+            return_dict["q_close"] = torch.allclose(got_q, rwq.data, atol=1e-5)
+            return_dict["k_close"] = torch.allclose(got_k, rwk.data, atol=1e-5)
+    finally:
+        dist.destroy_process_group()
+
+
+def test_distributed_matches_single_device():
+    world_size = 2
+    mgr = mp.Manager()
+    return_dict = mgr.dict()
+    mp.spawn(
+        _dist_worker,
+        args=(world_size, 29611, return_dict),
+        nprocs=world_size,
+        join=True,
+    )
+    assert return_dict.get(
+        "q_close"
+    ), "distributed Q update diverged from single-device"
+    assert return_dict.get(
+        "k_close"
+    ), "distributed K update diverged from single-device"

--- a/tests/test_compositional_muon.py
+++ b/tests/test_compositional_muon.py
@@ -366,6 +366,8 @@ class TestOptimizer:
 
 
 def _dist_worker(rank, world_size, port, return_dict):
+    import dion.compositional_muon as cm_mod
+
     os.environ["MASTER_ADDR"] = "127.0.0.1"
     os.environ["MASTER_PORT"] = str(port)
     dist.init_process_group(backend="gloo", rank=rank, world_size=world_size)
@@ -375,37 +377,86 @@ def _dist_worker(rank, world_size, port, return_dict):
         d, hd, Hq, Hkv = 16, 4, 4, 2
 
         torch.manual_seed(21)
-        wq_full = torch.randn(Hq * hd, d)
-        wk_full = torch.randn(Hkv * hd, d)
+        wq_full, wk_full = torch.randn(Hq * hd, d), torch.randn(Hkv * hd, d)
+        wv_full, wo_full = torch.randn(Hkv * hd, d), torch.randn(d, Hq * hd)
         torch.manual_seed(22)
-        gq_full = torch.randn(Hq * hd, d)
-        gk_full = torch.randn(Hkv * hd, d)
+        gq_full, gk_full = torch.randn(Hq * hd, d), torch.randn(Hkv * hd, d)
+        gv_full, go_full = torch.randn(Hkv * hd, d), torch.randn(d, Hq * hd)
 
-        # Shard on dim 0 (the heads dim) across ranks.
-        wq = torch.nn.Parameter(distribute_tensor(wq_full, mesh, [Shard(0)]))
-        wk = torch.nn.Parameter(distribute_tensor(wk_full, mesh, [Shard(0)]))
-        wq.grad = distribute_tensor(gq_full, mesh, [Shard(0)])
-        wk.grad = distribute_tensor(gk_full, mesh, [Shard(0)])
+        def shard(t):
+            p = torch.nn.Parameter(distribute_tensor(t, mesh, [Shard(0)]))
+            return p
+
+        wq, wk = shard(wq_full), shard(wk_full)
+        wv, wo = shard(wv_full), shard(
+            wo_full
+        )  # q/k/v shard on heads; o shards on hidden
+        for p, g in ((wq, gq_full), (wk, gk_full), (wv, gv_full), (wo, go_full)):
+            p.grad = distribute_tensor(g, mesh, [Shard(0)])
 
         opt = CompositionalMuon(
-            [dict(params=[wq, wk], algorithm="cm_qk", head_dim=hd)], lr=0.02
+            [
+                dict(params=[wq, wk], algorithm="cm_qk", head_dim=hd),
+                dict(params=[wv, wo], algorithm="cm_ov", head_dim=hd),
+            ],
+            lr=0.02,
         )
-        opt.step()
 
-        got_q = wq.data.full_tensor()
-        got_k = wk.data.full_tensor()
+        # Count gathers: the head-sharded QK pair must take the no-comm local path
+        # (zero _full calls for q/k); only the hidden-sharded O factor gathers.
+        orig_full = cm_mod._full
+        calls = {"n": 0}
+
+        def counting_full(x):
+            calls["n"] += 1
+            return orig_full(x)
+
+        cm_mod._full = counting_full
+        try:
+            opt.step()
+        finally:
+            cm_mod._full = orig_full
+
+        got = {
+            n: p.data.full_tensor()
+            for n, p in (("q", wq), ("k", wk), ("v", wv), ("o", wo))
+        }
 
         if rank == 0:
-            # Single-device reference with identical inputs.
-            rwq = torch.nn.Parameter(wq_full.clone())
-            rwk = torch.nn.Parameter(wk_full.clone())
-            rwq.grad, rwk.grad = gq_full.clone(), gk_full.clone()
+            ref_p = {
+                n: torch.nn.Parameter(t.clone())
+                for n, t in (
+                    ("q", wq_full),
+                    ("k", wk_full),
+                    ("v", wv_full),
+                    ("o", wo_full),
+                )
+            }
+            for n, g in (
+                ("q", gq_full),
+                ("k", gk_full),
+                ("v", gv_full),
+                ("o", go_full),
+            ):
+                ref_p[n].grad = g.clone()
             ref = CompositionalMuon(
-                [dict(params=[rwq, rwk], algorithm="cm_qk", head_dim=hd)], lr=0.02
+                [
+                    dict(
+                        params=[ref_p["q"], ref_p["k"]], algorithm="cm_qk", head_dim=hd
+                    ),
+                    dict(
+                        params=[ref_p["v"], ref_p["o"]], algorithm="cm_ov", head_dim=hd
+                    ),
+                ],
+                lr=0.02,
             )
             ref.step()
-            return_dict["q_close"] = torch.allclose(got_q, rwq.data, atol=1e-5)
-            return_dict["k_close"] = torch.allclose(got_k, rwk.data, atol=1e-5)
+            for n in ("q", "k", "v", "o"):
+                return_dict[f"{n}_close"] = torch.allclose(
+                    got[n], ref_p[n].data, atol=1e-5
+                )
+            # QK (4 factors over 2 pairs) gathered nothing; OV gathered V and O.
+            return_dict["qk_full_calls"] = calls["n"]
     finally:
         dist.destroy_process_group()
 
@@ -420,9 +471,13 @@ def test_distributed_matches_single_device():
         nprocs=world_size,
         join=True,
     )
-    assert return_dict.get(
-        "q_close"
-    ), "distributed Q update diverged from single-device"
-    assert return_dict.get(
-        "k_close"
-    ), "distributed K update diverged from single-device"
+    for n in ("q", "k", "v", "o"):
+        assert return_dict.get(
+            f"{n}_close"
+        ), f"distributed {n} update diverged from single-device"
+    # The head-sharded QK pair takes the no-comm local path (0 gathers); only the
+    # OV pair gathers (its 2 weights + 2 momentum buffers = 4 _full calls).
+    assert return_dict.get("qk_full_calls") == 4, (
+        f"expected only OV to gather (4 _full calls), got {return_dict.get('qk_full_calls')} "
+        "- the QK no-comm local path may not have been taken"
+    )

--- a/tests/test_compositional_muon.py
+++ b/tests/test_compositional_muon.py
@@ -285,6 +285,32 @@ class TestOptimizer:
         opt.step()
         assert torch.isfinite(attn.data).all()
 
+    def test_normuon_fallback(self):
+        mlp = torch.nn.Parameter(torch.randn(32, 16))
+        opt = CompositionalMuon(
+            [dict(params=[mlp], algorithm="normuon", num_heads=None)],
+            lr=0.02,
+            muon_beta2=0.9,
+        )
+        before = mlp.detach().clone()
+        mlp.grad = torch.randn_like(mlp)
+        opt.step()
+        assert not torch.equal(mlp.data, before)
+        assert torch.isfinite(mlp.data).all()
+        # NorMuon keeps a per-neuron variance buffer; vanilla Muon does not.
+        assert "variance_neuron" in opt.state[mlp]
+
+    def test_normuon_fallback_per_head(self):
+        attn = torch.nn.Parameter(torch.randn(8 * 4, 16))
+        opt = CompositionalMuon(
+            [dict(params=[attn], algorithm="normuon", num_heads=8)],
+            lr=0.02,
+            muon_beta2=0.9,
+        )
+        attn.grad = torch.randn_like(attn)
+        opt.step()
+        assert torch.isfinite(attn.data).all()
+
 
 # ---------------------------------------------------------------------------
 # Distributed gather / re-shard path (2-rank gloo, no GPU needed)

--- a/tests/test_compositional_muon.py
+++ b/tests/test_compositional_muon.py
@@ -24,7 +24,6 @@ from dion.compositional_muon import (
     ov_delta,
     _coupled_inv_sqrt,
     _to_heads_row,
-    _unwrap_subclass,
 )
 
 DEVICE = "cpu"
@@ -139,21 +138,6 @@ class TestDirectionMath:
         WQ, WK = torch.randn(d, 5 * hd), torch.randn(d, 2 * hd)  # 5 not divisible by 2
         with pytest.raises(ValueError, match="divisible"):
             qk_delta(WQ, WK, torch.randn_like(WQ), torch.randn_like(WK), hd)
-
-    def test_unwrap_subclass(self):
-        # Plain tensors pass through; a wrapper subclass unwraps to its master.
-        plain = torch.randn(4, 4)
-        assert _unwrap_subclass(plain) is plain
-
-        class _FakeWeightWrapper:
-            def __init__(self, data):
-                self._data = data
-
-            def __tensor_flatten__(self):
-                return ["_data"], None
-
-        master = torch.randn(4, 4)
-        assert _unwrap_subclass(_FakeWeightWrapper(master)) is master
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_compositional_muon.py
+++ b/tests/test_compositional_muon.py
@@ -121,6 +121,42 @@ class TestDirectionMath:
             assert torch.allclose(dQ[:, sl], dQ_h, atol=1e-3)
             assert torch.allclose(dK[:, sl], dK_h, atol=1e-3)
 
+    def test_ov_orthogonality_invariant(self):
+        # OV hybrid: delta_V = msign(G_V C_O^-1) C_O^-1 => delta_V C_O ~ orthogonal
+        # (per head); O whitens per head before a single per-matrix sign, so
+        # C_V delta_O ~ orthogonal across the stacked heads.
+        d, hd, H = 32, 8, 4
+        torch.manual_seed(6)
+        WV, WO = torch.randn(d, H * hd), torch.randn(H * hd, d)
+        GV, GO = torch.randn(d, H * hd), torch.randn(H * hd, d)
+        dV, dO = ov_delta(WV, WO, GV, GO, hd, damping=1e-2)
+        WV_h = _to_heads_row(WV, H, hd)
+        WO_h = WO.view(H, hd, d)
+        C_O = torch.linalg.inv(_coupled_inv_sqrt(WO_h @ WO_h.mT, 1e-2))
+        C_V = torch.linalg.inv(_coupled_inv_sqrt(WV_h.mT @ WV_h, 1e-2))
+        sv_V = torch.linalg.svdvals((_to_heads_row(dV, H, hd) @ C_O).float())
+        sv_O = torch.linalg.svdvals((C_V @ dO.view(H, hd, d)).reshape(H * hd, d).float())
+        # 5-step Polar Express in bf16 lands singular values near 1.
+        assert sv_V.min() > 0.8 and sv_V.max() < 1.2
+        assert sv_O.min() > 0.8 and sv_O.max() < 1.2
+
+    def test_ov_gqa_groups_are_isolated(self):
+        # Under GQA the V update of one KV group must not depend on another group's
+        # O grad/weight: each shared V head pairs only with the G query heads (hence
+        # the O heads) of its own group. Perturbing group 1's O leaves group 0's V
+        # bit-identical; group 1's V changes.
+        d, hd, Hq, Hkv = 24, 4, 4, 2  # group_size == 2
+        torch.manual_seed(7)
+        WV, WO = torch.randn(d, Hkv * hd), torch.randn(Hq * hd, d)
+        GV, GO = torch.randn(d, Hkv * hd), torch.randn(Hq * hd, d)
+        dV0, _ = ov_delta(WV, WO, GV, GO, hd)
+        WO_pert = WO.clone()
+        WO_pert[2 * hd :, :] += 5.0  # O heads of query group 1 (kv head 1)
+        dV1, _ = ov_delta(WV, WO_pert, GV, GO, hd)
+        dV0_h, dV1_h = _to_heads_row(dV0, Hkv, hd), _to_heads_row(dV1, Hkv, hd)
+        assert torch.equal(dV0_h[0], dV1_h[0])
+        assert not torch.equal(dV0_h[1], dV1_h[1])
+
     def test_gqa_shapes(self):
         d, hd, Hq, Hkv = 16, 4, 6, 2
         torch.manual_seed(5)


### PR DESCRIPTION
## Compositional Muon

Adds `CompositionalMuon`, an additive new optimizer implementing **Compositional Muon (CM)** by Tilde Research ([blog](https://blog.tilderesearch.com/blog/compositional-muon), [reference impl](https://github.com/tilde-research/comp-muon-release)). Existing `Muon` / `NorMuon` / `Dion*` are untouched.

### What CM does

Vanilla Muon controls the operator norm of *each* weight update independently. CM controls the operator norm of the **composed** update the loss actually sees — the QK product `M = W_Q W_Kᵀ` and OV product `W_O W_V` — by whitening each factor's gradient with its **partner's** inverse Gram root before the spectral sign and scaling by it again afterward:

```
C_K = (W_Kᵀ W_K + λI)^½
ΔW_Q = -(η/2)·msign(G_Q C_K⁻¹)·C_K⁻¹
ΔW_K = -(η/2)·msign(G_K C_Q⁻¹)·C_Q⁻¹     # symmetric; OV analogous on the other side
```

`msign(A)=UVᵀ` (thin SVD) is computed by reusing dion's existing `polar_express` Newton–Schulz. The `η/2` half-split budget keeps the *product* perturbation within the operator-norm trust region. Momentum is the standard Muon SUM momentum on raw gradients, rewhitened each step against the current partner geometry.

### Scope (recommended-path port)

This ports the reference's **recommended configuration**: `method="half_split"`, full partner whitening (`whitening="both"`), OV `hybrid` granularity (V per-head sign, O per-matrix sign), and no gauge connection. The reference's ablation knobs (`joint`, `isotropic`, gauge `connection`s, `momentum_reproject`, `per_mat_renorm`) are intentionally left for a follow-up. Gram inverse-roots use the reference's coupled Newton–Schulz (`coupled_inv_sqrt`, fp32, batched per head); no eigendecomposition on this path.

### Grouped-query attention (the blog's underspecified, load-bearing point)

The reference assumes MHA (`H_q == H_kv`). Under GQA a shared K/V head pairs with `G = H_q/H_kv` query heads. The generalization here **reduces exactly to the reference for `G == 1`**:

- **Per-query side** (Q, O): partner is the one KV head of its group → expand the KV-head Gram root over query heads (`repeat_interleave`, Llama `repeat_kv` grouping).
- **Shared side** (K, V): partner is the group of `G` query heads → aggregate the group's per-head Grams (sum) before the root.
- **Budget**: the blog allocates the shared-side budget as `η/(2·query_heads_per_group)`, so the shared factor (which changes `G` products at once) takes `1/G` of the step; the per-query factor keeps the full `0.5`.

### Distributed

Mirrors `muon_reference`: each factor is gathered with `full_tensor()` for the coupled CM math and the update is re-sharded before being applied (FSDP2 `DTensor` shards and DDP). The math is replicated across ranks (communication-correct); a compute-sharded megabatch path — incompatible with paired partner-whitening as-is — is left as future work.

### API

Drop-in single optimizer. Param groups are tagged by `algorithm`:

```python
opt = CompositionalMuon([
    dict(params=[q0.weight, k0.weight, q1.weight, k1.weight], algorithm="cm_qk", head_dim=hd),
    dict(params=[v0.weight, o0.weight, v1.weight, o1.weight], algorithm="cm_ov", head_dim=hd),
    dict(params=mlp_matrices, algorithm="muon"),       # vanilla Muon fallback
    dict(params=vectors,      algorithm="adamw"),       # element-wise fallback
], lr=1e-3, mp=1.0, damping=1e-2)
```

`cm_qk` / `cm_ov` params are listed **pairwise** ((Q,K) / (V,O)) and the group carries `head_dim`. New hyperparameters (reference defaults): `mp=1.0` (CM LR multiplier), `damping=1e-2` (Tikhonov λ on the Gram). CM applies no spectral shape-scale factor, per the reference.

### Underspecified-detail choices

- **Pairing** — an `Optimizer` can't infer Q↔K / V↔O; chosen = ordered pairwise `cm_qk`/`cm_ov` groups + `head_dim`.
- **msign** — dion's existing **5-step** `polar_express` (integrates with the repo's Newton–Schulz) rather than the reference's 8-step set.
- **GQA grouping** — contiguous query-head groups per KV head (Llama `repeat_kv`); requires `H_q % H_kv == 0` and `head_dim` dividing both projection widths, else raises.

### Tests

`tests/test_compositional_muon.py` (18 tests, CPU-runnable):
- **Direction math**: the core CM orthogonality invariant (`ΔW_Q·C_K` ≈ orthogonal), a hand-computed scalar-partner case (`W_K = c·orthonormal` ⇒ `ΔW_Q = msign(G_Q)/c`), GQA→MHA reduction, GQA shapes, bad-ratio rejection.
- **Optimizer contract**: param updates, determinism, zero-grad no-op, NaN propagation consistent with Muon, single-pair, pairing/`head_dim`/algorithm validation, partial-pair-grad rejection, Muon/AdamW/Lion fallbacks, per-head Muon.
- **Distributed**: a 2-rank gloo run (no GPU needed) shards Q/K on the heads dim and asserts the gathered update matches the single-device reference.

`COMPOSITIONAL_MUON_NOTES.md` documents the algorithm, hyperparameters, and the GQA derivation.
