### PR TITLE
Make gram-newton-schulz / quack-kernels optional extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## [Unreleased]
+
+### Changed
+
+- **Breaking (install):** `gram-newton-schulz` and `quack-kernels` are no longer
+  base dependencies. They moved to an optional `dion[gram-newton-schulz]` extra
+  (alias `dion[gns]`), and are also excluded from the `dev` and `train` extras.
+  This keeps the default install free of the transitive `nvidia-cutlass-dsl==4.4.2`
+  pin, which conflicts with Flash-Attention-4 / Blackwell stacks built on cutlass
+  `4.5.2`.
+
+  **Action required:** if you run with `use_gram_newton_schulz=True`, install the
+  extra (`pip install "dion[gns] @ git+https://github.com/microsoft/dion.git"`, or
+  `pip install -e ".[gns]"` from a clone). Without it, optimizer construction now
+  raises a clear `ImportError` at runtime instead of the kernels being silently
+  present. Opting in re-introduces the cutlass `4.4.2` pin, so use a separate
+  environment from FA4/Blackwell.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ git clone https://github.com/microsoft/dion.git
 cd dion
 pip install -e .[train]
 ```
+> `train` stays free of the Gram Newton-Schulz kernels (and their `nvidia-cutlass-dsl==4.4.2` pin) so the default training install works on Flash-Attention-4 / Blackwell stacks. To train with `--use_gram_newton_schulz`, use `pip install -e ".[train,gns]"` in a separate environment.
 
 Download pretokenized FineWeb dataset:
 ```bash

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Our implementations are available as a `pip` package! Install to use in your pro
 pip install git+https://github.com/microsoft/dion.git
 ```
 
+> The optional Gram Newton-Schulz orthogonalization kernels (enabled with `use_gram_newton_schulz=True`) are not pulled in by the base install. Add them with `pip install "dion[gram-newton-schulz]"`.
+
 Then in your code, you can use:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Our implementations are available as a `pip` package! Install to use in your pro
 pip install git+https://github.com/microsoft/dion.git
 ```
 
-> The optional Gram Newton-Schulz orthogonalization kernels (enabled with `use_gram_newton_schulz=True`) are not pulled in by the base install. Add them with `pip install "dion[gram-newton-schulz]"`.
+> The optional Gram Newton-Schulz orthogonalization kernels (enabled with `use_gram_newton_schulz=True`) are not pulled in by the base install. Add them with `pip install "dion[gram-newton-schulz] @ git+https://github.com/microsoft/dion.git"`, or `pip install -e ".[gram-newton-schulz]"` from a clone. Note: this extra pins `nvidia-cutlass-dsl==4.4.2`, which conflicts with Flash-Attention-4 / Blackwell stacks built on cutlass `4.5.2`, so install it in a separate environment if you need both.
 
 Then in your code, you can use:
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ git clone https://github.com/microsoft/dion.git
 cd dion
 pip install -e .[train]
 ```
-> `train` stays free of the Gram Newton-Schulz kernels (and their `nvidia-cutlass-dsl==4.4.2` pin) so the default training install works on Flash-Attention-4 / Blackwell stacks. To train with `--use_gram_newton_schulz`, use `pip install -e ".[train,gns]"` in a separate environment.
+> `train` stays free of the Gram Newton-Schulz kernels (and their `nvidia-cutlass-dsl==4.4.2` pin) so the default training install works on Flash-Attention-4 / Blackwell stacks. To train with `--use_gram_newton_schulz`, use `pip install -e ".[train,gns]"` in a separate environment. Likewise, to develop or test the Gram Newton-Schulz path, install `pip install -e ".[dev,gns]"` — a plain `[dev]` install skips the GNS-specific test cases.
 
 Download pretokenized FineWeb dataset:
 ```bash

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -79,9 +79,10 @@ class DistributedOrthoBase(Optimizer):
                 from gram_newton_schulz import GramNewtonSchulz
             except ImportError:
                 raise ImportError(
-                    "use_gram_newton_schulz=True requires the 'gram-newton-schulz' package, "
-                    "which is not installed. "
-                    "Install it with: pip install gram-newton-schulz"
+                    "use_gram_newton_schulz=True requires the optional 'gram-newton-schulz' "
+                    "package, which is not installed. Install it with: "
+                    'pip install gram-newton-schulz (or reinstall dion with its '
+                    '"gram-newton-schulz" extra).'
                 )
             use_polar_express = True
             _gns = GramNewtonSchulz(

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -80,9 +80,8 @@ class DistributedOrthoBase(Optimizer):
             except ImportError:
                 raise ImportError(
                     "use_gram_newton_schulz=True requires the optional 'gram-newton-schulz' "
-                    "package, which is not installed. Install it with: "
-                    'pip install gram-newton-schulz (or reinstall dion with its '
-                    '"gram-newton-schulz" extra).'
+                    'package, which is not installed. Install it with: pip install -e ".[gns]" '
+                    "(or pip install gram-newton-schulz)."
                 )
             use_polar_express = True
             _gns = GramNewtonSchulz(

--- a/requirements_dion.txt
+++ b/requirements_dion.txt
@@ -1,4 +1,2 @@
 numpy
 torch>=2.7.1
-gram-newton-schulz==0.1.4
-quack-kernels==0.4.1

--- a/requirements_gns.txt
+++ b/requirements_gns.txt
@@ -1,2 +1,6 @@
+# Optional Gram Newton-Schulz orthogonalization kernels (use_gram_newton_schulz=True).
+# quack-kernels is pulled in transitively by gram-newton-schulz; the explicit pin here
+# is for reproducibility and must track whatever quack version the pinned gram-newton-schulz
+# requires (gram-newton-schulz==0.1.4 also transitively pins nvidia-cutlass-dsl==4.4.2).
 gram-newton-schulz==0.1.4
 quack-kernels==0.4.1

--- a/requirements_gns.txt
+++ b/requirements_gns.txt
@@ -1,0 +1,2 @@
+gram-newton-schulz==0.1.4
+quack-kernels==0.4.1

--- a/setup.py
+++ b/setup.py
@@ -22,14 +22,16 @@ def read_requirements(path):
 # requirements_dion contains the dependencies for the standalone optimizer
 install_requires = read_requirements(req_path)
 
+# requirements_gns contains the optional Gram Newton-Schulz orthogonalization kernels
+gns_requires = read_requirements(req_gns_path)
+
 # requirements_dev contains the dependencies for development, e.g., testing, linting, etc.
-install_dev_requires = install_requires + read_requirements(req_dev_path)
+# GNS is folded in so `dion[dev]` can still exercise the use_gram_newton_schulz tests
+install_dev_requires = install_requires + read_requirements(req_dev_path) + gns_requires
 
 # requirements_train contains the dependencies for training, e.g., datasets, etc.
-install_train_requires = install_requires + read_requirements(req_train_path)
-
-# requirements_gns contains the optional Gram Newton-Schulz orthogonalization kernels
-install_gns_requires = install_requires + read_requirements(req_gns_path)
+# GNS is folded in so train.py's --use_gram_newton_schulz path stays available
+install_train_requires = install_requires + read_requirements(req_train_path) + gns_requires
 
 readme_path = os.path.join(this_directory, "README.md")
 readme_contents = ""
@@ -73,6 +75,8 @@ setup(
         "dev": install_dev_requires,  # Can be installed with `pip install dion[dev]`
         "train": install_train_requires,
         "triton": install_requires + ["triton"],
-        "gram-newton-schulz": install_gns_requires,  # Can be installed with `pip install dion[gram-newton-schulz]`
+        # `pip install "dion[gram-newton-schulz] @ git+https://github.com/microsoft/dion.git"` (alias: gns)
+        "gram-newton-schulz": install_requires + gns_requires,
+        "gns": install_requires + gns_requires,
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -26,12 +26,10 @@ install_requires = read_requirements(req_path)
 gns_requires = read_requirements(req_gns_path)
 
 # requirements_dev contains the dependencies for development, e.g., testing, linting, etc.
-# GNS is folded in so `dion[dev]` can still exercise the use_gram_newton_schulz tests
-install_dev_requires = install_requires + read_requirements(req_dev_path) + gns_requires
+install_dev_requires = install_requires + read_requirements(req_dev_path)
 
 # requirements_train contains the dependencies for training, e.g., datasets, etc.
-# GNS is folded in so train.py's --use_gram_newton_schulz path stays available
-install_train_requires = install_requires + read_requirements(req_train_path) + gns_requires
+install_train_requires = install_requires + read_requirements(req_train_path)
 
 readme_path = os.path.join(this_directory, "README.md")
 readme_contents = ""

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ this_directory = os.path.dirname(__file__)
 req_path = os.path.join(this_directory, "requirements_dion.txt")
 req_dev_path = os.path.join(this_directory, "requirements_dev.txt")
 req_train_path = os.path.join(this_directory, "requirements_train.txt")
+req_gns_path = os.path.join(this_directory, "requirements_gns.txt")
 
 
 def read_requirements(path):
@@ -26,6 +27,9 @@ install_dev_requires = install_requires + read_requirements(req_dev_path)
 
 # requirements_train contains the dependencies for training, e.g., datasets, etc.
 install_train_requires = install_requires + read_requirements(req_train_path)
+
+# requirements_gns contains the optional Gram Newton-Schulz orthogonalization kernels
+install_gns_requires = install_requires + read_requirements(req_gns_path)
 
 readme_path = os.path.join(this_directory, "README.md")
 readme_contents = ""
@@ -69,5 +73,6 @@ setup(
         "dev": install_dev_requires,  # Can be installed with `pip install dion[dev]`
         "train": install_train_requires,
         "triton": install_requires + ["triton"],
+        "gram-newton-schulz": install_gns_requires,  # Can be installed with `pip install dion[gram-newton-schulz]`
     },
 )

--- a/tests/test_dion2_post_ortho_triton.py
+++ b/tests/test_dion2_post_ortho_triton.py
@@ -338,6 +338,9 @@ class TestDion2TritonEndToEnd:
     @pytest.mark.parametrize("param_dtype", [torch.float32, torch.bfloat16])
     def test_triton_vs_default(self, shapes, fraction, ef_decay, use_triton, use_gram_newton_schulz, param_dtype):
         """Triton post-ortho should match default up to fused-rounding tolerance."""
+        if use_gram_newton_schulz:
+            pytest.importorskip("gram_newton_schulz", reason="optional dion[gram-newton-schulz] extra not installed")
+
         kwargs = dict(
             lr=0.01, fraction=fraction, ef_decay=ef_decay,
             use_triton=use_triton, use_gram_newton_schulz=use_gram_newton_schulz,


### PR DESCRIPTION
## What

Move `gram-newton-schulz` and `quack-kernels` from the mandatory `requirements_dion.txt` into an optional `dion[gram-newton-schulz]` extra (aliased `gns`). The `dev` and `train` extras stay GNS-free too, so the default `pip install -e .[train]` is FA4/Blackwell-clean; only `[gns]` (or `[train,gns]` / `[dev,gns]`) pulls the kernels.

## Why

These packages are only used by the opt-in Gram Newton-Schulz orthogonalization path (`use_gram_newton_schulz=True`, which defaults to `False`). The import is already lazy and guarded in `dion/megabatch_base.py`:

```python
elif use_gram_newton_schulz:
    try:
        from gram_newton_schulz import GramNewtonSchulz
    except ImportError:
        raise ImportError(
            "use_gram_newton_schulz=True requires the 'gram-newton-schulz' package, "
            "which is not installed. "
            "Install it with: pip install gram-newton-schulz"
        )
```

But as **hard** dependencies they are installed for everyone, and `gram-newton-schulz` transitively hard-pins `nvidia-cutlass-dsl==4.4.2`. On modern Flash-Attention-4 / Blackwell (B200) images that ship `nvidia-cutlass-dsl==4.5.2`, a plain `pip install dion` (or `pip install -e .` of a project that depends on dion) silently downgrades cutlass to `4.4.2` and breaks FA4. Consumers currently work around this with `--no-deps`, which is fragile and easy to get wrong.

Making the kernels an extra keeps the base install agnostic to the host CUDA-kernel stack. Users who want GNS opt in with the extras-from-git form (since `dion` is not on PyPI):

```bash
pip install "dion[gram-newton-schulz] @ git+https://github.com/microsoft/dion.git"
# or, from a clone:
pip install -e ".[gram-newton-schulz]"
```

Note: the extra still pins `nvidia-cutlass-dsl==4.4.2`, so opting in on a Flash-Attention-4 / Blackwell image (cutlass `4.5.2`) re-introduces that conflict — use a separate environment if you need both.

## Notes

- The `dev` and `train` extras stay GNS-free so the default `pip install -e .[train]` is FA4/Blackwell-clean; the GPU-gated `use_gram_newton_schulz=True` tests `pytest.importorskip("gram_newton_schulz")` and skip when the extra is absent. Use `pip install -e ".[train,gns]"` to train with the kernels.
- `quack-kernels` has no direct imports in `dion/` (it is only pulled in transitively by `gram-newton-schulz`), so both move together.
- The base optimizers (`Dion`, `Dion2`, `Muon`, `NorMuon`) import only torch/stdlib at module load, so `from dion import ...` is unaffected by this change.
- The only code change is a one-line `ImportError` message in `megabatch_base.py` pointing at the optional package / extra; the lazy import already covers the "opted in but not installed" case.
