### PR TITLE
Default selection_scope to local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented in this file.
 
 ### Changed
 
+- The FSDP2 row-sharded `selection_scope` default (both `Dion2` and `NorDion2`)
+  is now `"local"` (per-shard top-k) again, reverting the `"global"` default from
+  #98 while keeping that PR's `global_select_size` padding-correctness fix intact.
+  `"local"` has cheaper per-shard communication (the win grows with matrix size)
+  and, in a 1B / 8-way-FSDP A/B, converges indistinguishably from `"global"`.
+  Note that `"local"` selection is sharding/world-size dependent, so default runs
+  are no longer bit-reproducible across world sizes; pass
+  `selection_scope="global"` for exact, layout-invariant selection (preferable at
+  larger scale or higher shard counts, where an earlier 1.5B A/B saw `"local"`
+  trail). No effect off the row-sharded path, where the two coincide.
+
 - AdamW scalar fallback now uses the base learning rate for LM head parameters,
   while Lion fallback keeps the `1 / sqrt(d_in)` LM-head scaling. This affects
   shipped `configs/*_160m.yaml` runs, which set `scalar_opt: adamw`.

--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -44,11 +44,13 @@ class Dion2(DistributedOrthoBase):
             Signature is ``func(input: Tensor, epsilon: float) -> Tensor``.
         verbose: Whether to print debug information during updates. If True, it prints whether rows or columns are selected for the submatrix selection process.
         selection_scope: On the FSDP2 row-sharded path, how the orthogonalized
-            submatrix is selected. "global" (default): exact top-k on the
-            assembled whole matrix -- layout-invariant/reproducible and better-
-            converging. "local": per-shard top-k (union) -- cheaper comm but a
-            sharding-dependent approximation that converges slightly worse; opt
-            in when comm-bound at large scale. No-op off the row-sharded path.
+            submatrix is selected. "local" (default): per-shard top-k (union) --
+            cheaper comm (the win grows with model size), a sharding-dependent
+            approximation of the true top-k. "global": exact top-k on the
+            assembled whole matrix -- full comm, layout-invariant/reproducible.
+            The gap is scale-dependent (see megabatch docstring); they tie at
+            moderate scale, so "local" is the default. No-op off the row-sharded
+            path.
 
     Dion2 optimizer by Ahn et al.: TBD
     """
@@ -71,7 +73,7 @@ class Dion2(DistributedOrthoBase):
         newton_schulz_func: Optional[Callable] = None,
         verbose: bool = False,
         triton_post_ortho: bool = False,
-        selection_scope: str = "global",
+        selection_scope: str = "local",
     ):
         # Validate hyperparameters
         if lr < 0.0:
@@ -216,7 +218,7 @@ def dion2_update_megabatch_async(
     newton_schulz_func: Optional[Callable] = None,
     verbose: bool = False,
     triton_post_ortho: bool = False,
-    selection_scope: str = "global",  # "global" (exact whole-matrix top-k, default) or "local" (per-shard top-k; cheaper comm, sharding-variant)
+    selection_scope: str = "local",  # "local" (per-shard top-k, cheaper comm, default) or "global" (exact whole-matrix top-k; layout-invariant)
 ) -> Generator[None, None, None]:
     """
     Mega-batched Dion2 update: processes ALL same-shape parameters in one
@@ -225,18 +227,22 @@ def dion2_update_megabatch_async(
     ``selection_scope`` controls how the orthogonalized submatrix is chosen on
     the row-sharded path:
 
-    - ``"global"`` (default): the full shard is communicated (like NorMuon), the
-      top-k is taken on the assembled whole matrix, and Newton-Schulz runs on
-      that submatrix. Comm is full-size but the selected set is the exact global
+    - ``"local"`` (default): each rank picks its own top-k rows, and only those
+      rows are communicated and orthogonalized, so comm and Newton-Schulz cost
+      scale with ``fraction``. The selected set is the union of per-rank top-k --
+      a sharding-dependent approximation of the true top-k (world-size variant).
+      Cheaper comm, and the win grows with model size.
+    - ``"global"``: the full shard is communicated (like NorMuon), the top-k is
+      taken on the assembled whole matrix, and Newton-Schulz runs on that
+      submatrix. Comm is full-size but the selected set is the exact global
       top-k -- invariant to the sharding layout (reproducible across world
-      sizes) and, in A/B tests, better-converging than "local" (which under-
-      performed it by ~0.09 nat at matched steps on a 1.5B dense run).
-    - ``"local"``: each rank picks its own top-k rows, and only those rows are
-      communicated and orthogonalized, so comm and Newton-Schulz cost scale with
-      ``fraction``. The selected set is the union of per-rank top-k -- a
-      sharding-dependent approximation of the true top-k (world-size variant).
-      Cheaper comm (the win grows with model size), but converges slightly
-      worse; opt in when comm-bound at large scale.
+      sizes).
+
+    Convergence is scale/shard-dependent. At 1B (dense MixFormer, 8-way FSDP,
+    10B tokens) "local" and "global" tie within noise on train CE, downstream
+    CORE, and BPB; an earlier 1.5B dense A/B saw "local" trail by ~0.09 nat at
+    matched steps. "local" is the default for its lower comm; choose "global"
+    for exact layout-invariant selection or at scales where the gap matters.
 
     Off the row-sharded path (per-head, single-GPU, batch-sharded) each rank
     already holds whole matrices, so local and global selection coincide and
@@ -335,7 +341,7 @@ def dion2_update_megabatch_async(
         )
         return
 
-    # --- Local selection (opt-in, selection_scope="local"): per-shard top-k, communicate only the
+    # --- Local selection (default; selection_scope="local"): per-shard top-k, communicate only the
     # selected rows. Under FSDP2 contiguous chunking every rank holds at most
     # ``padded_local = ceil(global / world_size)`` rows, so a uniform
     # ``k = ceil(fraction * padded_local)`` is the per-rank selected count. We

--- a/dion/nordion2.py
+++ b/dion/nordion2.py
@@ -51,11 +51,13 @@ class NorDion2(DistributedOrthoBase):
         newton_schulz_func: Use a custom Newton-Schulz function for orthogonalization.
             Signature is ``func(input: Tensor, epsilon: float) -> Tensor``.
         selection_scope: On the FSDP2 row-sharded path, how the orthogonalized
-            submatrix is selected. "global" (default): exact top-k on the
-            assembled whole matrix -- layout-invariant/reproducible and better-
-            converging. "local": per-shard top-k (union) -- cheaper comm but a
-            sharding-dependent approximation that converges slightly worse; opt
-            in when comm-bound at large scale. No-op off the row-sharded path.
+            submatrix is selected. "local" (default): per-shard top-k (union) --
+            cheaper comm (the win grows with model size), a sharding-dependent
+            approximation of the true top-k. "global": exact top-k on the
+            assembled whole matrix -- full comm, layout-invariant/reproducible.
+            The gap is scale-dependent (see megabatch docstring); they tie at
+            moderate scale, so "local" is the default. No-op off the row-sharded
+            path.
 
     NorDion2 optimizer applying Dion2 update to NorMuon
     """
@@ -78,7 +80,7 @@ class NorDion2(DistributedOrthoBase):
         use_gram_newton_schulz: bool = False,
         newton_schulz_func: Optional[Callable] = None,
         triton_post_ortho: bool = False,
-        selection_scope: str = "global",
+        selection_scope: str = "local",
     ):
         # Validate hyperparameters
         if lr < 0.0:
@@ -245,17 +247,18 @@ def nordion2_update_megabatch_async(
     process_group: Optional[ProcessGroup] = None,
     newton_schulz_func: Optional[Callable] = None,
     triton_post_ortho: bool = False,
-    selection_scope: str = "global",
+    selection_scope: str = "local",
 ) -> Generator[None, None, None]:
     """
     Mega-batched NorDion2 update: processes ALL same-shape parameters in one
     communication round instead of world_size-sized batches.
 
-    ``selection_scope`` mirrors Dion2: "global" (default) sends the full shard
-    and selects the exact top-k on the assembled whole matrix (full comm,
-    layout-invariant, better-converging); "local" selects each rank's top-k rows
-    before communication (cheaper comm, but a sharding-variant approximation that
-    converges slightly worse). See ``dion2_update_megabatch_async`` for details.
+    ``selection_scope`` mirrors Dion2: "local" (default) selects each rank's
+    top-k rows before communication (cheaper comm, sharding-variant
+    approximation); "global" sends the full shard and selects the exact top-k on
+    the assembled whole matrix (full comm, layout-invariant). They tie within
+    noise at 1B/8-way FSDP; see ``dion2_update_megabatch_async`` for the
+    scale-dependence and A/B evidence.
     """
     N = len(X)
     assert N == len(G) == len(M) == len(V)
@@ -327,7 +330,7 @@ def nordion2_update_megabatch_async(
         )
         return
 
-    # --- Local selection (opt-in, selection_scope="local"): per-shard top-k, communicate only the
+    # --- Local selection (default; selection_scope="local"): per-shard top-k, communicate only the
     # selected rows. Uniform k = ceil(fraction * ceil(global / world_size)) is
     # the per-rank selected count under FSDP2 contiguous chunking; the megabatch
     # pads every shard to exactly k (short/empty shards zero-pad), so the

--- a/tests/test_dion2_selection_scope.py
+++ b/tests/test_dion2_selection_scope.py
@@ -142,7 +142,7 @@ def test_global_scope_k_uses_global_size_not_padded():
     deriving k from that padded size selects ceil(fraction*padded) slices -- more
     than the whole-matrix top-k, and a count that varies with world_size -- when
     global is not divisible by world_size, silently breaking the exact/reproducible
-    guarantee that motivates the global default. The existing sharded tests use a
+    guarantee that global scope provides. The existing sharded tests use a
     divisible matrix (16 rows, 2 ranks) so they never exercise this. Pure-CPU unit
     test of the wrapper (no GPUs, no distribution)."""
     import math

--- a/tests/test_dion2_selection_scope.py
+++ b/tests/test_dion2_selection_scope.py
@@ -169,6 +169,32 @@ def test_global_scope_k_uses_global_size_not_padded():
     assert out[global_rows:].abs().sum() == 0
 
 
+def test_default_selection_scope_is_local():
+    """The default ``selection_scope`` is "local" -- the sole behavior change of
+    #101. Pin it in one cheap CPU-only place (no GPUs, no distribution) so an
+    accidental re-flip, or drift between the four default sites -- ``Dion2`` and
+    ``NorDion2`` ``__init__`` and their ``*_update_megabatch_async`` functions --
+    is caught by CI. The convergence/throughput case for the value lives in the
+    A/B evidence; this only guards the constant and keeps the two optimizers (and
+    their direct-call entry points) in agreement."""
+    import inspect
+    from dion.dion2 import dion2_update_megabatch_async
+    from dion.nordion2 import nordion2_update_megabatch_async
+
+    p = torch.nn.Parameter(torch.randn(4, 6))
+    d2 = Dion2([dict(params=[p])], distributed_mesh=None, lr=0.1)
+    nd2 = NorDion2(
+        [dict(params=[p])], distributed_mesh=None, lr=0.1, mu=0.95, muon_beta2=0.95
+    )
+    assert d2.param_groups[0]["selection_scope"] == "local"
+    assert nd2.param_groups[0]["selection_scope"] == "local"
+
+    # The megabatch update functions carry their own default; a direct caller that
+    # omits selection_scope must see the same "local" the optimizer applies.
+    for fn in (dion2_update_megabatch_async, nordion2_update_megabatch_async):
+        assert inspect.signature(fn).parameters["selection_scope"].default == "local"
+
+
 @pytest.mark.skipif(CUDA < 2, reason="needs 2 GPUs")
 @pytest.mark.parametrize("OptCls,kw", [
     (Dion2, {}),


### PR DESCRIPTION
## Summary

Flip the `selection_scope` default (both `NorDion2` and `Dion2`) from `"global"` back to `"local"` on the FSDP2 row-sharded path. This is a one-value change plus docs — it **keeps #98's `global_select_size` padding-correctness fix intact** (only the default is reverted, not the machinery).

## Why

#98 set the default to `global` on the strength of a single A/B where `local` trailed by ~0.09 nat on a 1.5B dense run. Since then we've assembled a broader evidence base on the production target (phinext MixFormer), and `local` ties `global`:

**Convergence A/B — 1B, dense MixFormer, 8-way FSDP, 10B tokens phinext, matched step, `fraction=0.25`** (also ran `fraction=0.5`; same result):

| scope | train CE | CORE | BPB climbmix / web / code |
|---|---|---|---|
| `global` | 1.4717 | 0.2262 | 0.8486 / 0.9963 / 0.4744 |
| `local`  | 1.4705 | 0.2209 | 0.8480 / 0.9959 / 0.4736 |

Every delta is within noise (BPB SE 0.003–0.016; CORE 1B floor ±0.016); `local` is if anything marginally ahead. The claimed ~0.09 nat ≈ 0.13 bits gap does not reproduce — the observed BPB gap is ~0.0006 bits (~200× smaller).

**Throughput — same-pod, real MixFormer + production GNS, CUDA-event timing (no intra-step sync):** `local` ties `global` at 1B and is ~0.9% faster full-step at 14B (optimizer 0.92×); the per-shard comm saving grows with matrix size.

## Honest caveat

The two results aren't contradictory — `local`'s per-shard top-k error is **scale/shard-dependent**: it ties at 1B / 8-way FSDP and trailed at 1.5B. So `global` is the safer choice at larger scale or higher shard counts, and it remains a first-class option — its docstring now documents **both** data points and the scale-dependence, rather than asserting `global` converges better unconditionally. For the common case, `local` is cheaper and converges indistinguishably, which makes it the better default.

## Changes

- `dion/dion2.py`, `dion/nordion2.py`: default `selection_scope="global"` → `"local"` in the optimizer `__init__` **and** the megabatch update functions; docstrings reframed to present both A/B data points.
- `tests/test_dion2_selection_scope.py`: unchanged in behavior (tests parametrize `selection_scope` explicitly, so the default flip doesn't touch their assertions); one stale "global default" comment updated.

CI runs the row-sharded correctness tests for both scopes; the `local` path is also validated end-to-end by the convergence A/B above.
