### PR TITLE
fix(triton): use int64 for batched pointer offsets

### DIFF
--- a/dion/newton_schulz_triton.py
+++ b/dion/newton_schulz_triton.py
@@ -46,6 +46,11 @@ def _get_autotune_configs():
 
 
 @triton.jit
+def _batch_offset(batch_idx, batch_stride):
+    return batch_idx.to(tl.int64) * batch_stride
+
+
+@triton.jit
 def _pid_to_block(
     pid,
     M,
@@ -116,8 +121,8 @@ def ns_line_1_kernel(
         return
 
     # Index into one matrix of batch
-    A_ptr += batch_idx * a_stride_b
-    C_ptr += batch_idx * c_stride_b
+    A_ptr += _batch_offset(batch_idx, a_stride_b)
+    C_ptr += _batch_offset(batch_idx, c_stride_b)
 
     # Create pointer arrays for A and A.T
     offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
@@ -235,8 +240,8 @@ def ns_line_2_kernel(
         return
 
     # Index into one matrix of batch
-    A_ptr += batch_idx * a_stride_b
-    C_ptr += batch_idx * c_stride_b
+    A_ptr += _batch_offset(batch_idx, a_stride_b)
+    C_ptr += _batch_offset(batch_idx, c_stride_b)
 
     # Create pointer arrays for A and A.T
     offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
@@ -403,9 +408,9 @@ def ns_line_3_kernel(
     )
 
     # Offset base pointers to this batch
-    B_ptr += batch * b_stride_b
-    X_ptr += batch * x_stride_b
-    C_ptr += batch * c_stride_b
+    B_ptr += _batch_offset(batch, b_stride_b)
+    X_ptr += _batch_offset(batch, x_stride_b)
+    C_ptr += _batch_offset(batch, c_stride_b)
 
     # Create index ranges for the tile
     offs_m = m_start + tl.arange(0, BLOCK_SIZE_M)


### PR DESCRIPTION
Cast batch indices to int64 before multiplying by tensor strides in the Newton-Schulz Triton kernels. This prevents 32-bit address offset overflow for large Muon megabatches, such as w13 tensors with shape [320, 2560, 3072].

Apply the fix consistently to ns_line_1, ns_line_2, and ns_line_3, and add a low-memory regression test that verifies offsets beyond INT32_MAX and confirms the generated TTIR performs the multiplication in i64.