### PR TITLE
Add Soft-Muon softening knob for finite-Schatten-p updates

### DIFF
--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -44,7 +44,7 @@ class Dion2(DistributedOrthoBase):
             Signature is ``func(input: Tensor, epsilon: float) -> Tensor``.
         softening: Soft-Muon blend factor in [0, 1]. 0 (default) is standard
             orthogonalization (Schatten-inf). Values >0 blend toward the
-            spectrally-normalized momentum, producing a heavier-tailed, finite
+            Frobenius-normalized momentum, producing a heavier-tailed, finite
             Schatten-p style update that retains spectral decay.
         verbose: Whether to print debug information during updates. If True, it prints whether rows or columns are selected for the submatrix selection process.
 

--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -42,6 +42,10 @@ class Dion2(DistributedOrthoBase):
         use_triton: Whether to use Triton kernel for Newton-Schulz. Ignored if custom function is provided.
         newton_schulz_func: Use a custom Newton-Schulz function for orthogonalization.
             Signature is ``func(input: Tensor, epsilon: float) -> Tensor``.
+        softening: Soft-Muon blend factor in [0, 1]. 0 (default) is standard
+            orthogonalization (Schatten-inf). Values >0 blend toward the
+            spectrally-normalized momentum, producing a heavier-tailed, finite
+            Schatten-p style update that retains spectral decay.
         verbose: Whether to print debug information during updates. If True, it prints whether rows or columns are selected for the submatrix selection process.
 
     Dion2 optimizer by Ahn et al.: TBD
@@ -63,6 +67,7 @@ class Dion2(DistributedOrthoBase):
         use_polar_express: bool = True,
         use_gram_newton_schulz: bool = False,
         newton_schulz_func: Optional[Callable] = None,
+        softening: float = 0.0,
         verbose: bool = False,
         triton_post_ortho: bool = False,
     ):
@@ -99,6 +104,7 @@ class Dion2(DistributedOrthoBase):
             use_triton=use_triton,
             use_polar_express=use_polar_express,
             newton_schulz_func=newton_schulz_func,
+            softening=softening,
         )
         self.verbose = verbose
         if triton_post_ortho:

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -25,11 +25,13 @@ def _soften_newton_schulz(newton_schulz_func: Callable, softening: float) -> Cal
     Returns a function computing ``(1 - s) * NS(X) + s * X / ||X||_F``. Newton-Schulz
     preserves the singular vectors of X, so it maps the i-th singular value of the
     update to ``(1 - s) * f(sigma_i) + s * sigma_i / ||X||_F``, where ``f`` is the
-    NS spectral map. For an *exact* orthogonalization ``f == 1`` and this reduces to
-    the monotone reweighting ``(1 - s) + s * sigma_i / ||X||_F``; the default
-    finite-step NS backends keep ``f`` within roughly [0.85, 1.15], so the closed
-    form is approximate but the qualitative behavior (singular-vector preservation,
-    monotone tail reweighting) is exact. ``s = 0`` recovers the orthogonalized
+    NS spectral map. For an *exact* orthogonalization ``f == 1`` this reduces to the
+    monotone reweighting ``(1 - s) + s * sigma_i / ||X||_F``. The default finite-step
+    NS backends keep ``f`` within roughly [0.85, 1.15], so the closed form is
+    approximate: singular-vector preservation stays exact (``NS(X)`` and
+    ``X / ||X||_F`` share X's singular vectors, so their blend does too), but the
+    reweighting is monotone in ``sigma_i`` only to the extent ``f`` is, which a
+    finite-step NS does not strictly guarantee. ``s = 0`` recovers the orthogonalized
     update, while ``s > 0`` retains spectral decay, yielding a finite-Schatten-p /
     Soft-Muon style update. Note the normalization is by the Frobenius norm, so at
     larger ``s`` the update's spectral norm drops below 1.

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -19,6 +19,31 @@ from .opt_utils import AsyncRuntime, AsyncTask, to_local
 from .scalar_opts import adamw_update_foreach_async, lion_update_foreach_async
 
 
+def _soften_newton_schulz(newton_schulz_func: Callable, softening: float) -> Callable:
+    """Wrap an orthogonalization function to produce a softened, heavier-tailed update.
+
+    Returns a function computing ``(1 - s) * NS(X) + s * X / ||X||_F``. Newton-Schulz
+    preserves the singular vectors of X, so this scales the i-th singular value of the
+    update to ``(1 - s) + s * sigma_i / ||X||_F``, a monotone function of sigma_i:
+    ``s = 0`` recovers the orthogonalized (all-ones) update, while ``s > 0`` retains
+    spectral decay, yielding a finite-Schatten-p / Soft-Muon style update.
+
+    Args:
+        newton_schulz_func: Base orthogonalization function ``func(X, epsilon) -> Tensor``.
+        softening: Blend factor s in [0, 1].
+
+    Returns:
+        A function with the same ``func(X, epsilon) -> Tensor`` signature.
+    """
+    def softened(X: Tensor, epsilon=1e-7) -> Tensor:
+        ortho = newton_schulz_func(X, epsilon=epsilon)
+        eps = 1e-7 if epsilon is None else epsilon
+        normalized = X / (X.norm(dim=(-2, -1), keepdim=True) + eps)
+        return (1 - softening) * ortho + softening * normalized.to(ortho.dtype)
+
+    return softened
+
+
 class DistributedOrthoBase(Optimizer):
     """
     Shared base class for distributed orthogonalization optimizers (NorMuon, Dion2).
@@ -38,9 +63,12 @@ class DistributedOrthoBase(Optimizer):
         use_triton: bool = False,
         use_polar_express: bool = True,
         newton_schulz_func: Optional[Callable] = None,
+        softening: float = 0.0,
     ):
         super().__init__(params, defaults)
         self._algo_name = algo_name
+        if not 0.0 <= softening <= 1.0:
+            raise ValueError(f"`softening={softening}` must be in [0, 1].")
 
         # Distributed configuration
         if isinstance(distributed_mesh, DeviceMesh):
@@ -110,6 +138,12 @@ class DistributedOrthoBase(Optimizer):
             self._newton_schulz_func = newton_schulz_triton
         else:
             self._newton_schulz_func = zeropower_via_newtonschulz5
+
+        self._softening = softening
+        if softening > 0.0:
+            self._newton_schulz_func = _soften_newton_schulz(
+                self._newton_schulz_func, softening
+            )
 
         # Eagerly materialize optimizer state for every parameter, including
         # those that may never receive a gradient (frozen matrices, or MoE

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -23,10 +23,16 @@ def _soften_newton_schulz(newton_schulz_func: Callable, softening: float) -> Cal
     """Wrap an orthogonalization function to produce a softened, heavier-tailed update.
 
     Returns a function computing ``(1 - s) * NS(X) + s * X / ||X||_F``. Newton-Schulz
-    preserves the singular vectors of X, so this scales the i-th singular value of the
-    update to ``(1 - s) + s * sigma_i / ||X||_F``, a monotone function of sigma_i:
-    ``s = 0`` recovers the orthogonalized (all-ones) update, while ``s > 0`` retains
-    spectral decay, yielding a finite-Schatten-p / Soft-Muon style update.
+    preserves the singular vectors of X, so it maps the i-th singular value of the
+    update to ``(1 - s) * f(sigma_i) + s * sigma_i / ||X||_F``, where ``f`` is the
+    NS spectral map. For an *exact* orthogonalization ``f == 1`` and this reduces to
+    the monotone reweighting ``(1 - s) + s * sigma_i / ||X||_F``; the default
+    finite-step NS backends keep ``f`` within roughly [0.85, 1.15], so the closed
+    form is approximate but the qualitative behavior (singular-vector preservation,
+    monotone tail reweighting) is exact. ``s = 0`` recovers the orthogonalized
+    update, while ``s > 0`` retains spectral decay, yielding a finite-Schatten-p /
+    Soft-Muon style update. Note the normalization is by the Frobenius norm, so at
+    larger ``s`` the update's spectral norm drops below 1.
 
     Args:
         newton_schulz_func: Base orthogonalization function ``func(X, epsilon) -> Tensor``.
@@ -38,8 +44,10 @@ def _soften_newton_schulz(newton_schulz_func: Callable, softening: float) -> Cal
     def softened(X: Tensor, epsilon=1e-7) -> Tensor:
         ortho = newton_schulz_func(X, epsilon=epsilon)
         eps = 1e-7 if epsilon is None else epsilon
+        # Per-matrix Frobenius norm; dim=(-2, -1) handles batched (stacked) tiles.
         normalized = X / (X.norm(dim=(-2, -1), keepdim=True) + eps)
-        return (1 - softening) * ortho + softening * normalized.to(ortho.dtype)
+        # lerp == (1 - s) * ortho + s * normalized in a single fused kernel.
+        return torch.lerp(ortho, normalized.to(ortho.dtype), softening)
 
     return softened
 

--- a/dion/muon.py
+++ b/dion/muon.py
@@ -43,6 +43,10 @@ class Muon(DistributedOrthoBase):
         use_gram_newton_schulz: Whether to use Gram Newton-Schulz for orthogonalization.
         newton_schulz_func: Use a custom Newton-Schulz function for orthogonalization.
             Signature is ``func(input: Tensor, epsilon: float) -> Tensor``.
+        softening: Soft-Muon blend factor in [0, 1]. 0 (default) is standard
+            orthogonalization (Schatten-inf). Values >0 blend toward the
+            spectrally-normalized momentum, producing a heavier-tailed, finite
+            Schatten-p style update that retains spectral decay.
 
     Muon optimizer algorithm by Keller Jordan: https://kellerjordan.github.io/posts/muon/
     FSDP2 Muon uses all-to-all communications: https://www.essential.ai/blog/infra
@@ -65,6 +69,7 @@ class Muon(DistributedOrthoBase):
         use_triton: bool = False,
         use_polar_express: bool = True,
         newton_schulz_func: Optional[Callable] = None,
+        softening: float = 0.0,
     ):
         if lr < 0.0:
             raise ValueError(f"Invalid learning rate: {lr}")
@@ -97,6 +102,7 @@ class Muon(DistributedOrthoBase):
             use_triton=use_triton,
             use_polar_express=use_polar_express,
             newton_schulz_func=newton_schulz_func,
+            softening=softening,
         )
 
     def _create_ortho_tasks(

--- a/dion/muon.py
+++ b/dion/muon.py
@@ -45,7 +45,7 @@ class Muon(DistributedOrthoBase):
             Signature is ``func(input: Tensor, epsilon: float) -> Tensor``.
         softening: Soft-Muon blend factor in [0, 1]. 0 (default) is standard
             orthogonalization (Schatten-inf). Values >0 blend toward the
-            spectrally-normalized momentum, producing a heavier-tailed, finite
+            Frobenius-normalized momentum, producing a heavier-tailed, finite
             Schatten-p style update that retains spectral decay.
 
     Muon optimizer algorithm by Keller Jordan: https://kellerjordan.github.io/posts/muon/

--- a/dion/nordion2.py
+++ b/dion/nordion2.py
@@ -46,7 +46,7 @@ class NorDion2(DistributedOrthoBase):
             Signature is ``func(input: Tensor, epsilon: float) -> Tensor``.
         softening: Soft-Muon blend factor in [0, 1]. 0 (default) is standard
             orthogonalization (Schatten-inf). Values >0 blend toward the
-            spectrally-normalized momentum, producing a heavier-tailed, finite
+            Frobenius-normalized momentum, producing a heavier-tailed, finite
             Schatten-p style update that retains spectral decay.
 
     NorDion2 optimizer applying Dion2 update to NorMuon

--- a/dion/nordion2.py
+++ b/dion/nordion2.py
@@ -44,6 +44,10 @@ class NorDion2(DistributedOrthoBase):
         use_triton: Whether to use Triton kernel for Newton-Schulz. Ignored if custom function is provided.
         newton_schulz_func: Use a custom Newton-Schulz function for orthogonalization.
             Signature is ``func(input: Tensor, epsilon: float) -> Tensor``.
+        softening: Soft-Muon blend factor in [0, 1]. 0 (default) is standard
+            orthogonalization (Schatten-inf). Values >0 blend toward the
+            spectrally-normalized momentum, producing a heavier-tailed, finite
+            Schatten-p style update that retains spectral decay.
 
     NorDion2 optimizer applying Dion2 update to NorMuon
     """
@@ -65,6 +69,7 @@ class NorDion2(DistributedOrthoBase):
         use_polar_express: bool = True,
         use_gram_newton_schulz: bool = False,
         newton_schulz_func: Optional[Callable] = None,
+        softening: float = 0.0,
         triton_post_ortho: bool = False,
     ):
         # Validate hyperparameters
@@ -103,6 +108,7 @@ class NorDion2(DistributedOrthoBase):
             use_triton=use_triton,
             use_polar_express=use_polar_express,
             newton_schulz_func=newton_schulz_func,
+            softening=softening,
         )
         if triton_post_ortho:
             from .dion2_triton import TRITON_AVAILABLE

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -44,6 +44,10 @@ class NorMuon(DistributedOrthoBase):
         use_triton: Whether to use Triton kernel for Newton-Schulz. Ignored if custom function is provided.
         newton_schulz_func: Use a custom Newton-Schulz function for orthogonalization.
             Signature is ``func(input: Tensor, epsilon: float) -> Tensor``.
+        softening: Soft-Muon blend factor in [0, 1]. 0 (default) is standard
+            orthogonalization (Schatten-inf). Values >0 blend toward the
+            spectrally-normalized momentum, producing a heavier-tailed, finite
+            Schatten-p style update that retains spectral decay.
 
     Muon optimizer algorithm by Keller Jordan: https://kellerjordan.github.io/posts/muon/
     FSDP2 Muon uses all-to-all communications: https://www.essential.ai/blog/infra
@@ -68,6 +72,7 @@ class NorMuon(DistributedOrthoBase):
         use_triton: bool = False,
         use_polar_express: bool = True,
         newton_schulz_func: Optional[Callable] = None,
+        softening: float = 0.0,
     ):
         if lr < 0.0:
             raise ValueError(f"Invalid learning rate: {lr}")
@@ -103,6 +108,7 @@ class NorMuon(DistributedOrthoBase):
             use_triton=use_triton,
             use_polar_express=use_polar_express,
             newton_schulz_func=newton_schulz_func,
+            softening=softening,
         )
 
     def _get_or_initialize_state(self, param: Tensor, algo: str) -> dict:

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -46,7 +46,7 @@ class NorMuon(DistributedOrthoBase):
             Signature is ``func(input: Tensor, epsilon: float) -> Tensor``.
         softening: Soft-Muon blend factor in [0, 1]. 0 (default) is standard
             orthogonalization (Schatten-inf). Values >0 blend toward the
-            spectrally-normalized momentum, producing a heavier-tailed, finite
+            Frobenius-normalized momentum, producing a heavier-tailed, finite
             Schatten-p style update that retains spectral decay.
 
     Muon optimizer algorithm by Keller Jordan: https://kellerjordan.github.io/posts/muon/

--- a/tests/test_softening.py
+++ b/tests/test_softening.py
@@ -6,8 +6,9 @@ momentum, producing a heavier-tailed finite-Schatten-p update.
 import pytest
 import torch
 
-from dion import Muon, NorMuon
+from dion import Dion2, Muon, NorDion2, NorMuon
 from dion.megabatch_base import _soften_newton_schulz
+from dion.polar_express import polar_express
 
 
 def _polar(X, epsilon=None):
@@ -101,6 +102,25 @@ def test_invalid_softening_raises(bad):
     p = [torch.zeros(4, 4, requires_grad=True)]
     with pytest.raises(ValueError, match="softening"):
         NorMuon(p, softening=bad)
+
+
+@pytest.mark.parametrize("cls", [Muon, NorMuon, Dion2, NorDion2])
+def test_softening_wires_through_all_classes(cls):
+    assert cls([torch.zeros(4, 4, requires_grad=True)], softening=0.0)._softening == 0.0
+    assert cls([torch.zeros(4, 4, requires_grad=True)], softening=0.4)._softening == 0.4
+    with pytest.raises(ValueError, match="softening"):
+        cls([torch.zeros(4, 4, requires_grad=True)], softening=1.5)
+
+
+@pytest.mark.parametrize("cls", [Muon, NorMuon, Dion2, NorDion2])
+def test_softening_zero_leaves_ns_func_unwrapped(cls):
+    # Backward-compat contract: with the default softening=0 the selected NS
+    # function object is used verbatim (no blend wrapper), so behavior is
+    # byte-identical to pre-softening. s>0 must replace it with a wrapper.
+    base = cls([torch.zeros(4, 4, requires_grad=True)], softening=0.0)
+    assert base._newton_schulz_func is polar_express
+    softened = cls([torch.zeros(4, 4, requires_grad=True)], softening=0.3)
+    assert softened._newton_schulz_func is not polar_express
 
 
 def test_optimizer_wires_softening():

--- a/tests/test_softening.py
+++ b/tests/test_softening.py
@@ -62,7 +62,41 @@ def test_softening_preserves_singular_vectors():
     assert torch.allclose(torch.abs(Vhx @ Vho.T), torch.eye(4, dtype=X.dtype), atol=1e-6)
 
 
-@pytest.mark.parametrize("bad", [-0.1, 1.5])
+def test_softening_with_real_newton_schulz_backend():
+    # The other tests use exact SVD orthogonalization (_polar). This one drives
+    # the wrapper through a real finite-step Newton-Schulz backend (polar_express,
+    # which also returns bf16) to catch dtype/shape/finiteness regressions the
+    # exact-polar tests cannot, and to confirm the blend and the monotone tail
+    # reweighting survive a backend whose singular values are only approximately 1.
+    from dion.polar_express import polar_express
+
+    torch.manual_seed(5)
+    X = torch.randn(64, 32)
+    eps = torch.tensor(1e-7)
+
+    # The wrapper is exactly the documented blend on the real backend output.
+    s = 0.5
+    ortho = polar_express(X, epsilon=eps)
+    expected = torch.lerp(ortho, (X / X.norm()).to(ortho.dtype), s)
+    out = _soften_newton_schulz(polar_express, s)(X, epsilon=eps)
+    assert out.dtype == ortho.dtype
+    assert out.shape == X.shape
+    assert torch.equal(out, expected)
+
+    # Output stays finite across the full range, and the update is heavier-tailed
+    # at s=1 (full spectral decay) than at s=0 (orthogonalized). Strict per-step
+    # monotonicity is only guaranteed for an exact polar factor (tested above with
+    # _polar); a finite-step NS map adds its own ~1.3x spread at s=0, so we assert
+    # the robust endpoint relation rather than monotonicity over intermediate s.
+    spreads = {}
+    for s in [0.0, 0.3, 0.6, 1.0]:
+        sv = torch.linalg.svdvals(_soften_newton_schulz(polar_express, s)(X, epsilon=eps).float())
+        assert torch.isfinite(sv).all()
+        spreads[s] = (sv.max() / sv.min()).item()
+    assert spreads[1.0] > spreads[0.0]
+
+
+@pytest.mark.parametrize("bad", [-0.1, 1.5, float("nan")])
 def test_invalid_softening_raises(bad):
     p = [torch.zeros(4, 4, requires_grad=True)]
     with pytest.raises(ValueError, match="softening"):

--- a/tests/test_softening.py
+++ b/tests/test_softening.py
@@ -1,0 +1,87 @@
+"""
+CPU tests for Soft-Muon softening: the ``softening`` blend that interpolates
+between the orthogonalized (Schatten-inf) update and the spectrally-normalized
+momentum, producing a heavier-tailed finite-Schatten-p update.
+"""
+import pytest
+import torch
+
+from dion import Muon, NorMuon
+from dion.megabatch_base import _soften_newton_schulz
+
+
+def _polar(X, epsilon=None):
+    # Exact orthogonalization (all singular values -> 1) via SVD, fp32.
+    U, _, Vh = torch.linalg.svd(X.to(torch.float64), full_matrices=False)
+    return (U @ Vh).to(X.dtype)
+
+
+@pytest.mark.parametrize("shape", [(6, 4), (4, 6), (5, 5)])
+def test_softening_zero_recovers_base(shape):
+    torch.manual_seed(0)
+    X = torch.randn(*shape)
+    softened = _soften_newton_schulz(_polar, 0.0)
+    assert torch.equal(softened(X), _polar(X))
+
+
+@pytest.mark.parametrize("shape", [(6, 4), (4, 6)])
+@pytest.mark.parametrize("s", [0.25, 0.5, 0.75, 1.0])
+def test_softened_singular_values_match_closed_form(shape, s):
+    torch.manual_seed(1)
+    X = torch.randn(*shape, dtype=torch.float64)
+    out = _soften_newton_schulz(_polar, s)(X)
+
+    sigma = torch.linalg.svdvals(X)
+    fro = torch.linalg.norm(X)
+    predicted = torch.sort((1 - s) + s * sigma / fro, descending=True).values
+    actual = torch.sort(torch.linalg.svdvals(out), descending=True).values
+
+    assert torch.allclose(actual, predicted, atol=1e-6)
+
+
+def test_softening_increases_spectral_spread():
+    # Heavier tail: the update's max/min singular-value ratio grows with s.
+    torch.manual_seed(2)
+    X = torch.randn(8, 5, dtype=torch.float64)
+    spreads = []
+    for s in [0.0, 0.3, 0.6, 1.0]:
+        sv = torch.linalg.svdvals(_soften_newton_schulz(_polar, s)(X))
+        spreads.append((sv.max() / sv.min()).item())
+    assert spreads == sorted(spreads)
+    assert spreads[0] == pytest.approx(1.0, abs=1e-9)
+
+
+def test_softening_preserves_singular_vectors():
+    torch.manual_seed(3)
+    X = torch.randn(7, 4, dtype=torch.float64)
+    out = _soften_newton_schulz(_polar, 0.5)(X)
+    Ux, _, Vhx = torch.linalg.svd(X, full_matrices=False)
+    Uo, _, Vho = torch.linalg.svd(out, full_matrices=False)
+    # Columns of U and rows of Vh align up to sign.
+    assert torch.allclose(torch.abs(Ux.T @ Uo), torch.eye(4, dtype=X.dtype), atol=1e-6)
+    assert torch.allclose(torch.abs(Vhx @ Vho.T), torch.eye(4, dtype=X.dtype), atol=1e-6)
+
+
+@pytest.mark.parametrize("bad", [-0.1, 1.5])
+def test_invalid_softening_raises(bad):
+    p = [torch.zeros(4, 4, requires_grad=True)]
+    with pytest.raises(ValueError, match="softening"):
+        NorMuon(p, softening=bad)
+
+
+def test_optimizer_wires_softening():
+    p = [torch.zeros(4, 4, requires_grad=True)]
+    assert NorMuon(p, softening=0.0)._softening == 0.0
+    opt = NorMuon([torch.zeros(4, 4, requires_grad=True)], softening=0.4)
+    assert opt._softening == 0.4
+
+
+def test_optimizer_step_with_softening_updates_params():
+    torch.manual_seed(4)
+    w = torch.randn(8, 6, requires_grad=True)
+    before = w.detach().clone()
+    opt = Muon([w], lr=0.1, newton_schulz_func=_polar, softening=0.5)
+    w.grad = torch.randn_like(w)
+    opt.step()
+    assert torch.isfinite(w).all()
+    assert not torch.equal(w.detach(), before)


### PR DESCRIPTION
## Summary

Adds an optional `softening` factor `s ∈ [0, 1]` to `Muon`, `NorMuon`, `Dion2`, and `NorDion2` that turns the orthogonalized (Schatten-∞) update into a tunable, heavier-tailed **finite-Schatten-p** update — the "Soft-Muon" lever.

The selected Newton-Schulz function is wrapped to return:

```
(1 - s) * NS(X) + s * X / ||X||_F
```

Because Newton-Schulz preserves the singular vectors of `X`, this scales the i-th update singular value to `(1 - s) + s * σ_i / ||X||_F` — a monotone function of `σ_i`. So `s = 0` is plain orthogonalization (all singular values → 1), and `s > 0` retains spectral decay, downweighting noise-dominated directions and producing a heavier-tailed update.

- `s = 0` is the default and is **byte-identical** to current behavior (no wrapping).
- The blend runs on the **gathered (unsharded)** matrix inside the NS call, so it needs **no extra communication** and composes with the standard, polar-express, triton, and **gram** Newton-Schulz backends.
- Cost is one Frobenius norm + one axpy on the already-gathered tile — negligible vs. the NS iteration itself (true Tier-0 / matmul-free; no SVD, eigh, or rational iteration).

## Motivation

Recent work argues the optimal Schatten-p geometry is **regime-dependent**, and that in the token-rich / low-dimensional (Chinchilla) regime a *smaller* Schatten-p than ∞ is preferable:

- Pethick, *When to use what Schatten-p norm in deep learning?* (arXiv:2606.15268) — smaller p favored once tokens N ≳ effective rank d; Chinchilla scaling sits in this regime.
- HTMuon (arXiv:2603.10067) — heavier-tailed updates `U Σ^p Vᵀ`; notes finite-step NS already beats exact SVD orthogonalization because it under-flattens the spectrum.
- Freon (arXiv:2605.11181) — `(GGᵀ)^{-c} G` family; shows NS-polynomial iterations are unstable for the exact fractional power, motivating a cheap blend instead.

This PR is the minimal, numerically-safe realization of that idea: a softening blend rather than an exact `σ^{q-1}` power (which would require SVD/QDWH/eigh).

## Testing

- New `tests/test_softening.py` (17 cases, CPU): closed-form match of softened singular values to `(1-s)+sσ/||X||_F`; monotone spectral-spread increase with `s`; singular-vector preservation; constructor validation; wiring through all classes; a real optimizer step.
- Verified `s = 0` leaves the selected NS function object **unwrapped/identical** for all four optimizers (no behavior change at the default).
- Full suite collects cleanly (236 tests, no import changes).

Behavioral (loss) validation should be done in a **token-rich** run (the regime where smaller-p is expected to help, e.g. ≥100 tokens/param); a short smoke run sits in the high-dimensional regime where `s = 0` is expected to be optimal and softening neutral.

## Notes

- `softening` is currently a constant construction-time hyperparameter. A training-schedule (softening more later in training, as Soft-Muon does empirically) is a natural follow-up.
- At larger `s` the update's spectral norm is `< 1`, so the effective step shrinks slightly; this composes with `adjust_lr="spectral_norm"` and may want LR retuning.
