### PR TITLE
Pre-populate optimizer state for all params in DistributedOrthoBase

### DIFF
--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -124,10 +124,24 @@ class DistributedOrthoBase(Optimizer):
         # Ported from InternLM/xtuner v1/optim/muon.py (the equivalent __init__
         # loop), generalized here to the whole DistributedOrthoBase family via
         # the (possibly overridden) _get_or_initialize_state.
+        self._state_prepopulated = False
         for group in self.param_groups:
-            algo = group["algorithm"]
-            for p in group["params"]:
-                self._get_or_initialize_state(p, algo)
+            self._prepopulate_group_state(group)
+        self._state_prepopulated = True
+
+    def _prepopulate_group_state(self, group: dict) -> None:
+        algo = group["algorithm"]
+        for p in group["params"]:
+            self._get_or_initialize_state(p, algo)
+
+    def add_param_group(self, param_group: dict) -> None:
+        super().add_param_group(param_group)
+        # Keep the pre-population invariant for groups added after construction
+        # so state_dict() stays complete and rank-symmetric. The guard skips the
+        # add_param_group calls that Optimizer.__init__ makes before this class
+        # finishes setup; the __init__ loop above pre-populates those groups.
+        if getattr(self, "_state_prepopulated", False):
+            self._prepopulate_group_state(self.param_groups[-1])
 
     @torch.no_grad()
     def step(self, closure=None):

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -111,6 +111,24 @@ class DistributedOrthoBase(Optimizer):
         else:
             self._newton_schulz_func = zeropower_via_newtonschulz5
 
+        # Eagerly materialize optimizer state for every parameter, including
+        # those that may never receive a gradient (frozen matrices, or MoE
+        # experts that get no tokens on a given rank/step). State is otherwise
+        # created lazily only for params with a gradient, so the set of keys in
+        # state_dict() can differ across ranks (rank-asymmetric gradients) or
+        # between save and resume. Distributed checkpointing (DCP) gathers
+        # optimizer state collectively and assumes a rank-symmetric key set, so
+        # the lazy path can mismatch or hang. Pre-populating keeps state_dict()
+        # complete and identical across ranks. The per-step path reuses the same
+        # (now non-empty) state, so this changes nothing numerically.
+        # Ported from InternLM/xtuner v1/optim/muon.py (the equivalent __init__
+        # loop), generalized here to the whole DistributedOrthoBase family via
+        # the (possibly overridden) _get_or_initialize_state.
+        for group in self.param_groups:
+            algo = group["algorithm"]
+            for p in group["params"]:
+                self._get_or_initialize_state(p, algo)
+
     @torch.no_grad()
     def step(self, closure=None):
         """Perform a single optimization step."""

--- a/tests/test_state_prepopulation.py
+++ b/tests/test_state_prepopulation.py
@@ -1,0 +1,109 @@
+"""Tests for eager optimizer-state pre-population in DistributedOrthoBase.
+
+The DistributedOrthoBase family (Muon, NorMuon, Dion2, NorDion2) materializes
+optimizer state for every parameter at construction time, including parameters
+that may never receive a gradient. This keeps state_dict() complete and
+rank-symmetric (a requirement for distributed checkpointing) and is numerically
+inert: a grad-less param's buffers stay zero and its weights are untouched.
+
+Ported behavior from InternLM/xtuner v1/optim/muon.py.
+"""
+
+import pytest
+import torch
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+CUDA_AVAILABLE = torch.cuda.is_available()
+
+
+def _optimizer_cases():
+    from dion import Dion2, Muon, NorDion2, NorMuon
+
+    # (class, kwargs, extra state keys beyond "momentum" for the ortho algo)
+    return [
+        (Muon, dict(lr=0.01), set()),
+        (NorMuon, dict(lr=0.01), {"variance_neuron"}),
+        (Dion2, dict(lr=0.01), set()),
+        (NorDion2, dict(lr=0.01), {"variance_neuron"}),
+    ]
+
+
+def _make_params():
+    torch.manual_seed(42)
+    active = torch.nn.Parameter(torch.randn(64, 128, device=DEVICE))
+    frozen = torch.nn.Parameter(torch.randn(64, 128, device=DEVICE))
+    return active, frozen
+
+
+@pytest.mark.parametrize("opt_cls,opt_kwargs,extra_keys", _optimizer_cases())
+def test_state_prepopulated_at_init(opt_cls, opt_kwargs, extra_keys):
+    active, frozen = _make_params()
+    opt = opt_cls([active, frozen], **opt_kwargs)
+
+    # Both params have state immediately, before any step or gradient.
+    assert active in opt.state
+    assert frozen in opt.state
+
+    expected_keys = {"momentum"} | extra_keys
+    for p in (active, frozen):
+        assert set(opt.state[p].keys()) == expected_keys
+        assert torch.count_nonzero(opt.state[p]["momentum"]) == 0
+        assert opt.state[p]["momentum"].shape == p.shape
+
+
+@pytest.mark.parametrize("opt_cls,opt_kwargs,extra_keys", _optimizer_cases())
+def test_state_dict_complete_and_resumable(opt_cls, opt_kwargs, extra_keys):
+    active, frozen = _make_params()
+    opt = opt_cls([active, frozen], **opt_kwargs)
+
+    # state_dict() carries an entry for every param (indices 0 and 1), even
+    # though neither has seen a gradient yet.
+    sd = opt.state_dict()
+    assert set(sd["state"].keys()) == {0, 1}
+
+    # Resuming into a fresh optimizer must not raise and must restore both keys.
+    active2, frozen2 = _make_params()
+    opt2 = opt_cls([active2, frozen2], **opt_kwargs)
+    opt2.load_state_dict(sd)
+    assert set(opt2.state.keys()) == {active2, frozen2}
+
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA required for optimizer step")
+@pytest.mark.parametrize("opt_cls,opt_kwargs,extra_keys", _optimizer_cases())
+def test_gradless_param_is_inert(opt_cls, opt_kwargs, extra_keys):
+    active, frozen = _make_params()
+    frozen_before = frozen.data.clone()
+    opt = opt_cls([active, frozen], **opt_kwargs)
+
+    for step in range(3):
+        torch.manual_seed(100 + step)
+        active.grad = torch.randn_like(active)
+        frozen.grad = None  # never receives a gradient
+        opt.step()
+
+    # The grad-less param is untouched and its buffers remain zero, proving the
+    # pre-populated state does not perturb the update.
+    assert torch.equal(frozen.data, frozen_before)
+    for key in {"momentum"} | extra_keys:
+        assert torch.count_nonzero(opt.state[frozen][key]) == 0
+
+    # The active param did train.
+    assert torch.count_nonzero(opt.state[active]["momentum"]) > 0
+
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA required for optimizer step")
+def test_prepopulation_is_numerically_inert_for_active_param():
+    from dion import Muon
+
+    # First step on an active param: with momentum pre-initialized to zero,
+    # M = mu * 0 + G == G, so the buffer equals the gradient. This is exactly
+    # what the lazy path produced, so pre-population changes nothing numerically.
+    active, _ = _make_params()
+    opt = Muon([active], lr=0.01)
+    torch.manual_seed(7)
+    g = torch.randn_like(active)
+    active.grad = g.clone()
+    opt.step()
+    assert torch.equal(
+        opt.state[active]["momentum"], g.to(opt.state[active]["momentum"].dtype)
+    )

--- a/tests/test_state_prepopulation.py
+++ b/tests/test_state_prepopulation.py
@@ -68,6 +68,22 @@ def test_state_dict_complete_and_resumable(opt_cls, opt_kwargs, extra_keys):
     assert set(opt2.state.keys()) == {active2, frozen2}
 
 
+@pytest.mark.parametrize("opt_cls,opt_kwargs,extra_keys", _optimizer_cases())
+def test_add_param_group_prepopulates(opt_cls, opt_kwargs, extra_keys):
+    active, _ = _make_params()
+    opt = opt_cls([active], **opt_kwargs)
+
+    # A group added after construction must also get complete state, so the
+    # pre-population invariant (rank-symmetric state_dict) is not silently lost.
+    late = torch.nn.Parameter(torch.randn(64, 128, device=DEVICE))
+    opt.add_param_group({"params": [late]})
+
+    assert late in opt.state
+    expected_keys = {"momentum"} | extra_keys
+    assert set(opt.state[late].keys()) == expected_keys
+    assert set(opt.state_dict()["state"].keys()) == {0, 1}
+
+
 @pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA required for optimizer step")
 @pytest.mark.parametrize("opt_cls,opt_kwargs,extra_keys", _optimizer_cases())
 def test_gradless_param_is_inert(opt_cls, opt_kwargs, extra_keys):


### PR DESCRIPTION
## What

Eagerly materialize optimizer state for **every** parameter at construction time in `DistributedOrthoBase.__init__`, instead of creating it lazily only for params that have a gradient. This covers the whole family — **Muon, NorMuon, Dion2, NorDion2** — because the loop dispatches through each subclass's (possibly overridden) `_get_or_initialize_state`, so NorMuon/NorDion2 also pre-populate their `variance_neuron` buffer.

```python
for group in self.param_groups:
    algo = group["algorithm"]
    for p in group["params"]:
        self._get_or_initialize_state(p, algo)
```

## Why

State was created lazily only for params with `p.grad is not None`. So the set of keys in `state_dict()` can differ:
- **across ranks** when gradients are rank-asymmetric — e.g. an MoE expert that receives no tokens on some ranks that step, or an inconsistently-frozen param; and
- **between save and resume**, when a param hadn't yet seen a gradient at checkpoint time.

Distributed checkpointing (DCP) gathers optimizer state collectively and assumes a rank-symmetric key set, so the lazy path can mismatch. Pre-populating keeps `state_dict()` complete and identical across ranks.

The change is **numerically inert**: the per-step path reuses the now-non-empty state, and a freshly-zeroed momentum is exactly what lazy init produced (`M = mu*0 + G == G` on the first step). For the common dense FSDP2 path (every matrix param gets a gradient every step) it is effectively a no-op; the benefit is for MoE/frozen-param setups under DCP.

Scope note: the standalone `Dion` class in `dion/dion.py` has a different `_get_or_initialize_state(param, group)` signature and is **not** a `DistributedOrthoBase` subclass, so it is intentionally left unchanged.

## Tests

`tests/test_state_prepopulation.py` (parametrized over Muon/NorMuon/Dion2/NorDion2) locks:
- every param has complete state at init (momentum, plus `variance_neuron` for NorMuon/NorDion2);
- `state_dict()` carries an entry for every param and resumes into a fresh optimizer without error;
- a grad-less param is numerically inert — weights unchanged, buffers stay zero — while the active param trains;
- an active param's post-step momentum equals its gradient, proving zero pre-init changes nothing numerically.

All 91 existing optimizer tests continue to pass.

## Credit

Ported from InternLM/xtuner's Muon (`xtuner/v1/optim/muon.py`), which performs the equivalent state-pre-population loop in its `__init__` (the "Ensure every parameter has a state entry so that `state_dict()` includes all params" block). This PR generalizes that idea to dion's shared `DistributedOrthoBase` so all four optimizers benefit.