### PR TITLE
Default selection_scope to global; fix selection_scope tests

### DIFF
--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -43,6 +43,12 @@ class Dion2(DistributedOrthoBase):
         newton_schulz_func: Use a custom Newton-Schulz function for orthogonalization.
             Signature is ``func(input: Tensor, epsilon: float) -> Tensor``.
         verbose: Whether to print debug information during updates. If True, it prints whether rows or columns are selected for the submatrix selection process.
+        selection_scope: On the FSDP2 row-sharded path, how the orthogonalized
+            submatrix is selected. "global" (default): exact top-k on the
+            assembled whole matrix -- layout-invariant/reproducible and better-
+            converging. "local": per-shard top-k (union) -- cheaper comm but a
+            sharding-dependent approximation that converges slightly worse; opt
+            in when comm-bound at large scale. No-op off the row-sharded path.
 
     Dion2 optimizer by Ahn et al.: TBD
     """
@@ -65,7 +71,7 @@ class Dion2(DistributedOrthoBase):
         newton_schulz_func: Optional[Callable] = None,
         verbose: bool = False,
         triton_post_ortho: bool = False,
-        selection_scope: str = "local",
+        selection_scope: str = "global",
     ):
         # Validate hyperparameters
         if lr < 0.0:
@@ -210,7 +216,7 @@ def dion2_update_megabatch_async(
     newton_schulz_func: Optional[Callable] = None,
     verbose: bool = False,
     triton_post_ortho: bool = False,
-    selection_scope: str = "local",  # "local" (per-shard top-k, cheap comm) or "global" (whole-matrix top-k)
+    selection_scope: str = "global",  # "global" (exact whole-matrix top-k, default) or "local" (per-shard top-k; cheaper comm, sharding-variant)
 ) -> Generator[None, None, None]:
     """
     Mega-batched Dion2 update: processes ALL same-shape parameters in one
@@ -219,17 +225,18 @@ def dion2_update_megabatch_async(
     ``selection_scope`` controls how the orthogonalized submatrix is chosen on
     the row-sharded path:
 
+    - ``"global"`` (default): the full shard is communicated (like NorMuon), the
+      top-k is taken on the assembled whole matrix, and Newton-Schulz runs on
+      that submatrix. Comm is full-size but the selected set is the exact global
+      top-k -- invariant to the sharding layout (reproducible across world
+      sizes) and, in A/B tests, better-converging than "local" (which under-
+      performed it by ~0.09 nat at matched steps on a 1.5B dense run).
     - ``"local"``: each rank picks its own top-k rows, and only those rows are
-      communicated and orthogonalized. Comm and Newton-Schulz cost scale with
-      ``fraction``. The selected set is the union of per-rank top-k, so it
-      depends on the sharding layout (world-size variant). This matches the
-      pre-megabatch Dion2 behavior; numerically identical to the previous
-      full-pad implementation (the padded zero rows it dropped never affected
-      U^T U), just without paying for the dropped rows.
-    - ``"global"``: the full shard is communicated (like NorMuon), the top-k is
-      taken on the assembled whole matrix, and Newton-Schulz runs on that
-      submatrix. Comm is full-size but the selected set is exact and invariant
-      to the sharding layout (reproducible across world sizes).
+      communicated and orthogonalized, so comm and Newton-Schulz cost scale with
+      ``fraction``. The selected set is the union of per-rank top-k -- a
+      sharding-dependent approximation of the true top-k (world-size variant).
+      Cheaper comm (the win grows with model size), but converges slightly
+      worse; opt in when comm-bound at large scale.
 
     Off the row-sharded path (per-head, single-GPU, batch-sharded) each rank
     already holds whole matrices, so local and global selection coincide and
@@ -328,7 +335,7 @@ def dion2_update_megabatch_async(
         )
         return
 
-    # --- Local selection (default): per-shard top-k, communicate only the
+    # --- Local selection (opt-in, selection_scope="local"): per-shard top-k, communicate only the
     # selected rows. Under FSDP2 contiguous chunking every rank holds at most
     # ``padded_local = ceil(global / world_size)`` rows, so a uniform
     # ``k = ceil(fraction * padded_local)`` is the per-rank selected count. We

--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -299,7 +299,7 @@ def dion2_update_megabatch_async(
         U_full = dion2_pre_accumulate(G=to_local(G), M=to_local(M))
         global_comm_dim_size = global_dim_size
         select_ns = _make_select_and_orthogonalize(
-            newton_schulz_func, fraction, select_dim
+            newton_schulz_func, fraction, select_dim, global_select_size=global_dim_size
         )
         U_ortho = yield from megabatch_orthogonalize_async(
             U_full,
@@ -555,7 +555,10 @@ def dion2_pre_accumulate(G: List[Tensor], M: List[Tensor]) -> List[Tensor]:
 
 
 def _make_select_and_orthogonalize(
-    newton_schulz_func: Callable, fraction: float, select_dim: int
+    newton_schulz_func: Callable,
+    fraction: float,
+    select_dim: int,
+    global_select_size: Optional[int] = None,
 ) -> Callable:
     """
     Wrap a Newton-Schulz function so it (1) selects the top-k slices of each
@@ -567,12 +570,28 @@ def _make_select_and_orthogonalize(
     layout. The returned full-size tensor has exactly
     zero rows/cols everywhere except the selected positions, which the masked
     post step keys off.
+
+    ``global_select_size`` is the true unsharded size along ``select_dim``. On
+    the row-sharded path the matrix handed to this wrapper is zero-padded to
+    ``ceil(global / world_size) * world_size`` rows, which exceeds the true
+    global size whenever it is not divisible by ``world_size``. Deriving ``k``
+    from ``X.size(select_dim)`` would then select ``ceil(fraction * padded)``
+    slices -- more than the true whole-matrix top-k, and a count that depends on
+    ``world_size`` -- silently breaking the exact/reproducible-across-world-sizes
+    guarantee. So ``k`` is computed from ``global_select_size`` when provided;
+    the padded rows are exactly zero and never rank into the top-k, so selecting
+    over the padded matrix still picks exactly the real global top-k. Falls back
+    to ``X.size(select_dim)`` when not given (e.g. an already-whole matrix).
     """
 
     def _select_ns(X: Tensor, epsilon=None) -> Tensor:
-        num_select = X.size(select_dim)
+        num_select = (
+            X.size(select_dim) if global_select_size is None else global_select_size
+        )
         norm_dim = -1 if select_dim == -2 else -2
-        k = max(1, int(math.ceil(fraction * num_select)))
+        # k derives from the true global size but never exceeds the (padded)
+        # matrix handed in, so topk is always valid.
+        k = min(max(1, int(math.ceil(fraction * num_select))), X.size(select_dim))
         slice_norms = X.norm(p=1, dim=norm_dim)
         _, indices = torch.topk(slice_norms, k, dim=-1, sorted=False)
         if select_dim == -2:

--- a/dion/nordion2.py
+++ b/dion/nordion2.py
@@ -50,6 +50,12 @@ class NorDion2(DistributedOrthoBase):
         use_triton: Whether to use Triton kernel for Newton-Schulz. Ignored if custom function is provided.
         newton_schulz_func: Use a custom Newton-Schulz function for orthogonalization.
             Signature is ``func(input: Tensor, epsilon: float) -> Tensor``.
+        selection_scope: On the FSDP2 row-sharded path, how the orthogonalized
+            submatrix is selected. "global" (default): exact top-k on the
+            assembled whole matrix -- layout-invariant/reproducible and better-
+            converging. "local": per-shard top-k (union) -- cheaper comm but a
+            sharding-dependent approximation that converges slightly worse; opt
+            in when comm-bound at large scale. No-op off the row-sharded path.
 
     NorDion2 optimizer applying Dion2 update to NorMuon
     """
@@ -72,7 +78,7 @@ class NorDion2(DistributedOrthoBase):
         use_gram_newton_schulz: bool = False,
         newton_schulz_func: Optional[Callable] = None,
         triton_post_ortho: bool = False,
-        selection_scope: str = "local",
+        selection_scope: str = "global",
     ):
         # Validate hyperparameters
         if lr < 0.0:
@@ -239,16 +245,17 @@ def nordion2_update_megabatch_async(
     process_group: Optional[ProcessGroup] = None,
     newton_schulz_func: Optional[Callable] = None,
     triton_post_ortho: bool = False,
-    selection_scope: str = "local",
+    selection_scope: str = "global",
 ) -> Generator[None, None, None]:
     """
     Mega-batched NorDion2 update: processes ALL same-shape parameters in one
     communication round instead of world_size-sized batches.
 
-    ``selection_scope`` mirrors Dion2: "local" selects each rank's top-k rows
-    before communication (cheap comm, world-size variant); "global" sends the
-    full shard and selects on the assembled whole matrix (full comm, invariant).
-    See ``dion2_update_megabatch_async`` for details.
+    ``selection_scope`` mirrors Dion2: "global" (default) sends the full shard
+    and selects the exact top-k on the assembled whole matrix (full comm,
+    layout-invariant, better-converging); "local" selects each rank's top-k rows
+    before communication (cheaper comm, but a sharding-variant approximation that
+    converges slightly worse). See ``dion2_update_megabatch_async`` for details.
     """
     N = len(X)
     assert N == len(G) == len(M) == len(V)
@@ -320,7 +327,7 @@ def nordion2_update_megabatch_async(
         )
         return
 
-    # --- Local selection (default): per-shard top-k, communicate only the
+    # --- Local selection (opt-in, selection_scope="local"): per-shard top-k, communicate only the
     # selected rows. Uniform k = ceil(fraction * ceil(global / world_size)) is
     # the per-rank selected count under FSDP2 contiguous chunking; the megabatch
     # pads every shard to exactly k (short/empty shards zero-pad), so the

--- a/dion/nordion2.py
+++ b/dion/nordion2.py
@@ -287,7 +287,7 @@ def nordion2_update_megabatch_async(
         # --- Global selection: send the full shard, select after assembly ---
         U_full = dion2_pre_accumulate(G=to_local(G), M=to_local(M))
         select_ns = _make_select_and_orthogonalize(
-            newton_schulz_func, fraction, select_dim
+            newton_schulz_func, fraction, select_dim, global_select_size=global_dim_size
         )
         U_ortho = yield from megabatch_orthogonalize_async(
             U_full,

--- a/tests/test_dion2_selection_scope.py
+++ b/tests/test_dion2_selection_scope.py
@@ -49,14 +49,6 @@ def _ns(x, epsilon=1e-7):
     return polar_express(x, epsilon=epsilon)
 
 
-def _force_full_pad(comm_dim, global_dim_size, world_size, fraction):
-    """Stand-in for ``_local_selection_comm_size`` that forces the pre-fix
-    full-shard-pad path: no uniform per-rank k budget, so each rank selects
-    ``ceil(fraction * local_size)`` rows and the megabatch pads them back to the
-    full shard before the all-to-all (the old behavior)."""
-    return None, global_dim_size
-
-
 # ---- single-process reference: one optimizer step on the whole matrix ----
 def _reference_step(OptCls, W0, G, *, fraction, scope, **kw):
     """Run one step on an unsharded (single-GPU) param. With no process_group,
@@ -87,12 +79,20 @@ def _worker(rank, world_size, port, OptCls, scope, fraction, kw, out_path, force
     mesh = DeviceMesh("cuda", list(range(world_size)))
 
     if force_pad:
-        # Route the "local" scope through the old full-shard-pad path in both
-        # optimizers (the function is imported by name into each module).
+        # Force the pre-fix full-shard-pad path: wrap megabatch_orthogonalize_async
+        # so local_comm_size is dropped (None). The local scope still selects its
+        # k rows, but the megabatch then pads each shard back to the full
+        # ceil(global/world_size) size before the all-to-all -- the old behavior
+        # whose padded zero rows this PR eliminates. Patch both modules' bound
+        # name (each imports megabatch_orthogonalize_async into its namespace).
         import dion.dion2 as _d2
         import dion.nordion2 as _nd2
-        _d2._local_selection_comm_size = _force_full_pad
-        _nd2._local_selection_comm_size = _force_full_pad
+        _real_mb = _d2.megabatch_orthogonalize_async
+        def _forced_mb(*a, **k):
+            k["local_comm_size"] = None
+            return _real_mb(*a, **k)
+        _d2.megabatch_orthogonalize_async = _forced_mb
+        _nd2.megabatch_orthogonalize_async = _forced_mb
 
     # Wide (rows <= cols) so the unsharded reference also selects rows; see the
     # module docstring. Deterministic whole-matrix weight + grad on every rank.

--- a/tests/test_dion2_selection_scope.py
+++ b/tests/test_dion2_selection_scope.py
@@ -6,13 +6,23 @@ back to the full shard before the all-to-all, erasing Dion's fraction saving):
 
 - ``selection_scope="local"``: per-shard top-k, communicate only the selected
   rows. Must be numerically identical to the previous full-pad implementation
-  (the dropped padded zero rows never affected U^T U).
+  (the dropped padded zero rows never affected U^T U). ``test_local_scope_nopad
+  _equals_pad`` checks this directly by running the *same* optimizer once through
+  the no-pad fast path and once through the forced full-shard-pad path.
 - ``selection_scope="global"``: select on the assembled whole matrix. Must be
   invariant to the sharding layout (same result at world_size 1 and 2) and equal
   to a single-process whole-matrix reference.
 
-Runs on the 2 login-node GPUs via NCCL. The momentum buffers are seeded
-identically across the sharded and reference runs so the comparison is exact.
+Runs on 2 GPUs via NCCL. The momentum buffers are seeded identically across the
+sharded and reference runs.
+
+The test matrix is wide (rows <= cols) on purpose: the row-sharded path always
+selects along the sharded (row) dimension, but an *unsharded* Dion2 selects the
+shorter dimension, so the single-GPU reference only selects rows -- and is thus
+comparable to the sharded run -- when rows <= cols. (NorDion2 always selects
+rows.) Tolerances are bf16-scale: the communicated shards and Newton-Schulz run
+in bf16, whose unit-in-last-place near magnitude 1 is ~8e-3, so exact-arithmetic
+equalities only hold to ~1e-2.
 """
 
 import os
@@ -29,9 +39,22 @@ from dion.polar_express import polar_express
 
 CUDA = torch.cuda.device_count() if torch.cuda.is_available() else 0
 
+# bf16 comm + Newton-Schulz: ~1 ULP near magnitude 1 is ~8e-3, so
+# exact-in-real-arithmetic identities only hold to bf16 scale.
+BF16_RTOL = 1.5e-2
+BF16_ATOL = 1.5e-2
+
 
 def _ns(x, epsilon=1e-7):
     return polar_express(x, epsilon=epsilon)
+
+
+def _force_full_pad(comm_dim, global_dim_size, world_size, fraction):
+    """Stand-in for ``_local_selection_comm_size`` that forces the pre-fix
+    full-shard-pad path: no uniform per-rank k budget, so each rank selects
+    ``ceil(fraction * local_size)`` rows and the megabatch pads them back to the
+    full shard before the all-to-all (the old behavior)."""
+    return None, global_dim_size
 
 
 # ---- single-process reference: one optimizer step on the whole matrix ----
@@ -40,7 +63,6 @@ def _reference_step(OptCls, W0, G, *, fraction, scope, **kw):
     the optimizer holds the whole matrix locally, so local and global selection
     coincide -- this is the ground truth for the global-scope sharded run, and
     (for fraction=1.0) for any scope."""
-    dev = W0.device
     p = torch.nn.Parameter(W0.clone())
     p.grad = G.clone()
     opt = OptCls(
@@ -56,7 +78,7 @@ def _reference_step(OptCls, W0, G, *, fraction, scope, **kw):
     return p.detach().clone()
 
 
-def _worker(rank, world_size, port, OptCls, scope, fraction, kw, out_path):
+def _worker(rank, world_size, port, OptCls, scope, fraction, kw, out_path, force_pad):
     os.environ["MASTER_ADDR"] = "127.0.0.1"
     os.environ["MASTER_PORT"] = str(port)
     torch.cuda.set_device(rank)
@@ -64,8 +86,17 @@ def _worker(rank, world_size, port, OptCls, scope, fraction, kw, out_path):
     dev = torch.device(f"cuda:{rank}")
     mesh = DeviceMesh("cuda", list(range(world_size)))
 
-    rows, cols = 16, 8
-    # Deterministic whole-matrix weight + grad, identical on every rank.
+    if force_pad:
+        # Route the "local" scope through the old full-shard-pad path in both
+        # optimizers (the function is imported by name into each module).
+        import dion.dion2 as _d2
+        import dion.nordion2 as _nd2
+        _d2._local_selection_comm_size = _force_full_pad
+        _nd2._local_selection_comm_size = _force_full_pad
+
+    # Wide (rows <= cols) so the unsharded reference also selects rows; see the
+    # module docstring. Deterministic whole-matrix weight + grad on every rank.
+    rows, cols = 16, 32
     g = torch.Generator(device=dev).manual_seed(1234)
     W0 = torch.randn(rows, cols, generator=g, device=dev)
     G = torch.randn(rows, cols, generator=g, device=dev)
@@ -91,10 +122,14 @@ def _worker(rank, world_size, port, OptCls, scope, fraction, kw, out_path):
     dist.destroy_process_group()
 
 
-def _run_sharded(OptCls, scope, fraction, kw, world_size, port, tmp):
+def _run_sharded(OptCls, scope, fraction, kw, world_size, port, tmp, force_pad=False):
     out = str(tmp / f"out_{port}.pt")
-    mp.spawn(_worker, args=(world_size, port, OptCls, scope, fraction, kw, out),
-             nprocs=world_size, join=True)
+    mp.spawn(
+        _worker,
+        args=(world_size, port, OptCls, scope, fraction, kw, out, force_pad),
+        nprocs=world_size,
+        join=True,
+    )
     return torch.load(out)
 
 
@@ -108,7 +143,7 @@ def test_global_scope_matches_single_gpu_reference(OptCls, kw, tmp_path):
     d = _run_sharded(OptCls, "global", 0.25, kw, 2, 29610, tmp_path)
     W0 = d["W0"].cuda(); G = d["G"].cuda()
     ref = _reference_step(OptCls, W0, G, fraction=0.25, scope="global", **kw).cpu()
-    torch.testing.assert_close(d["W"], ref, rtol=2e-3, atol=2e-3)
+    torch.testing.assert_close(d["W"], ref, rtol=BF16_RTOL, atol=BF16_ATOL)
 
 
 @pytest.mark.skipif(CUDA < 2, reason="needs 2 GPUs")
@@ -128,9 +163,25 @@ def test_local_scope_runs_and_updates_selected(OptCls, kw, tmp_path):
     (Dion2, {}),
     (NorDion2, {"mu": 0.95, "muon_beta2": 0.95}),
 ])
+def test_local_scope_nopad_equals_pad(OptCls, kw, tmp_path):
+    """The headline fix: the local no-pad fast path must be numerically identical
+    to the old full-shard-pad path. Both select the same per-shard top-k rows;
+    the only difference is whether the dropped rows are zero-padded back before
+    the all-to-all (they never affect U^T U). Compare the real optimizer against
+    itself with the pad path forced on."""
+    nopad = _run_sharded(OptCls, "local", 0.25, kw, 2, 29650, tmp_path)
+    pad = _run_sharded(OptCls, "local", 0.25, kw, 2, 29660, tmp_path, force_pad=True)
+    torch.testing.assert_close(nopad["W"], pad["W"], rtol=BF16_RTOL, atol=BF16_ATOL)
+
+
+@pytest.mark.skipif(CUDA < 2, reason="needs 2 GPUs")
+@pytest.mark.parametrize("OptCls,kw", [
+    (Dion2, {}),
+    (NorDion2, {"mu": 0.95, "muon_beta2": 0.95}),
+])
 def test_fraction_one_local_equals_global(OptCls, kw, tmp_path):
     """At fraction=1.0 every row is selected, so local and global must agree
     (and both equal the whole-matrix reference)."""
     dl = _run_sharded(OptCls, "local", 1.0, kw, 2, 29630, tmp_path)
     dg = _run_sharded(OptCls, "global", 1.0, kw, 2, 29640, tmp_path)
-    torch.testing.assert_close(dl["W"], dg["W"], rtol=2e-3, atol=2e-3)
+    torch.testing.assert_close(dl["W"], dg["W"], rtol=BF16_RTOL, atol=BF16_ATOL)

--- a/tests/test_dion2_selection_scope.py
+++ b/tests/test_dion2_selection_scope.py
@@ -70,7 +70,7 @@ def _reference_step(OptCls, W0, G, *, fraction, scope, **kw):
     return p.detach().clone()
 
 
-def _worker(rank, world_size, port, OptCls, scope, fraction, kw, out_path, force_pad):
+def _worker(rank, world_size, port, OptCls, scope, fraction, kw, out_path, force_pad, shape):
     os.environ["MASTER_ADDR"] = "127.0.0.1"
     os.environ["MASTER_PORT"] = str(port)
     torch.cuda.set_device(rank)
@@ -96,7 +96,7 @@ def _worker(rank, world_size, port, OptCls, scope, fraction, kw, out_path, force
 
     # Wide (rows <= cols) so the unsharded reference also selects rows; see the
     # module docstring. Deterministic whole-matrix weight + grad on every rank.
-    rows, cols = 16, 32
+    rows, cols = shape
     g = torch.Generator(device=dev).manual_seed(1234)
     W0 = torch.randn(rows, cols, generator=g, device=dev)
     G = torch.randn(rows, cols, generator=g, device=dev)
@@ -122,15 +122,51 @@ def _worker(rank, world_size, port, OptCls, scope, fraction, kw, out_path, force
     dist.destroy_process_group()
 
 
-def _run_sharded(OptCls, scope, fraction, kw, world_size, port, tmp, force_pad=False):
+def _run_sharded(
+    OptCls, scope, fraction, kw, world_size, port, tmp, force_pad=False, shape=(16, 32)
+):
     out = str(tmp / f"out_{port}.pt")
     mp.spawn(
         _worker,
-        args=(world_size, port, OptCls, scope, fraction, kw, out, force_pad),
+        args=(world_size, port, OptCls, scope, fraction, kw, out, force_pad, shape),
         nprocs=world_size,
         join=True,
     )
     return torch.load(out)
+
+
+def test_global_scope_k_uses_global_size_not_padded():
+    """Global-scope selection must derive k from the TRUE unsharded size, not the
+    zero-padded assembled size. On the row-sharded path the matrix handed to the
+    select-and-orthogonalize wrapper is padded to ceil(global/world)*world rows;
+    deriving k from that padded size selects ceil(fraction*padded) slices -- more
+    than the whole-matrix top-k, and a count that varies with world_size -- when
+    global is not divisible by world_size, silently breaking the exact/reproducible
+    guarantee that motivates the global default. The existing sharded tests use a
+    divisible matrix (16 rows, 2 ranks) so they never exercise this. Pure-CPU unit
+    test of the wrapper (no GPUs, no distribution)."""
+    import math
+    from dion.dion2 import _make_select_and_orthogonalize
+
+    fraction, global_rows, cols = 0.35, 17, 6
+    # Simulate world_size=4: padded_local=ceil(17/4)=5 -> assembled = 20 rows
+    # (17 real + 3 zero-pad), so ceil(0.35*20)=7 but the true top-k is
+    # ceil(0.35*17)=6.
+    padded_rows = 20
+    torch.manual_seed(0)
+    X = torch.cat(
+        [torch.randn(global_rows, cols), torch.zeros(padded_rows - global_rows, cols)],
+        dim=0,
+    )
+    # Identity NS isolates the selection logic from the orthogonalization.
+    sel_ns = _make_select_and_orthogonalize(
+        lambda t, epsilon=None: t, fraction, -2, global_select_size=global_rows
+    )
+    out = sel_ns(X)
+    n_selected = int((out.abs().sum(-1) > 0).sum())
+    assert n_selected == math.ceil(fraction * global_rows)  # 6, not ceil(.35*20)=7
+    # Padded zero rows must never be selected.
+    assert out[global_rows:].abs().sum() == 0
 
 
 @pytest.mark.skipif(CUDA < 2, reason="needs 2 GPUs")
@@ -143,6 +179,26 @@ def test_global_scope_matches_single_gpu_reference(OptCls, kw, tmp_path):
     d = _run_sharded(OptCls, "global", 0.25, kw, 2, 29610, tmp_path)
     W0 = d["W0"].cuda(); G = d["G"].cuda()
     ref = _reference_step(OptCls, W0, G, fraction=0.25, scope="global", **kw).cpu()
+    torch.testing.assert_close(d["W"], ref, rtol=BF16_RTOL, atol=BF16_ATOL)
+
+
+@pytest.mark.skipif(CUDA < 4, reason="needs 4 GPUs")
+@pytest.mark.parametrize("OptCls,kw", [
+    (Dion2, {}),
+    (NorDion2, {"mu": 0.95, "muon_beta2": 0.95}),
+])
+def test_global_scope_uneven_shards_matches_reference(OptCls, kw, tmp_path):
+    """global-scope over shards that do NOT divide evenly must still equal the
+    single-GPU whole-matrix reference. 17 rows over 4 ranks chunk to [5,5,5,2];
+    each shard zero-pads to ceil(17/4)=5, so the assembled matrix has 20 rows
+    (17 real + 3 pad). With fraction=0.35 the true top-k is ceil(0.35*17)=6, but a
+    k derived from the padded size would be ceil(0.35*20)=7 -- selecting an extra
+    row and diverging from the reference (and varying with world_size). This is
+    the uneven-division counterpart to the divisible test above, and exercises the
+    fix end-to-end on the row-sharded path."""
+    d = _run_sharded(OptCls, "global", 0.35, kw, 4, 29670, tmp_path, shape=(17, 32))
+    W0 = d["W0"].cuda(); G = d["G"].cuda()
+    ref = _reference_step(OptCls, W0, G, fraction=0.35, scope="global", **kw).cpu()
     torch.testing.assert_close(d["W"], ref, rtol=BF16_RTOL, atol=BF16_ATOL)
 
 


### PR DESCRIPTION
Follow-up to #97 (now merged): two changes surfaced by the review + a cluster A/B on that PR.

### 1. Default `selection_scope` to `"global"` (keep `"local"` as opt-in)
A matched-seed convergence A/B (1.5B dense, FSDP2 shard-8, 100M tokens, 2 seeds) had `global` converge **~0.09 nat lower** than `local` at equal steps, with seed spread (0.003–0.034) far below the gap. `global` is also exact, world-size-reproducible, and faster-or-tied on optimizer-step time at every scale tested (1.5B–3B, 8–32 GPU; `local`'s cheaper all-to-all only closes the gap by 3B/32-GPU). So `global` wins on convergence, reproducibility, and speed at the tested scales; `local` stays fully supported as an opt-in for the comm-bound large-scale regime where its smaller all-to-all may eventually pay off. #97 only just introduced the option, so flipping the default has no existing users. Also documents `selection_scope` in the constructor Args (it was undocumented).

### 2. Fix the `selection_scope` tests (→ 8/8 on 2 GPUs)
- Wide **16×32** matrix so an *unsharded* Dion2 selects rows (it picks the shorter dim), matching the row-sharded path — the tall 16×8 made the single-GPU reference select **columns** and diverge (~41%).
- **bf16-scale tolerance** (`1.5e-2`): shards + Newton-Schulz run in bf16 (ULP ~8e-3 near magnitude 1), tighter than the old `2e-3`.
- New **`test_local_scope_nopad_equals_pad`**: forces the old full-shard-pad path (`megabatch local_comm_size=None`) and asserts it matches the no-pad fast path — directly validating that the dropped padded zero rows never affect UᵀU, for both Dion2 and NorDion2.

Still open (not addressed here): a dedicated uneven/empty-shard test for #97's new local generalization, and scoping the "numerically identical" wording to even divisions.
