### PR TITLE
Fix AdamW LM head fallback scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented in this file.
 
 ### Changed
 
+- AdamW scalar fallback now uses the base learning rate for LM head parameters,
+  while Lion fallback keeps the `1 / sqrt(d_in)` LM-head scaling. This affects
+  shipped `configs/*_160m.yaml` runs, which set `scalar_opt: adamw`.
+
 - **Breaking (install):** `gram-newton-schulz` and `quack-kernels` are no longer
   base dependencies. They moved to an optional `dion[gram-newton-schulz]` extra
   (alias `dion[gns]`), and are also excluded from the `dev` and `train` extras.

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The details of parameter grouping are dependent on model architecture and implem
 * Biases in `nn.Linear` layers (if used) are one-dimensional vectors, which must be placed into a separate parameter group from the weight matrices. Use Lion or AdamW.
 * Normalization layers (e.g. `nn.LayerNorm`, `nn.RMSNorm`) may contain vectors of learnable weights. Use Lion or AdamW.
 * Embedding layers (e.g. `nn.Embedding`) are stored as 2D tensors, but should be treated as a collection of 1D vectors using Lion or AdamW. (Warning: using Dion here will run without error, but will give poor performance.)
-* Unembedding layers (e.g. LM head) are typically implemented as a `nn.Linear` layer, but shoud also be treated as a collection of 1D vectors. Furthermore, they should use a **smaller scaled learning rate**. It is very important to manually identify this layer and place it into its own parameter group, as it is otherwise indistinguishable from weight matrices!
+* Unembedding layers (e.g. LM head) are typically implemented as a `nn.Linear` layer, but shoud also be treated as a collection of 1D vectors. When using Lion as the scalar optimizer, they should use a **smaller scaled learning rate**; with AdamW, use the base learning rate unless you intentionally tune a separate AdamW learning rate. It is very important to manually identify this layer and place it into its own parameter group, as it is otherwise indistinguishable from weight matrices!
 (Warning: using Dion here will run without error, but will give poor performance.)
 * Convolution layers typically use parameter tensors with 3+ dimensions. These are currently not supported for Dion. Support for convolution layers in Muon is experimental, and can be enabled with the option `flatten=True` to automatically flatten them to 2D matrices when computing the optimizer update.
 
@@ -195,7 +195,8 @@ We summarize the above in this table. Let `d_in` be the input dimension of the u
 | Bias vector   | `nn.Linear.bias`                            | `"adamw"` / `"lion"`  | `lr`                   |
 | Normalization | `nn.LayerNorm.weight`, `nn.LayerNorm.bias`  | `"adamw"` / `"lion"`  | `lr`                   |
 | Embedding     | `nn.Embedding.weight`                       | `"adamw"` / `"lion"`  | `lr`                   |
-| Unembedding   | `nn.Linear.weight` (must identify manually) | `"adamw"` / `"lion"`  | `lr / math.sqrt(d_in)` |
+| Unembedding   | `nn.Linear.weight` (must identify manually) | `"adamw"`             | `lr`                   |
+| Unembedding   | `nn.Linear.weight` (must identify manually) | `"lion"`              | `lr / math.sqrt(d_in)` |
 
 We emphasize again that **particular care** needs to be taken with **embedding and unembedding layers**. They must be isolated from ordinary matrix parameters, and the unembedding layer furthermore should use a scaled learning rate. Merely checking the dimensions of a parameter (such as `if p.ndim == 2`) or the type of the module (such as `if isinstance(module, nn.Linear)`) **is not sufficient** to identify these special parameters. This is why we require manual parameter group creation.
 
@@ -223,12 +224,12 @@ param_groups = [
     dict(params=matrix_params),  # will default to "dion" algorithm
     dict(params=vector_params, algorithm="adamw"),
     dict(params=embed_params, algorithm="adamw"),
-    dict(params=lm_head_params, algorithm="adamw", lr=lr / math.sqrt(model_dim))
+    dict(params=lm_head_params, algorithm="adamw")
 ]
 
 optimizer = Dion2(
     param_groups,
-    lr=lr,  # used for all param groups except for lm_head_params
+    lr=lr,  # used for all param groups without an explicit override
     weight_decay=0.1,  # default setting for all param groups
     ...
 )
@@ -240,7 +241,7 @@ param_groups = [
     dict(params=matrix_params),
     dict(params=vector_params, algorithm="adamw"),
     dict(params=embed_params, algorithm="adamw", weight_decay=0),
-    dict(params=lm_head_params, algorithm="adamw", lr=lr / math.sqrt(model_dim), weight_decay=0)
+    dict(params=lm_head_params, algorithm="adamw", weight_decay=0)
 ]
 ```
 

--- a/dion/opt_utils.py
+++ b/dion/opt_utils.py
@@ -1,8 +1,14 @@
+import math
 import torch
 from collections import defaultdict
 from torch import Tensor
 from torch.distributed.tensor import DTensor
 from typing import Generator, List, Optional, Union
+
+
+def lm_head_lr_scale(scalar_opt: str, model_dim: int) -> float:
+    # See Dion paper App. D.2 and Fig. 14 for the Lion-specific 1 / sqrt(d_in) scale.
+    return 1 / math.sqrt(model_dim) if scalar_opt == "lion" else 1.0
 
 
 def to_local(tensor: Union[Tensor, List[Tensor]]) -> Union[Tensor, List[Tensor]]:

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -40,6 +40,19 @@ def _run_steps(optimizer_cls, params, opt_kwargs, n_steps=3):
     return [p.data.clone() for p in params]
 
 
+@pytest.mark.parametrize(
+    ("scalar_opt", "expected_scale"),
+    [
+        ("adamw", 1.0),
+        ("lion", 1 / 768**0.5),
+    ],
+)
+def test_lm_head_lr_scale_by_scalar_opt(scalar_opt, expected_scale):
+    from dion.opt_utils import lm_head_lr_scale
+
+    assert lm_head_lr_scale(scalar_opt, model_dim=768) == pytest.approx(expected_scale)
+
+
 # ---------------------------------------------------------------------------
 # Muon
 # ---------------------------------------------------------------------------

--- a/train.py
+++ b/train.py
@@ -343,11 +343,13 @@ def init_optimizer(
             weight_decay=0,  # no weight decay for embedding parameters
         )
     )
+    # scale lr for LM head only when using Lion fallback
+    lm_head_lr = hp.lr / math.sqrt(hp.model_dim) if hp.scalar_opt == "lion" else hp.lr
     param_groups.append(
         dict(
             params=lm_head_params,
             algorithm=hp.scalar_opt,
-            lr=hp.lr / math.sqrt(hp.model_dim),  # scale LR for lm_head
+            lr=lm_head_lr,
             betas=(0.95, 0.98),
             weight_decay=0,  # no weight decay for lm_head parameters
         )

--- a/train.py
+++ b/train.py
@@ -1,5 +1,4 @@
 import argparse
-import math
 import os
 import shutil
 import time
@@ -30,6 +29,7 @@ from dion import MuonReference
 from dion import Dion2
 from dion import NorMuon
 from dion import NorDion2
+from dion.opt_utils import lm_head_lr_scale
 
 
 @dataclass
@@ -343,8 +343,7 @@ def init_optimizer(
             weight_decay=0,  # no weight decay for embedding parameters
         )
     )
-    # scale lr for LM head only when using Lion fallback
-    lm_head_lr = hp.lr / math.sqrt(hp.model_dim) if hp.scalar_opt == "lion" else hp.lr
+    lm_head_lr = hp.lr * lm_head_lr_scale(hp.scalar_opt, hp.model_dim)
     param_groups.append(
         dict(
             params=lm_head_params,


### PR DESCRIPTION
Currently, the LM output head scaling for Adam fallback is `$1/\sqrt{d_\text{in}}$`, but that should only be applied to Lion fallback.

Adam has adaptive scaling and approximately ensures RMS 1 updates. Lion doesn't. Empirically, scaling by `$1/\sqrt{d_\text{in}}$` for the output head with Adam fallback leads to worse perf than it does with keeping it 1.

It makes sense to have this scaling with Lion, and the derivation for it is in Appendix D.2 of the original Dion paper: https://arxiv.org/pdf/2504.05295

In Figure 14 of the paper, it even says in the caption, "Lion is tested with learning rates scaled by `$1/\sqrt{d}$`, `$1/d$`, or left unscaled, while Adam uses a single fixed rate for all non-matrix parameters." This implies the original paper did not have this scaling with the AdamW fallback.

## Changes

- Use the base learning rate for LM head params when `scalar_opt == "adamw"`
- Keep `$1/\sqrt{d_\text{in}}$` scaling when `scalar_opt == "lion"`
- Update README examples and the parameter-group table to match this behavior

## Validation

- `PYTHONPYCACHEPREFIX=/tmp/dion_pycache python -m py_compile train.py`
- `tests/test_optimizers.py::TestMixedParamGroups`
