### PR TITLE
Bump gram-newton-schulz to 0.1.5 (cutlass-dsl 4.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,16 @@ All notable changes to this project are documented in this file.
 - **Breaking (install):** `gram-newton-schulz` and `quack-kernels` are no longer
   base dependencies. They moved to an optional `dion[gram-newton-schulz]` extra
   (alias `dion[gns]`), and are also excluded from the `dev` and `train` extras.
-  This keeps the default install free of the transitive `nvidia-cutlass-dsl==4.4.2`
-  pin, which conflicts with Flash-Attention-4 / Blackwell stacks built on cutlass
-  `4.5.2`.
+  This keeps the default install free of the heavy Gram Newton-Schulz GPU stack
+  (and its transitive `nvidia-cutlass-dsl` pin).
 
   **Action required:** if you run with `use_gram_newton_schulz=True`, install the
   extra (`pip install "dion[gns] @ git+https://github.com/microsoft/dion.git"`, or
   `pip install -e ".[gns]"` from a clone). Without it, optimizer construction now
   raises a clear `ImportError` at runtime instead of the kernels being silently
-  present. Opting in re-introduces the cutlass `4.4.2` pin, so use a separate
-  environment from FA4/Blackwell.
+  present.
+
+- Bumped the optional `dion[gns]` extra to `gram-newton-schulz==0.1.5`
+  (`quack-kernels==0.5.0`). This moves its transitive `nvidia-cutlass-dsl` pin from
+  `4.4.2` to `4.5.2`, matching current Flash-Attention-4 / Blackwell stacks, so the
+  extra no longer conflicts with them.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Our implementations are available as a `pip` package! Install to use in your pro
 pip install git+https://github.com/microsoft/dion.git
 ```
 
-> The optional Gram Newton-Schulz orthogonalization kernels (enabled with `use_gram_newton_schulz=True`) are not pulled in by the base install. Add them with `pip install "dion[gram-newton-schulz] @ git+https://github.com/microsoft/dion.git"`, or `pip install -e ".[gram-newton-schulz]"` from a clone. Note: this extra pins `nvidia-cutlass-dsl==4.4.2`, which conflicts with Flash-Attention-4 / Blackwell stacks built on cutlass `4.5.2`, so install it in a separate environment if you need both.
+> The optional Gram Newton-Schulz orthogonalization kernels (enabled with `use_gram_newton_schulz=True`) are not pulled in by the base install. Add them with `pip install "dion[gram-newton-schulz] @ git+https://github.com/microsoft/dion.git"`, or `pip install -e ".[gram-newton-schulz]"` from a clone. Note: this extra pins `nvidia-cutlass-dsl==4.5.2`, matching the cutlass version used by current Flash-Attention-4 / Blackwell stacks (the earlier `4.4.2` conflict no longer applies).
 
 Then in your code, you can use:
 
@@ -68,7 +68,7 @@ git clone https://github.com/microsoft/dion.git
 cd dion
 pip install -e .[train]
 ```
-> `train` stays free of the Gram Newton-Schulz kernels (and their `nvidia-cutlass-dsl==4.4.2` pin) so the default training install works on Flash-Attention-4 / Blackwell stacks. To train with `--use_gram_newton_schulz`, use `pip install -e ".[train,gns]"` in a separate environment. Likewise, to develop or test the Gram Newton-Schulz path, install `pip install -e ".[dev,gns]"` — a plain `[dev]` install skips the GNS-specific test cases.
+> `train` stays free of the Gram Newton-Schulz kernels, which remain an opt-in extra. To train with `--use_gram_newton_schulz`, use `pip install -e ".[train,gns]"`; the extra's `nvidia-cutlass-dsl==4.5.2` pin now matches Flash-Attention-4 / Blackwell stacks, so the two no longer conflict. Likewise, to develop or test the Gram Newton-Schulz path, install `pip install -e ".[dev,gns]"` — a plain `[dev]` install skips the GNS-specific test cases.
 
 Download pretokenized FineWeb dataset:
 ```bash

--- a/requirements_gns.txt
+++ b/requirements_gns.txt
@@ -1,6 +1,6 @@
 # Optional Gram Newton-Schulz orthogonalization kernels (use_gram_newton_schulz=True).
 # quack-kernels is pulled in transitively by gram-newton-schulz; the explicit pin here
 # is for reproducibility and must track whatever quack version the pinned gram-newton-schulz
-# requires (gram-newton-schulz==0.1.4 also transitively pins nvidia-cutlass-dsl==4.4.2).
-gram-newton-schulz==0.1.4
-quack-kernels==0.4.1
+# requires (gram-newton-schulz==0.1.5 also transitively pins nvidia-cutlass-dsl==4.5.2).
+gram-newton-schulz==0.1.5
+quack-kernels==0.5.0


### PR DESCRIPTION
## What

Bump the optional `[gns]` / `[gram-newton-schulz]` extra's pin from
`gram-newton-schulz==0.1.4` to **`0.1.5`** in `requirements_gns.txt`, and reconcile
the transitive pins it controls.

## Transitive pins (reconciled, not just one line)

`gram-newton-schulz==0.1.5` directly pins its dependencies differently from 0.1.4:

| Package | 0.1.4 (`Requires-Dist`) | 0.1.5 (`Requires-Dist`) | This PR |
| --- | --- | --- | --- |
| `quack-kernels` | `>=0.4.1` | `==0.5.0` | pin updated `0.4.1` → **`0.5.0`** |
| `nvidia-cutlass-dsl` | `==4.4.2` | `==4.5.2` | tracked in comment/docs **`4.4.2` → `4.5.2`** |

Both transitive versions **changed**, so this is not a no-op renumber. The explanatory
comment in `requirements_gns.txt` was updated to cite the 0.1.5-correct cutlass version.

## Docs reconciled

The cutlass-dsl pin is the whole point of these explicit pins — drift has historically
broken FlashAttention-4 downstream. Notably, `4.5.2` is the **same** cutlass version the
README/CHANGELOG attribute to FA4 / Blackwell stacks, so the previously-documented
`4.4.2`-vs-`4.5.2` conflict is now **resolved**, not merely renumbered. Updated:

- `README.md` (Quick Start note + `train` extra note): `4.4.2` → `4.5.2`, and the "install
  in a separate environment / conflicts with FA4" wording reworded to reflect that the
  extra's cutlass pin now matches FA4 / Blackwell.
- `CHANGELOG.md` (Unreleased): dropped the now-false `4.4.2` conflict statements from the
  breaking-install entry and added a bullet documenting the bump and the resulting
  `nvidia-cutlass-dsl` `4.4.2` → `4.5.2` alignment.

## Verification

- Confirmed `gram-newton-schulz==0.1.5` exists on PyPI.
- Read `Requires-Dist` for 0.1.5 from the PyPI JSON API: `quack-kernels==0.5.0`,
  `nvidia-cutlass-dsl==4.5.2`. Cross-checked `quack-kernels==0.5.0` requires
  `nvidia-cutlass-dsl>=4.5.2` (consistent with the `==4.5.2` pin).
- `pip install --dry-run` resolve of `gram-newton-schulz==0.1.5` in a scratch venv
  resolved to exactly **gram-newton-schulz 0.1.5 / quack-kernels 0.5.0 /
  nvidia-cutlass-dsl 4.5.2**, matching the written pins.