### PR TITLE
Bump dion[gns] extra to gram-newton-schulz==0.1.6 (autotuner-off leak fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ All notable changes to this project are documented in this file.
   raises a clear `ImportError` at runtime instead of the kernels being silently
   present.
 
+- Bumped the optional `dion[gns]` extra to `gram-newton-schulz==0.1.6`
+  (`quack-kernels==0.5.0`, `nvidia-cutlass-dsl==4.5.2` unchanged). `0.1.6` turns off
+  quack's autotuner in the Gram Newton-Schulz kernel backend (gram-newton-schulz
+  PR #22), fixing a reserved-GPU-memory leak that laddered to OOM under sharded
+  training. It also lands the GNS algorithm-selection/transpose refactor
+  (gram-newton-schulz PR #18); the orthogonalization math is unchanged.
+
 - Bumped the optional `dion[gns]` extra to `gram-newton-schulz==0.1.5`
   (`quack-kernels==0.5.0`). This moves its transitive `nvidia-cutlass-dsl` pin from
   `4.4.2` to `4.5.2`, matching current Flash-Attention-4 / Blackwell stacks, so the

--- a/requirements_gns.txt
+++ b/requirements_gns.txt
@@ -1,6 +1,6 @@
 # Optional Gram Newton-Schulz orthogonalization kernels (use_gram_newton_schulz=True).
 # quack-kernels is pulled in transitively by gram-newton-schulz; the explicit pin here
 # is for reproducibility and must track whatever quack version the pinned gram-newton-schulz
-# requires (gram-newton-schulz==0.1.5 also transitively pins nvidia-cutlass-dsl==4.5.2).
-gram-newton-schulz==0.1.5
+# requires (gram-newton-schulz==0.1.6 also transitively pins nvidia-cutlass-dsl==4.5.2).
+gram-newton-schulz==0.1.6
 quack-kernels==0.5.0


### PR DESCRIPTION
## What

Bump the optional `dion[gns]` extra from `gram-newton-schulz==0.1.5` to `==0.1.6` in `requirements_gns.txt` (the single source of truth for the extra's version; `setup.py` reads it). `quack-kernels` stays `0.5.0` and the transitive `nvidia-cutlass-dsl` pin stays `4.5.2` — **the fix is autotuner-off, not a quack downgrade.**

## Why

`gram-newton-schulz==0.1.6` (released 2026-07-02) contains:

- **PR #22 "Turn off quack's autotuner to avoid OOM hangs"** — the fix for a reserved-GPU-memory leak in the Gram Newton-Schulz kernel backend on `quack-kernels==0.5.0`. Under sharded training the leak laddered reserved memory (~+10.7 GiB / ~20 steps at fixed peak-allocated) until OOM / NCCL-timeout SIGABRT ~step 85. The leak is quack 0.5.0's asymmetric-GEMM autotuner workspace fragmentation; `0.1.6` passes `tuned=False` to that backend so the trial workspace is never stranded.
- **PR #18** — a GNS refactor reducing algorithm-selection / transpose overhead. The orthogonalization math is unchanged.

The `0.1.5`→`0.1.6` `GramNewtonSchulz` change is autotuner-off + the selection refactor; it keeps the same `quack-kernels==0.5.0` / `nvidia-cutlass-dsl==4.5.2` dependency set (`0.1.6`'s `requires_dist` verified on PyPI).

## Validation — flat, no leak

Validated downstream on an 8×B200 sharded pretraining run at the scale that previously OOM'd (1B NorDion2, `use_gram_newton_schulz=True`, mxfp8, FA4, `subsample_stride=100` — the config that triggers the leak):

- **Reserved GPU memory FLAT**: a single distinct `reserved_gb` value (`112.798828125` GiB) across the whole run, monitored on **all 8 GPUs** (the leak is rank-dependent — rank-0-only monitors miss it); every GPU balanced at 124378 MiB used (max == min). Ran clean to step 1250 (~15× past the ~step-85 OOM point).
- The prior `0.1.5` / quack 0.5.0 combo (same cutlass 4.5.2) laddered to 168–183 GB on 5/8 GPUs and SIGABRT'd at step ~80–85.
- CE trained down monotonically (7.82 → ~2.20) straight through the steps where the leak used to crash — the PR #18 refactor did not change the math.

## Changes

- `requirements_gns.txt`: `gram-newton-schulz==0.1.5` → `==0.1.6` (+ comment).
- `CHANGELOG.md`: new `[Unreleased]` entry.

No README change: the README documents the extra name and the `nvidia-cutlass-dsl==4.5.2` pin (both unchanged); it does not pin the gram-newton-schulz version.