### PR TITLE
Make the megabatched optimizer step CUDA-graph-capturable

### DIFF
--- a/dion/cuda_graph.py
+++ b/dion/cuda_graph.py
@@ -12,19 +12,30 @@ graph launch (GPU time unchanged), and the capture holds through the megabatch a
 Usage (drop-in around any optimizer whose step() is graph-safe -- no host syncs, fixed
 shapes, gradients living in stable ``.grad`` tensors):
 
-    opt = CudaGraphOptimizer(Dion2(param_groups, ...), warmup_steps=10)
+    inner = Dion2(param_groups, ...)
+    sched = torch.optim.lr_scheduler.CosineAnnealingLR(inner, T_max=...)  # NOT the wrapper
+    opt = CudaGraphOptimizer(inner, warmup_steps=10)
     for batch in loader:
         loss = model(batch); loss.backward()
         opt.step()                    # eager for warmup_steps, then captured+replayed
         opt.zero_grad(set_to_none=False)   # MUST keep .grad tensors stable for replay
+        sched.step()
 
 Requirements / caveats:
+  * LR schedulers must be constructed on the *inner* optimizer: torch's ``LRScheduler``
+    rejects anything failing ``isinstance(opt, torch.optim.Optimizer)``, which this
+    wrapper is not. Scheduling still works -- the scheduler writes ``group["lr"]`` and the
+    wrapper pushes that into the device LR tensors before each replay.
   * ``loss.backward()`` must accumulate into the same ``p.grad`` tensors each step, so
     call ``zero_grad(set_to_none=False)`` (the wrapper enforces this). The first
     backward allocates ``.grad``; capture pins those buffers.
   * The step must not do a host sync (``.item()``/``.cpu()``) or change tensor shapes
     across steps. Dion2/NorDion2's selection *count* is fixed; only indices/values vary,
     which replay handles (it re-reads the live tensors).
+  * On the sharded path the graph holds the captured megabatch all-to-all, so the NCCL
+    ops outlive the step. ``dist.destroy_process_group()`` blocks while they are alive:
+    drop the wrapper (and any graph it holds) before tearing the process group down at
+    the end of a run, or shutdown hangs.
   * torch.compile is neither needed nor wanted under a graph (the graph already removes
     dispatch, and a fullgraph compile of the unrolled per-matrix loops is what makes the
     first step take minutes at many layers). Disable it for the wrapped optimizer.
@@ -44,10 +55,26 @@ import torch
 
 class CudaGraphOptimizer:
     def __init__(self, optimizer, warmup_steps: int = 10):
+        if warmup_steps < 1:
+            raise ValueError(
+                f"warmup_steps must be >= 1, got {warmup_steps}. Capture needs at least "
+                "one eager step to have allocated the optimizer state, cuBLAS workspaces "
+                "and NCCL buffers; capturing the first step instead allocates them inside "
+                "the graph and fails deep in the backend."
+            )
         self.optimizer = optimizer
         self.warmup_steps = warmup_steps
         self._step_count = 0
         self._graph: Optional[torch.cuda.CUDAGraph] = None
+
+    def __getattr__(self, name):
+        # Delegate the rest of the Optimizer API (state, defaults, add_param_group, ...).
+        # Only called for attributes not found normally, so the overrides below still win.
+        # ``optimizer`` is guarded because __getattr__ runs before __init__ assigns it
+        # (e.g. during unpickling), which would otherwise recurse forever.
+        if name == "optimizer":
+            raise AttributeError(name)
+        return getattr(self.optimizer, name)
 
     @property
     def param_groups(self):
@@ -96,7 +123,13 @@ class CudaGraphOptimizer:
         if self._step_count < self.warmup_steps:
             self.optimizer.step()
         elif self._graph is None:
+            # step() runs (and so does its host-side bookkeeping) while being traced.
             self._capture()
         else:
             self._graph.replay()
+            # Replay executes only the recorded device work, so any host-side per-step
+            # bookkeeping in step() has to be advanced here instead.
+            advance = getattr(self.optimizer, "_advance_host_step_counters", None)
+            if advance is not None:
+                advance()
         self._step_count += 1

--- a/dion/cuda_graph.py
+++ b/dion/cuda_graph.py
@@ -1,0 +1,102 @@
+"""CUDA-graph capture for the optimizer step.
+
+The megabatched Muon/NorMuon/Dion2/NorDion2 optimizer step issues hundreds of small host
+ops per step for its per-matrix selection / error-feedback / normalization bookkeeping. On
+a sharded step that host dispatch (tens of ms at multi-B scale) is a fixed overhead that
+does not shrink with the data-parallel group, so it dominates the distributed step at
+small per-GPU compute. The step is a fixed-shape, repeated computation -- an ideal
+CUDA-graph target. Capturing it once and replaying collapses the host dispatch to a single
+graph launch (GPU time unchanged), and the capture holds through the megabatch all-to-all
+(NCCL) and the symmetric-GEMM (CuteDSL) kernels.
+
+Usage (drop-in around any optimizer whose step() is graph-safe -- no host syncs, fixed
+shapes, gradients living in stable ``.grad`` tensors):
+
+    opt = CudaGraphOptimizer(Dion2(param_groups, ...), warmup_steps=10)
+    for batch in loader:
+        loss = model(batch); loss.backward()
+        opt.step()                    # eager for warmup_steps, then captured+replayed
+        opt.zero_grad(set_to_none=False)   # MUST keep .grad tensors stable for replay
+
+Requirements / caveats:
+  * ``loss.backward()`` must accumulate into the same ``p.grad`` tensors each step, so
+    call ``zero_grad(set_to_none=False)`` (the wrapper enforces this). The first
+    backward allocates ``.grad``; capture pins those buffers.
+  * The step must not do a host sync (``.item()``/``.cpu()``) or change tensor shapes
+    across steps. Dion2/NorDion2's selection *count* is fixed; only indices/values vary,
+    which replay handles (it re-reads the live tensors).
+  * torch.compile is neither needed nor wanted under a graph (the graph already removes
+    dispatch, and a fullgraph compile of the unrolled per-matrix loops is what makes the
+    first step take minutes at many layers). Disable it for the wrapped optimizer.
+  * Both the matrix (Muon/NorMuon/Dion2/NorDion2) path and the AdamW *scalar* path
+    (embeddings / 1-D params) are capturable. Each group carries its learning rate as a
+    device tensor (``megabatch_base._group_lr_tensor``) that the wrapper refreshes before
+    each replay, so a *scheduled* LR takes effect under replay instead of freezing at the
+    capture value; and ``scalar_opts.adamw_update_foreach``'s capturable form keeps each
+    AdamW param's step as a device tensor and increments it on-device before the fused
+    kernel, so bias correction advances inside the graph. Verified bit-exact eager-vs-
+    replay for both a constant and a per-step-scheduled LR (``tests/test_cuda_graph.py``).
+"""
+
+from typing import Optional
+import torch
+
+
+class CudaGraphOptimizer:
+    def __init__(self, optimizer, warmup_steps: int = 10):
+        self.optimizer = optimizer
+        self.warmup_steps = warmup_steps
+        self._step_count = 0
+        self._graph: Optional[torch.cuda.CUDAGraph] = None
+
+    @property
+    def param_groups(self):
+        return self.optimizer.param_groups
+
+    def state_dict(self):
+        return self.optimizer.state_dict()
+
+    def load_state_dict(self, sd):
+        # Loading new state invalidates any captured graph (buffers may move).
+        self._graph = None
+        self._step_count = 0
+        return self.optimizer.load_state_dict(sd)
+
+    def zero_grad(self, set_to_none: bool = False):
+        # set_to_none=True would swap .grad for a fresh tensor each step, breaking the
+        # graph's pinned grad buffers. Force the stable-buffer path.
+        if set_to_none:
+            raise ValueError(
+                "CudaGraphOptimizer requires stable .grad buffers; call "
+                "zero_grad(set_to_none=False)."
+            )
+        self.optimizer.zero_grad(set_to_none=False)
+
+    def _capture(self):
+        # Capture exactly ONE step. Lazy allocations, cuBLAS workspaces and NCCL setup are
+        # already done by the warmup_steps eager steps, so nothing allocates inside the
+        # graph. Capture only RECORDS the ops onto the graph -- it does not execute them --
+        # so we replay once immediately to actually perform this step's update. Without
+        # that replay the trajectory would be one step short (params/state/step frozen at
+        # their pre-capture values for this call).
+        torch.cuda.synchronize()
+        self._graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(self._graph):
+            self.optimizer.step()
+        self._graph.replay()
+
+    def step(self):
+        # Push the current (possibly scheduled) LR into the wrapped optimizer's device LR
+        # tensors here, OUTSIDE the graph, so the captured step reads the live value on
+        # every replay. The optimizer's own in-step refresh is skipped while capturing, so
+        # this is the only refresh the replay path gets.
+        refresh = getattr(self.optimizer, "_refresh_lr_tensors", None)
+        if refresh is not None:
+            refresh()
+        if self._step_count < self.warmup_steps:
+            self.optimizer.step()
+        elif self._graph is None:
+            self._capture()
+        else:
+            self._graph.replay()
+        self._step_count += 1

--- a/dion/cuda_graph.py
+++ b/dion/cuda_graph.py
@@ -23,9 +23,13 @@ shapes, gradients living in stable ``.grad`` tensors):
 
 Requirements / caveats:
   * LR schedulers must be constructed on the *inner* optimizer: torch's ``LRScheduler``
-    rejects anything failing ``isinstance(opt, torch.optim.Optimizer)``, which this
-    wrapper is not. Scheduling still works -- the scheduler writes ``group["lr"]`` and the
-    wrapper pushes that into the device LR tensors before each replay.
+    rejects anything failing ``isinstance(opt, torch.optim.Optimizer)``, which this wrapper
+    is not. Scheduling still works with no wrapper plumbing -- ``group["lr"]`` is the device
+    tensor the captured graph reads, and the scheduler (bound to the inner optimizer, which
+    shares the same param_groups) fills it in place outside the graph, so every replay
+    re-reads the live value. A *scheduled* LR takes effect under replay only through such an
+    in-place update; reassigning a python float (``group["lr"] = 0.05``) swaps the tensor
+    out and leaves replay reading the stale one until the next eager step.
   * ``loss.backward()`` must accumulate into the same ``p.grad`` tensors each step, so
     call ``zero_grad(set_to_none=False)`` (the wrapper enforces this). The first
     backward allocates ``.grad``; capture pins those buffers.
@@ -41,12 +45,14 @@ Requirements / caveats:
     first step take minutes at many layers). Disable it for the wrapped optimizer.
   * Both the matrix (Muon/NorMuon/Dion2/NorDion2) path and the AdamW *scalar* path
     (embeddings / 1-D params) are capturable. Each group carries its learning rate as a
-    device tensor (``megabatch_base._group_lr_tensor``) that the wrapper refreshes before
-    each replay, so a *scheduled* LR takes effect under replay instead of freezing at the
-    capture value; and ``scalar_opts.adamw_update_foreach``'s capturable form keeps each
-    AdamW param's step as a device tensor and increments it on-device before the fused
-    kernel, so bias correction advances inside the graph. Verified bit-exact eager-vs-
-    replay for both a constant and a per-step-scheduled LR (``tests/test_cuda_graph.py``).
+    device tensor -- ``group["lr"]`` *is* that tensor -- which the kernels read directly, so
+    a ``torch.optim`` LR scheduler drives a captured step natively: it fills the tensor in
+    place outside the graph and every replay re-reads the live value, no refresh plumbing.
+    (Build the scheduler on the *inner* optimizer; ``group["lr"]`` is shared, so it updates
+    the exact tensor the captured graph reads.) The AdamW step is likewise a device tensor,
+    incremented on-device before the fused kernel so bias correction advances inside the
+    graph. Verified bit-exact eager-vs-replay for a constant and a per-step-scheduled LR,
+    including under a real ``CosineAnnealingLR`` (``tests/test_cuda_graph.py``).
 """
 
 from typing import Optional
@@ -113,13 +119,9 @@ class CudaGraphOptimizer:
         self._graph.replay()
 
     def step(self):
-        # Push the current (possibly scheduled) LR into the wrapped optimizer's device LR
-        # tensors here, OUTSIDE the graph, so the captured step reads the live value on
-        # every replay. The optimizer's own in-step refresh is skipped while capturing, so
-        # this is the only refresh the replay path gets.
-        refresh = getattr(self.optimizer, "_refresh_lr_tensors", None)
-        if refresh is not None:
-            refresh()
+        # No LR plumbing here: the wrapped optimizer carries each group's LR as the device
+        # tensor ``group["lr"]`` that the kernels read, and a scheduler fills it in place
+        # outside the graph, so every replay already re-reads the live value.
         if self._step_count < self.warmup_steps:
             self.optimizer.step()
         elif self._graph is None:

--- a/dion/cuda_graph.py
+++ b/dion/cuda_graph.py
@@ -21,10 +21,15 @@ shapes, gradients living in stable ``.grad`` tensors):
         opt.zero_grad(set_to_none=False)   # MUST keep .grad tensors stable for replay
         sched.step()
 
+Under a framework that drives automatic optimization with a closure (Lightning calls
+``opt.step(closure)``, the closure running forward+backward), ``step`` runs the closure
+first, then replays the captured update and returns its loss.
+
 Requirements / caveats:
-  * LR schedulers must be constructed on the *inner* optimizer: torch's ``LRScheduler``
-    rejects anything failing ``isinstance(opt, torch.optim.Optimizer)``, which this wrapper
-    is not. Scheduling still works with no wrapper plumbing -- ``group["lr"]`` is the device
+  * The wrapper is a ``torch.optim.Optimizer`` subclass (so ``isinstance`` holds for
+    Lightning and torch's ``LRScheduler``) that delegates all state to the inner optimizer;
+    a scheduler may bind to either, since they share ``param_groups``. Scheduling works with
+    no wrapper plumbing -- ``group["lr"]`` is the device
     tensor the captured graph reads, and the scheduler (bound to the inner optimizer, which
     shares the same param_groups) fills it in place outside the graph, so every replay
     re-reads the live value. A *scheduled* LR takes effect under replay only through such an
@@ -55,12 +60,15 @@ Requirements / caveats:
     including under a real ``CosineAnnealingLR`` (``tests/test_cuda_graph.py``).
 """
 
-from typing import Optional
+import warnings
+from collections import OrderedDict
+from typing import Callable, Optional
+
 import torch
 
 
-class CudaGraphOptimizer:
-    def __init__(self, optimizer, warmup_steps: int = 10):
+class CudaGraphOptimizer(torch.optim.Optimizer):
+    def __init__(self, optimizer: torch.optim.Optimizer, warmup_steps: int = 10):
         if warmup_steps < 1:
             raise ValueError(
                 f"warmup_steps must be >= 1, got {warmup_steps}. Capture needs at least "
@@ -68,10 +76,23 @@ class CudaGraphOptimizer:
                 "and NCCL buffers; capturing the first step instead allocates them inside "
                 "the graph and fails deep in the backend."
             )
+        # We deliberately do NOT call Optimizer.__init__: it would build a second, empty
+        # param_groups/state on this object. Subclassing is only so isinstance(self,
+        # Optimizer) holds (Lightning, torch's LRScheduler); every Optimizer attribute
+        # delegates to the wrapped optimizer via the overrides below and __getattr__. We
+        # still create the hook registries Optimizer.__init__ would, since torch reads them
+        # on state_dict()/step().
         self.optimizer = optimizer
         self.warmup_steps = warmup_steps
         self._step_count = 0
         self._graph: Optional[torch.cuda.CUDAGraph] = None
+        self._warned_set_to_none = False
+        self._optimizer_step_pre_hooks = OrderedDict()
+        self._optimizer_step_post_hooks = OrderedDict()
+        self._optimizer_state_dict_pre_hooks = OrderedDict()
+        self._optimizer_state_dict_post_hooks = OrderedDict()
+        self._optimizer_load_state_dict_pre_hooks = OrderedDict()
+        self._optimizer_load_state_dict_post_hooks = OrderedDict()
 
     def __getattr__(self, name):
         # Delegate the rest of the Optimizer API (state, defaults, add_param_group, ...).
@@ -86,6 +107,17 @@ class CudaGraphOptimizer:
     def param_groups(self):
         return self.optimizer.param_groups
 
+    @param_groups.setter
+    def param_groups(self, value):
+        self.optimizer.param_groups = value
+
+    def add_param_group(self, param_group):
+        # torch.optim.Optimizer defines add_param_group, so (unlike state/defaults) it is
+        # found on the base class and __getattr__ never delegates it -- override explicitly.
+        # A new group is not in the captured graph; drop it so the next step re-captures.
+        self._graph = None
+        return self.optimizer.add_param_group(param_group)
+
     def state_dict(self):
         return self.optimizer.state_dict()
 
@@ -97,11 +129,14 @@ class CudaGraphOptimizer:
 
     def zero_grad(self, set_to_none: bool = False):
         # set_to_none=True would swap .grad for a fresh tensor each step, breaking the
-        # graph's pinned grad buffers. Force the stable-buffer path.
-        if set_to_none:
-            raise ValueError(
-                "CudaGraphOptimizer requires stable .grad buffers; call "
-                "zero_grad(set_to_none=False)."
+        # graph's pinned grad buffers. Force the stable-buffer path; a framework that
+        # defaults to True (e.g. Lightning) gets a one-time warning, not a hard failure.
+        if set_to_none and not self._warned_set_to_none:
+            self._warned_set_to_none = True
+            warnings.warn(
+                "CudaGraphOptimizer needs stable .grad buffers for graph replay; "
+                "ignoring set_to_none=True and zeroing in place.",
+                RuntimeWarning,
             )
         self.optimizer.zero_grad(set_to_none=False)
 
@@ -118,10 +153,16 @@ class CudaGraphOptimizer:
             self.optimizer.step()
         self._graph.replay()
 
-    def step(self):
+    def step(self, closure: Optional[Callable] = None):
+        # Automatic-optimization frameworks (Lightning) call step(closure); the closure runs
+        # forward+backward, filling the stable .grad buffers the capture reads. Run it eagerly
+        # first, then apply the captured update and return its loss. replay() launches on the
+        # current stream -- where the closure's backward ran -- so the update is ordered after
+        # the fresh gradients.
         # No LR plumbing here: the wrapped optimizer carries each group's LR as the device
         # tensor ``group["lr"]`` that the kernels read, and a scheduler fills it in place
         # outside the graph, so every replay already re-reads the live value.
+        loss = closure() if closure is not None else None
         if self._step_count < self.warmup_steps:
             self.optimizer.step()
         elif self._graph is None:
@@ -135,3 +176,4 @@ class CudaGraphOptimizer:
             if advance is not None:
                 advance()
         self._step_count += 1
+        return loss

--- a/dion/cuda_graph.py
+++ b/dion/cuda_graph.py
@@ -29,18 +29,23 @@ Requirements / caveats:
   * The wrapper is a ``torch.optim.Optimizer`` subclass (so ``isinstance`` holds for
     Lightning and torch's ``LRScheduler``) that delegates all state to the inner optimizer;
     a scheduler may bind to either, since they share ``param_groups``. Scheduling works with
-    no wrapper plumbing -- ``group["lr"]`` is the device
-    tensor the captured graph reads, and the scheduler (bound to the inner optimizer, which
-    shares the same param_groups) fills it in place outside the graph, so every replay
-    re-reads the live value. A *scheduled* LR takes effect under replay only through such an
-    in-place update; reassigning a python float (``group["lr"] = 0.05``) swaps the tensor
-    out and leaves replay reading the stale one until the next eager step.
+    no wrapper plumbing -- ``group["lr"]`` is the device tensor the captured graph reads,
+    and a stock ``torch.optim`` scheduler fills it in place outside the graph, so every
+    replay re-reads the live value. Assigning a plain float (``group["lr"] = 0.05``, the
+    idiom of a hand-rolled schedule) also works: before capturing or replaying, the wrapper
+    asks the inner optimizer to push any such value back into the persistent tensor.
+    Optimizers outside this family have no such hook, so any hyperparameter they read as a
+    host-side python value -- an LR included -- is baked in at capture and stops changing.
   * ``loss.backward()`` must accumulate into the same ``p.grad`` tensors each step, so
     call ``zero_grad(set_to_none=False)`` (the wrapper enforces this). The first
     backward allocates ``.grad``; capture pins those buffers.
   * The step must not do a host sync (``.item()``/``.cpu()``) or change tensor shapes
     across steps. Dion2/NorDion2's selection *count* is fixed; only indices/values vary,
     which replay handles (it re-reads the live tensors).
+  * Which parameters take part is fixed at capture time: the step skips params whose
+    ``.grad`` is None, so a param that is frozen (or gets no tokens) during the warmup
+    steps is left out of the graph and stops being updated for the rest of the run, with
+    no error. Wrap only a step whose set of grad-carrying params is stable.
   * On the sharded path the graph holds the captured megabatch all-to-all, so the NCCL
     ops outlive the step. ``dist.destroy_process_group()`` blocks while they are alive:
     drop the wrapper (and any graph it holds) before tearing the process group down at
@@ -68,7 +73,12 @@ import torch
 
 
 class CudaGraphOptimizer(torch.optim.Optimizer):
-    def __init__(self, optimizer: torch.optim.Optimizer, warmup_steps: int = 10):
+    def __init__(
+        self,
+        optimizer: torch.optim.Optimizer,
+        warmup_steps: int = 10,
+        capture_error_mode: str = "thread_local",
+    ):
         if warmup_steps < 1:
             raise ValueError(
                 f"warmup_steps must be >= 1, got {warmup_steps}. Capture needs at least "
@@ -84,6 +94,13 @@ class CudaGraphOptimizer(torch.optim.Optimizer):
         # on state_dict()/step().
         self.optimizer = optimizer
         self.warmup_steps = warmup_steps
+        # torch's cudaStreamCaptureMode. torch defaults to "global", which errors when
+        # *any* thread makes a capture-unsafe CUDA call while capture is underway -- and in
+        # a distributed run the ProcessGroupNCCL watchdog thread polls cudaEventQuery,
+        # which is exactly such a call. "thread_local" is what inductor uses for all of its
+        # own captures, for the same reason; it still catches unsafe calls made by the
+        # capturing thread, i.e. by the step itself.
+        self.capture_error_mode = capture_error_mode
         self._step_count = 0
         self._graph: Optional[torch.cuda.CUDAGraph] = None
         self._warned_set_to_none = False
@@ -115,7 +132,12 @@ class CudaGraphOptimizer(torch.optim.Optimizer):
         # torch.optim.Optimizer defines add_param_group, so (unlike state/defaults) it is
         # found on the base class and __getattr__ never delegates it -- override explicitly.
         # A new group is not in the captured graph; drop it so the next step re-captures.
+        # Restart the warmup as well: the new group's state, workspaces and comm buffers
+        # have never been touched by an eager step, and re-capturing straight away would
+        # allocate (or recompile) them inside the graph -- the failure warmup_steps exists
+        # to prevent.
         self._graph = None
+        self._step_count = 0
         return self.optimizer.add_param_group(param_group)
 
     def state_dict(self):
@@ -148,10 +170,25 @@ class CudaGraphOptimizer(torch.optim.Optimizer):
         # that replay the trajectory would be one step short (params/state/step frozen at
         # their pre-capture values for this call).
         torch.cuda.synchronize()
-        self._graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(self._graph):
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, capture_error_mode=self.capture_error_mode):
             self.optimizer.step()
-        self._graph.replay()
+        # Publish only once capture has succeeded. A graph left over from a failed capture
+        # is not replayable, and holding it here would turn one loud capture error into
+        # every later step silently replaying garbage.
+        self._graph = graph
+        graph.replay()
+
+    def _sync_host_hyperparams(self):
+        # The captured graph reads each group's LR from the device tensor that was live at
+        # capture time. A stock LR scheduler fills that tensor in place, so it needs
+        # nothing from us -- but the equally common `group["lr"] = 0.05` assignment
+        # replaces it with a float the graph will never see. step() reconciles that on the
+        # eager path; under capture/replay it either does not run at all (replay) or runs
+        # with capture already underway (capture), so do it here, before either.
+        sync = getattr(self.optimizer, "_sync_lr_tensors", None)
+        if sync is not None:
+            sync()
 
     def step(self, closure: Optional[Callable] = None):
         # Automatic-optimization frameworks (Lightning) call step(closure); the closure runs
@@ -159,21 +196,23 @@ class CudaGraphOptimizer(torch.optim.Optimizer):
         # first, then apply the captured update and return its loss. replay() launches on the
         # current stream -- where the closure's backward ran -- so the update is ordered after
         # the fresh gradients.
-        # No LR plumbing here: the wrapped optimizer carries each group's LR as the device
-        # tensor ``group["lr"]`` that the kernels read, and a scheduler fills it in place
-        # outside the graph, so every replay already re-reads the live value.
-        loss = closure() if closure is not None else None
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
         if self._step_count < self.warmup_steps:
             self.optimizer.step()
-        elif self._graph is None:
-            # step() runs (and so does its host-side bookkeeping) while being traced.
-            self._capture()
         else:
-            self._graph.replay()
-            # Replay executes only the recorded device work, so any host-side per-step
-            # bookkeeping in step() has to be advanced here instead.
-            advance = getattr(self.optimizer, "_advance_host_step_counters", None)
-            if advance is not None:
-                advance()
+            self._sync_host_hyperparams()
+            if self._graph is None:
+                # step() runs (and so does its host-side bookkeeping) while being traced.
+                self._capture()
+            else:
+                self._graph.replay()
+                # Replay executes only the recorded device work, so any host-side per-step
+                # bookkeeping in step() has to be advanced here instead.
+                advance = getattr(self.optimizer, "_advance_host_step_counters", None)
+                if advance is not None:
+                    advance()
         self._step_count += 1
         return loss

--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -142,7 +142,7 @@ class Dion2(DistributedOrthoBase):
                 continue
 
             update_args = dict(
-                lr=self._group_lr_tensor(group),
+                lr=group["lr"],
                 ef_decay=torch.tensor(group["ef_decay"]),
                 fraction=group["fraction"],
                 weight_decay=torch.tensor(group["weight_decay"]),

--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -142,7 +142,7 @@ class Dion2(DistributedOrthoBase):
                 continue
 
             update_args = dict(
-                lr=torch.tensor(group["lr"]),
+                lr=self._group_lr_tensor(group),
                 ef_decay=torch.tensor(group["ef_decay"]),
                 fraction=group["fraction"],
                 weight_decay=torch.tensor(group["weight_decay"]),

--- a/dion/dion2_triton.py
+++ b/dion/dion2_triton.py
@@ -58,8 +58,8 @@ def _dion2_post_ortho_kernel(
     X_ptr,
     U_ptr,
     map_ptr,
-    a,
-    b,
+    a_ptr,
+    b_ptr,
     M,
     N,
     x_stride_b,
@@ -82,7 +82,14 @@ def _dion2_post_ortho_kernel(
 
     The masked load returns 0.0 for unselected entries, so the single
     expression ``a*x - b*u`` handles both cases with one FP rounding.
+
+    ``a`` and ``b`` are passed as 0-d device tensors (loaded here) rather than host
+    scalars so the step is CUDA-graph capturable: a ``.item()`` on the caller side is a
+    host sync that CUDA graph capture forbids, and it would also freeze a scheduled LR at
+    the capture-time value under replay. Loading them in-kernel reads the live values.
     """
+    a = tl.load(a_ptr)
+    b = tl.load(b_ptr)
     pid = tl.program_id(0)
 
     num_blocks_m = tl.cdiv(M, BLOCK_M)
@@ -186,8 +193,10 @@ def dion2_post_orthogonalize_triton(
     if not TRITON_AVAILABLE:
         raise RuntimeError("Triton is required for dion2_post_orthogonalize_triton")
 
-    a = (1 - base_lr * weight_decay).item()
-    b = adjusted_lr.item()
+    # 0-d device tensors, not host scalars: the kernel loads them, so no .item() host sync
+    # (forbidden mid graph-capture) and a scheduled LR is read live under replay.
+    a = (1 - base_lr * weight_decay).to(torch.float32)
+    b = adjusted_lr.to(torch.float32)
     SELECT_ROWS = select_dim == -2
 
     for x, u, idx in zip(X, U, indices):

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -18,6 +18,10 @@ from .polar_express import polar_express, polar_express_triton
 from .opt_utils import AsyncRuntime, AsyncTask, to_local
 from .scalar_opts import adamw_update_foreach_async, lion_update_foreach_async
 
+# Param-group key holding the group's device LR tensor. Runtime scratch, not a
+# hyperparameter: state_dict() strips it and _group_lr_tensor() rebuilds it on demand.
+_LR_TENSOR_KEY = "_lr_dev"
+
 
 class DistributedOrthoBase(Optimizer):
     """
@@ -191,6 +195,17 @@ class DistributedOrthoBase(Optimizer):
             state["momentum"] = torch.zeros_like(param)
             if algo == "adamw":
                 state["variance"] = torch.zeros_like(param)
+        if algo == "adamw" and "step_dev" not in state:
+            # Device step counter for the capturable fused AdamW. The step has to live
+            # on-device for bias correction to advance under CUDA-graph replay, where
+            # step()'s host-side group["step"] increment does not run. Always fp32: the
+            # fused kernel requires it, and a param-dtype (bf16) counter would stop
+            # incrementing at 256. Initialized here rather than lazily at first use so it
+            # is present in state_dict() from construction, keeping the key set complete
+            # and rank-symmetric for distributed checkpointing (see __init__).
+            state["step_dev"] = torch.zeros(
+                (), dtype=torch.float32, device=to_local(param).device
+            )
         return state
 
     def _resolve_num_heads(self, group: dict) -> Optional[int]:
@@ -400,19 +415,76 @@ class DistributedOrthoBase(Optimizer):
         and the captured ops re-read it on every replay. float32 matches the dtype of the
         former ``torch.tensor(group["lr"])`` (so the update is unchanged) and is the dtype
         the fused AdamW kernel's ``tensor_lr`` overload requires."""
-        t = group.get("_lr_dev")
-        if t is None:
-            device = to_local(group["params"][0]).device
+        device = to_local(group["params"][0]).device
+        t = group.get(_LR_TENSOR_KEY)
+        # Rebuild on a device/dtype mismatch as well as on absence: a tensor restored from
+        # a checkpoint written by an older build lands on whatever device torch.load used,
+        # and a CPU LR is read once at capture and baked into the graph.
+        if t is None or t.device != device or t.dtype != dtype:
             t = torch.empty((), dtype=dtype, device=device)
             t.fill_(group["lr"])
-            group["_lr_dev"] = t
+            group[_LR_TENSOR_KEY] = t
         return t
 
     def _refresh_lr_tensors(self):
         for group in self.param_groups:
-            t = group.get("_lr_dev")
+            t = group.get(_LR_TENSOR_KEY)
             if t is not None:
                 t.fill_(group["lr"])
+
+    def _advance_host_step_counters(self):
+        """Advance the host-side ``group["step"]`` counters for a step that ran as a CUDA
+        graph replay. ``step()``'s python increment only runs when ``step()`` is actually
+        traced, so under replay the counter would otherwise freeze at its capture value and
+        be written stale into every subsequent checkpoint."""
+        for group in self.param_groups:
+            group["step"] += 1
+
+    def state_dict(self):
+        sd = super().state_dict()
+        # param_groups is serialized hyperparameter state; the cached device LR tensor is
+        # runtime scratch rebuilt from group["lr"], so keep it out of the checkpoint.
+        # Leaving it in writes a CUDA tensor into every checkpoint, and load_state_dict()
+        # copies the saved group dict over the live one -- resurrecting the LR tensor on
+        # whatever device torch.load() used (CPU, for the usual map_location="cpu" resume).
+        # A CPU LR tensor still trains eagerly, so the damage is silent: it is read once at
+        # capture and baked in, freezing a scheduled LR under replay.
+        for group in sd["param_groups"]:
+            group.pop(_LR_TENSOR_KEY, None)
+        return sd
+
+    def load_state_dict(self, state_dict):
+        super().load_state_dict(state_dict)
+        for group in self.param_groups:
+            # Drop any LR tensor a checkpoint from an older build carried in; the next
+            # _group_lr_tensor() call rebuilds it from the restored python group["lr"].
+            group.pop(_LR_TENSOR_KEY, None)
+            if group["algorithm"] != "adamw":
+                continue
+            for param in group["params"]:
+                state = self.state.get(param)
+                if state is not None:
+                    self._restore_step_tensor(state, param, group)
+
+    def _restore_step_tensor(self, state: dict, param: Tensor, group: dict) -> None:
+        """Repair a loaded AdamW device step counter.
+
+        Two ways ``Optimizer.load_state_dict()`` leaves it wrong. It casts state tensors to
+        the owning param's dtype (its ``step`` special case keys off the literal name, which
+        this is not), and a bf16 counter silently stops incrementing at 256 -- 256 + 1 == 256
+        in bf16. And a checkpoint written before the counter moved on-device has no entry at
+        all; there the host-side ``group["step"]`` is the value to resume from, since
+        restarting at 0 would replay AdamW's bias-correction warmup and spike the effective
+        LR on the first steps after every resume.
+        """
+        step = state.get("step_dev")
+        device = to_local(param).device
+        if step is None:
+            step = torch.empty((), dtype=torch.float32, device=device)
+            step.fill_(float(group["step"]))
+        elif step.dtype != torch.float32 or step.device != device:
+            step = step.to(dtype=torch.float32, device=device)
+        state["step_dev"] = step
 
     def _create_ortho_tasks(
         self, param_groups: List[dict]
@@ -457,15 +529,7 @@ class DistributedOrthoBase(Optimizer):
             states = [self._get_or_initialize_state(p, "adamw") for p in params]
             momentums = [s["momentum"] for s in states]
             variances = [s["variance"] for s in states]
-            # Per-param device step tensors for the capturable fused AdamW: the kernel
-            # increments each on-device and bias-corrects from it, so the step is not a
-            # host value baked into a CUDA graph at capture (which would freeze the bias
-            # correction under replay). Persisted in optimizer state.
-            step_tensors = []
-            for s, p in zip(states, params):
-                if "step_dev" not in s:
-                    s["step_dev"] = torch.zeros((), dtype=torch.float32, device=to_local(p).device)
-                step_tensors.append(s["step_dev"])
+            step_tensors = [s["step_dev"] for s in states]
 
             yield AsyncTask(
                 adamw_update_foreach_async(

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -125,8 +125,12 @@ class DistributedOrthoBase(Optimizer):
         # loop), generalized here to the whole DistributedOrthoBase family via
         # the (possibly overridden) _get_or_initialize_state.
         self._state_prepopulated = False
-        for group in self.param_groups:
-            self._ensure_lr_tensor(group)
+        # Persistent per-group LR device tensors, keyed by param group index. Held here
+        # (not only in group["lr"]) so the tensor identity survives a caller reassigning
+        # group["lr"]; see _ensure_lr_tensor.
+        self._lr_tensors: dict = {}
+        for index, group in enumerate(self.param_groups):
+            self._ensure_lr_tensor(index)
             self._prepopulate_group_state(group)
         self._state_prepopulated = True
 
@@ -142,7 +146,7 @@ class DistributedOrthoBase(Optimizer):
         # add_param_group calls that Optimizer.__init__ makes before this class
         # finishes setup; the __init__ loop above pre-populates those groups.
         if getattr(self, "_state_prepopulated", False):
-            self._ensure_lr_tensor(self.param_groups[-1])
+            self._ensure_lr_tensor(len(self.param_groups) - 1)
             self._prepopulate_group_state(self.param_groups[-1])
 
     @torch.no_grad()
@@ -155,12 +159,11 @@ class DistributedOrthoBase(Optimizer):
 
         # The LR is carried as a device tensor the kernels read directly (see
         # _ensure_lr_tensor); a scheduler updates it in place outside the graph and every
-        # replay re-reads the live value. Re-materialize it here in case a caller assigned a
-        # python float since the last step. Skipped while capturing -- it must not allocate
-        # inside the graph, and warmup has already made it a tensor by then.
-        if not torch.cuda.is_current_stream_capturing():
-            for group in self.param_groups:
-                self._ensure_lr_tensor(group)
+        # replay re-reads the live value. Push in anything a caller assigned to
+        # group["lr"] as a plain float since the last step. A no-op (and so safe under
+        # graph capture) once the tensor is in place, which the wrapper guarantees by
+        # calling this itself before capturing.
+        self._sync_lr_tensors()
 
         ortho_groups = []
         lion_groups = []
@@ -407,27 +410,67 @@ class DistributedOrthoBase(Optimizer):
 
         return is_batch_sharded, is_matrix_sharded, sharded_tensor_dim
 
-    def _ensure_lr_tensor(self, group: dict) -> Tensor:
-        """Make ``group["lr"]`` a persistent 0-d device float32 tensor and return it.
+    def _ensure_lr_tensor(self, index: int) -> Optional[Tensor]:
+        """Make ``param_groups[index]["lr"]`` this group's persistent 0-d device float32
+        tensor and return it (``None`` for a group with no parameters, which has no device
+        to put it on and no kernel to read it).
 
         The LR is carried as a device tensor the kernels read directly, so a ``torch.optim``
         LR scheduler -- which updates a tensor ``lr`` in place -- drives a captured step
         natively: the scheduler fills this tensor outside the graph and every replay re-reads
-        it, with no refresh plumbing. This is a no-op once the tensor exists on the right
-        device (the steady state, including right after a scheduler ``fill_``), so it adds no
-        per-step host sync. It rebuilds the tensor when the value is a python float (fresh
-        construction, or a caller assigning ``group["lr"] = 0.05``) or a wrong-device/dtype
-        tensor (restored from a checkpoint via ``map_location="cpu"``). float32 is what the
-        former ``torch.tensor(group["lr"])`` produced and the dtype the fused AdamW
-        ``tensor_lr`` overload requires. Construct any LR scheduler AFTER the optimizer (and
-        after ``load_state_dict``) so it binds to this tensor; a scheduler holding an earlier
-        reference would fill a tensor the kernels no longer read."""
-        device = to_local(group["params"][0]).device
+        it, with no refresh plumbing. float32 is what the former ``torch.tensor(group["lr"])``
+        produced and the dtype the fused AdamW ``tensor_lr`` overload requires.
+
+        The tensor is allocated once per group and thereafter only ever filled, never
+        replaced. That identity is what makes replay correct: a captured graph reads the
+        tensor recorded at capture time, so handing the group a *different* tensor would
+        leave every later replay on the stale one. Anything else found under ``lr`` -- a
+        python float from construction or from the ``group["lr"] = 0.05`` idiom of a
+        hand-rolled schedule, or a wrong-device tensor restored from a checkpoint via
+        ``map_location="cpu"`` -- is copied into the persistent tensor and the tensor put
+        back. The steady state (including right after a scheduler ``fill_``) hits the
+        identity check and does no work at all.
+        """
+        group = self.param_groups[index]
+        params = group["params"]
+        if not params:
+            return None
+
         lr = group["lr"]
-        if isinstance(lr, Tensor) and lr.device == device and lr.dtype == torch.float32:
-            return lr
-        group["lr"] = torch.full((), float(lr), dtype=torch.float32, device=device)
-        return group["lr"]
+        tensor = self._lr_tensors.get(index)
+        if lr is tensor:
+            return tensor
+
+        # Everything below writes to the device, so it must not run under graph capture:
+        # a recorded fill_ would re-apply the capture-time LR on every replay, silently
+        # overwriting whatever the scheduler had set.
+        if torch.cuda.is_available() and torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                f"param group {index} has a learning rate that is not its persistent "
+                f"device tensor ({type(lr).__name__}), and CUDA graph capture is already "
+                "underway so it cannot be refreshed. Sync the learning rate before "
+                "capturing (CudaGraphOptimizer does this for you)."
+            )
+
+        device = to_local(params[0]).device
+        if tensor is None or tensor.device != device:
+            tensor = torch.empty((), dtype=torch.float32, device=device)
+            self._lr_tensors[index] = tensor
+        if isinstance(lr, Tensor):
+            tensor.copy_(lr)
+        else:
+            tensor.fill_(lr)
+        group["lr"] = tensor
+        return tensor
+
+    def _sync_lr_tensors(self) -> None:
+        """Push each group's host-side ``lr`` into the persistent device tensor the kernels
+        (and any captured CUDA graph) read. Called at the top of ``step()``, and by
+        ``CudaGraphOptimizer`` before it captures or replays -- under replay ``step()``
+        never runs, so this is the only thing that carries a ``group["lr"] = 0.05``
+        assignment through to the graph."""
+        for index in range(len(self.param_groups)):
+            self._ensure_lr_tensor(index)
 
     def _advance_host_step_counters(self):
         """Advance the host-side ``group["step"]`` counters for a step that ran as a CUDA
@@ -439,26 +482,29 @@ class DistributedOrthoBase(Optimizer):
 
     def state_dict(self):
         sd = super().state_dict()
-        # lr is carried at runtime as a device tensor; serialize it as a plain float so
-        # checkpoints stay portable (no device baggage, human-readable, matches pre-feature
-        # checkpoints), and load_state_dict() rebuilds the device tensor. Serializing the
-        # tensor instead would ride a CUDA tensor into every checkpoint and come back on
-        # whatever device torch.load() used -- a CPU LR that still trains eagerly but is read
-        # once at capture and baked in, silently freezing a scheduled LR under replay.
-        # super().state_dict() copies each group dict, so replacing "lr" here does not touch
-        # the live optimizer.
+        # lr is carried at runtime as a device tensor; serialize it as a plain python
+        # number so checkpoints stay portable (no device baggage, human-readable, matches
+        # pre-feature checkpoints), and load_state_dict() refills the device tensor.
+        # Serializing the tensor instead would ride a CUDA tensor into every checkpoint and
+        # come back on whatever device torch.load() used -- a CPU LR that still trains
+        # eagerly but is read once at capture and baked in, silently freezing a scheduled
+        # LR under replay. This covers every 0-d tensor hyperparameter in the group, not
+        # just "lr": an attached LRScheduler also stashes "initial_lr" there, cloned from
+        # (and therefore as device-bound as) the LR tensor itself. super().state_dict()
+        # copies each group dict, so rewriting entries here does not touch the live
+        # optimizer.
         for group in sd["param_groups"]:
-            lr = group.get("lr")
-            if isinstance(lr, Tensor):
-                group["lr"] = float(lr)
+            for key, value in group.items():
+                if key != "params" and isinstance(value, Tensor) and value.ndim == 0:
+                    group[key] = value.item()
         return sd
 
     def load_state_dict(self, state_dict):
         super().load_state_dict(state_dict)
+        # Refill the device LR tensors from the loaded values (a float from a normal
+        # checkpoint, or a wrong-device tensor from one written by an earlier build).
+        self._sync_lr_tensors()
         for group in self.param_groups:
-            # Rebuild the device LR tensor from the loaded value (a float from a normal
-            # checkpoint, or a wrong-device tensor from one written by an earlier build).
-            self._ensure_lr_tensor(group)
             if group["algorithm"] != "adamw":
                 continue
             for param in group["params"]:

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -18,10 +18,6 @@ from .polar_express import polar_express, polar_express_triton
 from .opt_utils import AsyncRuntime, AsyncTask, to_local
 from .scalar_opts import adamw_update_foreach_async, lion_update_foreach_async
 
-# Param-group key holding the group's device LR tensor. Runtime scratch, not a
-# hyperparameter: state_dict() strips it and _group_lr_tensor() rebuilds it on demand.
-_LR_TENSOR_KEY = "_lr_dev"
-
 
 class DistributedOrthoBase(Optimizer):
     """
@@ -130,6 +126,7 @@ class DistributedOrthoBase(Optimizer):
         # the (possibly overridden) _get_or_initialize_state.
         self._state_prepopulated = False
         for group in self.param_groups:
+            self._ensure_lr_tensor(group)
             self._prepopulate_group_state(group)
         self._state_prepopulated = True
 
@@ -145,6 +142,7 @@ class DistributedOrthoBase(Optimizer):
         # add_param_group calls that Optimizer.__init__ makes before this class
         # finishes setup; the __init__ loop above pre-populates those groups.
         if getattr(self, "_state_prepopulated", False):
+            self._ensure_lr_tensor(self.param_groups[-1])
             self._prepopulate_group_state(self.param_groups[-1])
 
     @torch.no_grad()
@@ -155,12 +153,14 @@ class DistributedOrthoBase(Optimizer):
             with torch.enable_grad():
                 loss = closure()
 
-        # Push the (scheduler-updated) python LR into each group's persistent device LR
-        # tensor, so a CUDA-graph capture of this step reads a live LR under replay rather
-        # than baking the capture-time value. Skipped while capturing: the fill must stay
-        # OUTSIDE the graph, so CudaGraphOptimizer refreshes before each replay instead.
+        # The LR is carried as a device tensor the kernels read directly (see
+        # _ensure_lr_tensor); a scheduler updates it in place outside the graph and every
+        # replay re-reads the live value. Re-materialize it here in case a caller assigned a
+        # python float since the last step. Skipped while capturing -- it must not allocate
+        # inside the graph, and warmup has already made it a tensor by then.
         if not torch.cuda.is_current_stream_capturing():
-            self._refresh_lr_tensors()
+            for group in self.param_groups:
+                self._ensure_lr_tensor(group)
 
         ortho_groups = []
         lion_groups = []
@@ -407,30 +407,27 @@ class DistributedOrthoBase(Optimizer):
 
         return is_batch_sharded, is_matrix_sharded, sharded_tensor_dim
 
-    def _group_lr_tensor(self, group: dict, dtype: torch.dtype = torch.float32) -> Tensor:
-        """Persistent device LR tensor for a group. Passing the LR as a device tensor the
-        optimizer reads (rather than a python float / CPU scalar baked into the kernels)
-        is what lets ``CudaGraphOptimizer`` capture the step under a scheduled LR: the
-        value is refreshed in place each step by ``_refresh_lr_tensors`` outside the graph,
-        and the captured ops re-read it on every replay. float32 matches the dtype of the
-        former ``torch.tensor(group["lr"])`` (so the update is unchanged) and is the dtype
-        the fused AdamW kernel's ``tensor_lr`` overload requires."""
-        device = to_local(group["params"][0]).device
-        t = group.get(_LR_TENSOR_KEY)
-        # Rebuild on a device/dtype mismatch as well as on absence: a tensor restored from
-        # a checkpoint written by an older build lands on whatever device torch.load used,
-        # and a CPU LR is read once at capture and baked into the graph.
-        if t is None or t.device != device or t.dtype != dtype:
-            t = torch.empty((), dtype=dtype, device=device)
-            t.fill_(group["lr"])
-            group[_LR_TENSOR_KEY] = t
-        return t
+    def _ensure_lr_tensor(self, group: dict) -> Tensor:
+        """Make ``group["lr"]`` a persistent 0-d device float32 tensor and return it.
 
-    def _refresh_lr_tensors(self):
-        for group in self.param_groups:
-            t = group.get(_LR_TENSOR_KEY)
-            if t is not None:
-                t.fill_(group["lr"])
+        The LR is carried as a device tensor the kernels read directly, so a ``torch.optim``
+        LR scheduler -- which updates a tensor ``lr`` in place -- drives a captured step
+        natively: the scheduler fills this tensor outside the graph and every replay re-reads
+        it, with no refresh plumbing. This is a no-op once the tensor exists on the right
+        device (the steady state, including right after a scheduler ``fill_``), so it adds no
+        per-step host sync. It rebuilds the tensor when the value is a python float (fresh
+        construction, or a caller assigning ``group["lr"] = 0.05``) or a wrong-device/dtype
+        tensor (restored from a checkpoint via ``map_location="cpu"``). float32 is what the
+        former ``torch.tensor(group["lr"])`` produced and the dtype the fused AdamW
+        ``tensor_lr`` overload requires. Construct any LR scheduler AFTER the optimizer (and
+        after ``load_state_dict``) so it binds to this tensor; a scheduler holding an earlier
+        reference would fill a tensor the kernels no longer read."""
+        device = to_local(group["params"][0]).device
+        lr = group["lr"]
+        if isinstance(lr, Tensor) and lr.device == device and lr.dtype == torch.float32:
+            return lr
+        group["lr"] = torch.full((), float(lr), dtype=torch.float32, device=device)
+        return group["lr"]
 
     def _advance_host_step_counters(self):
         """Advance the host-side ``group["step"]`` counters for a step that ran as a CUDA
@@ -442,23 +439,26 @@ class DistributedOrthoBase(Optimizer):
 
     def state_dict(self):
         sd = super().state_dict()
-        # param_groups is serialized hyperparameter state; the cached device LR tensor is
-        # runtime scratch rebuilt from group["lr"], so keep it out of the checkpoint.
-        # Leaving it in writes a CUDA tensor into every checkpoint, and load_state_dict()
-        # copies the saved group dict over the live one -- resurrecting the LR tensor on
-        # whatever device torch.load() used (CPU, for the usual map_location="cpu" resume).
-        # A CPU LR tensor still trains eagerly, so the damage is silent: it is read once at
-        # capture and baked in, freezing a scheduled LR under replay.
+        # lr is carried at runtime as a device tensor; serialize it as a plain float so
+        # checkpoints stay portable (no device baggage, human-readable, matches pre-feature
+        # checkpoints), and load_state_dict() rebuilds the device tensor. Serializing the
+        # tensor instead would ride a CUDA tensor into every checkpoint and come back on
+        # whatever device torch.load() used -- a CPU LR that still trains eagerly but is read
+        # once at capture and baked in, silently freezing a scheduled LR under replay.
+        # super().state_dict() copies each group dict, so replacing "lr" here does not touch
+        # the live optimizer.
         for group in sd["param_groups"]:
-            group.pop(_LR_TENSOR_KEY, None)
+            lr = group.get("lr")
+            if isinstance(lr, Tensor):
+                group["lr"] = float(lr)
         return sd
 
     def load_state_dict(self, state_dict):
         super().load_state_dict(state_dict)
         for group in self.param_groups:
-            # Drop any LR tensor a checkpoint from an older build carried in; the next
-            # _group_lr_tensor() call rebuilds it from the restored python group["lr"].
-            group.pop(_LR_TENSOR_KEY, None)
+            # Rebuild the device LR tensor from the loaded value (a float from a normal
+            # checkpoint, or a wrong-device tensor from one written by an earlier build).
+            self._ensure_lr_tensor(group)
             if group["algorithm"] != "adamw":
                 continue
             for param in group["params"]:
@@ -509,7 +509,7 @@ class DistributedOrthoBase(Optimizer):
                     X=to_local(params),
                     G=to_local(gradients),
                     M=to_local(momentums),
-                    lr=self._group_lr_tensor(group),
+                    lr=group["lr"],
                     beta1=torch.tensor(group["beta1"]),
                     beta2=torch.tensor(group["beta2"]),
                     weight_decay=torch.tensor(group["weight_decay"]),
@@ -537,7 +537,7 @@ class DistributedOrthoBase(Optimizer):
                     G=to_local(gradients),
                     M=to_local(momentums),
                     V=to_local(variances),
-                    lr=self._group_lr_tensor(group, torch.float32),
+                    lr=group["lr"],
                     beta1=torch.tensor(group["beta1"]),
                     beta2=torch.tensor(group["beta2"]),
                     weight_decay=torch.tensor(group["weight_decay"]),

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -151,6 +151,13 @@ class DistributedOrthoBase(Optimizer):
             with torch.enable_grad():
                 loss = closure()
 
+        # Push the (scheduler-updated) python LR into each group's persistent device LR
+        # tensor, so a CUDA-graph capture of this step reads a live LR under replay rather
+        # than baking the capture-time value. Skipped while capturing: the fill must stay
+        # OUTSIDE the graph, so CudaGraphOptimizer refreshes before each replay instead.
+        if not torch.cuda.is_current_stream_capturing():
+            self._refresh_lr_tensors()
+
         ortho_groups = []
         lion_groups = []
         adamw_groups = []
@@ -385,6 +392,28 @@ class DistributedOrthoBase(Optimizer):
 
         return is_batch_sharded, is_matrix_sharded, sharded_tensor_dim
 
+    def _group_lr_tensor(self, group: dict, dtype: torch.dtype = torch.float32) -> Tensor:
+        """Persistent device LR tensor for a group. Passing the LR as a device tensor the
+        optimizer reads (rather than a python float / CPU scalar baked into the kernels)
+        is what lets ``CudaGraphOptimizer`` capture the step under a scheduled LR: the
+        value is refreshed in place each step by ``_refresh_lr_tensors`` outside the graph,
+        and the captured ops re-read it on every replay. float32 matches the dtype of the
+        former ``torch.tensor(group["lr"])`` (so the update is unchanged) and is the dtype
+        the fused AdamW kernel's ``tensor_lr`` overload requires."""
+        t = group.get("_lr_dev")
+        if t is None:
+            device = to_local(group["params"][0]).device
+            t = torch.empty((), dtype=dtype, device=device)
+            t.fill_(group["lr"])
+            group["_lr_dev"] = t
+        return t
+
+    def _refresh_lr_tensors(self):
+        for group in self.param_groups:
+            t = group.get("_lr_dev")
+            if t is not None:
+                t.fill_(group["lr"])
+
     def _create_ortho_tasks(
         self, param_groups: List[dict]
     ) -> Generator["AsyncTask", None, None]:
@@ -408,7 +437,7 @@ class DistributedOrthoBase(Optimizer):
                     X=to_local(params),
                     G=to_local(gradients),
                     M=to_local(momentums),
-                    lr=torch.tensor(group["lr"]),
+                    lr=self._group_lr_tensor(group),
                     beta1=torch.tensor(group["beta1"]),
                     beta2=torch.tensor(group["beta2"]),
                     weight_decay=torch.tensor(group["weight_decay"]),
@@ -428,6 +457,15 @@ class DistributedOrthoBase(Optimizer):
             states = [self._get_or_initialize_state(p, "adamw") for p in params]
             momentums = [s["momentum"] for s in states]
             variances = [s["variance"] for s in states]
+            # Per-param device step tensors for the capturable fused AdamW: the kernel
+            # increments each on-device and bias-corrects from it, so the step is not a
+            # host value baked into a CUDA graph at capture (which would freeze the bias
+            # correction under replay). Persisted in optimizer state.
+            step_tensors = []
+            for s, p in zip(states, params):
+                if "step_dev" not in s:
+                    s["step_dev"] = torch.zeros((), dtype=torch.float32, device=to_local(p).device)
+                step_tensors.append(s["step_dev"])
 
             yield AsyncTask(
                 adamw_update_foreach_async(
@@ -435,11 +473,11 @@ class DistributedOrthoBase(Optimizer):
                     G=to_local(gradients),
                     M=to_local(momentums),
                     V=to_local(variances),
-                    lr=torch.tensor(group["lr"]),
+                    lr=self._group_lr_tensor(group, torch.float32),
                     beta1=torch.tensor(group["beta1"]),
                     beta2=torch.tensor(group["beta2"]),
                     weight_decay=torch.tensor(group["weight_decay"]),
-                    step=torch.tensor(group["step"]),
+                    state_steps=step_tensors,
                     epsilon=torch.tensor(group["epsilon"]),
                     cautious_wd=group.get("cautious_wd", False),
                 )

--- a/dion/muon.py
+++ b/dion/muon.py
@@ -125,7 +125,7 @@ class Muon(DistributedOrthoBase):
                 continue
 
             update_args = dict(
-                lr=torch.tensor(group["lr"]),
+                lr=self._group_lr_tensor(group),
                 momentum=torch.tensor(group["mu"]),
                 weight_decay=torch.tensor(group["weight_decay"]),
                 epsilon=torch.tensor(group["epsilon"]),

--- a/dion/muon.py
+++ b/dion/muon.py
@@ -125,7 +125,7 @@ class Muon(DistributedOrthoBase):
                 continue
 
             update_args = dict(
-                lr=self._group_lr_tensor(group),
+                lr=group["lr"],
                 momentum=torch.tensor(group["mu"]),
                 weight_decay=torch.tensor(group["weight_decay"]),
                 epsilon=torch.tensor(group["epsilon"]),

--- a/dion/nordion2.py
+++ b/dion/nordion2.py
@@ -168,7 +168,7 @@ class NorDion2(DistributedOrthoBase):
                 continue
 
             update_args = dict(
-                lr=torch.tensor(group["lr"]),
+                lr=self._group_lr_tensor(group),
                 fraction=group["fraction"],
                 momentum=torch.tensor(group["mu"]),
                 muon_beta2=torch.tensor(group["muon_beta2"]),

--- a/dion/nordion2.py
+++ b/dion/nordion2.py
@@ -168,7 +168,7 @@ class NorDion2(DistributedOrthoBase):
                 continue
 
             update_args = dict(
-                lr=self._group_lr_tensor(group),
+                lr=group["lr"],
                 fraction=group["fraction"],
                 momentum=torch.tensor(group["mu"]),
                 muon_beta2=torch.tensor(group["muon_beta2"]),

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -148,7 +148,7 @@ class NorMuon(DistributedOrthoBase):
                 continue
 
             update_args = dict(
-                lr=torch.tensor(group["lr"]),
+                lr=self._group_lr_tensor(group),
                 momentum=torch.tensor(group["mu"]),
                 muon_beta2=torch.tensor(group["muon_beta2"]),
                 weight_decay=torch.tensor(group["weight_decay"]),

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -148,7 +148,7 @@ class NorMuon(DistributedOrthoBase):
                 continue
 
             update_args = dict(
-                lr=self._group_lr_tensor(group),
+                lr=group["lr"],
                 momentum=torch.tensor(group["mu"]),
                 muon_beta2=torch.tensor(group["muon_beta2"]),
                 weight_decay=torch.tensor(group["weight_decay"]),

--- a/dion/scalar_opts.py
+++ b/dion/scalar_opts.py
@@ -1,6 +1,6 @@
 import torch
 from torch import Tensor
-from typing import Generator, List
+from typing import Generator, List, Optional
 
 
 @torch.compile(fullgraph=True)
@@ -127,15 +127,24 @@ def adamw_update_foreach(
     beta1: Tensor,  # Beta 1 (scalar tensor or float)
     beta2: Tensor,  # Beta 2 (scalar tensor or float)
     weight_decay: Tensor,  # Weight decay (scalar tensor or float)
-    step: int,
-    epsilon: float,
+    step: Optional[int] = None,  # legacy scalar step (baked; not CUDA-graph-capturable)
+    epsilon: float = 1e-8,
     cautious_wd: bool = False,
+    state_steps: Optional[List[Tensor]] = None,  # per-param device step tensors (capturable)
 ):
-    """AdamW update for a list of tensors.
+    """AdamW update for a list of tensors, dispatched through ``torch._fused_adamw_``
+    (a multi-tensor-apply kernel, avoiding the ~6-call ``torch._foreach_*`` chain that
+    otherwise dispatches one aten op per tensor on the CPU side).
 
-    Dispatches through ``torch._fused_adamw_``, which is already a
-    multi-tensor-apply kernel; avoids the ~6-call ``torch._foreach_*`` chain
-    that otherwise dispatches one aten op per tensor on the CPU side.
+    Two forms, selected by which step argument is given:
+
+    * **Legacy** (``step`` = python int): the bias-correction step is baked into a cached
+      0-d device tensor at call time, and ``lr`` is passed as a float. Simple, but NOT
+      CUDA-graph-capturable -- both freeze at the capture-time value under replay.
+    * **Capturable** (``state_steps`` = list of per-param device step tensors, and ``lr``
+      a device tensor): the step is incremented on-device and ``lr`` is read through the
+      fused kernel's ``tensor_lr`` overload, so both advance inside a CUDA graph. This is
+      the form ``megabatch_base`` passes so a wrapped step is graph-capturable.
 
     Cautious weight decay (https://arxiv.org/pdf/2510.12402) is applied as a
     post-step correction rather than inside the kernel:
@@ -152,7 +161,6 @@ def adamw_update_foreach(
     n = len(X)
     assert n == len(G) == len(M) == len(V)
 
-    lr_f = float(lr)
     beta1_f = float(beta1)
     beta2_f = float(beta2)
     wd_f = float(weight_decay)
@@ -162,27 +170,51 @@ def adamw_update_foreach(
     if do_cwd_correction:
         X_orig = [x.clone() for x in X]
 
-    # Cache the step scalar per device. ``torch.tensor(x, device="cuda")``
-    # from a Python float stages through pageable CPU memory and issues a
-    # blocking ``cudaMemcpy``, which defeats the point of going fused.
-    # ``fill_`` on a cached 0-d CUDA tensor is a kernel launch — async.
-    step_t = _get_step_tensor(X[0].device)
-    step_t.fill_(float(step))
-    torch._fused_adamw_(
-        X, G, M, V, [],
-        [step_t] * n,
-        amsgrad=False,
-        beta1=beta1_f, beta2=beta2_f,
-        lr=lr_f, weight_decay=wd_f, eps=eps_f,
-        maximize=False,
-    )
+    if state_steps is not None:
+        # Capturable form. ``state_steps`` are per-param device tensors we increment
+        # on-device here (``_fused_adamw_`` reads but does not increment them), so the
+        # bias-correction step advances inside a CUDA graph instead of freezing at capture.
+        # grad_scale/found_inf MUST be passed (as None) with a Tensor ``lr``: they select
+        # the capturable ``tensor_lr`` overload; omitting them resolves to a different
+        # overload that misreads the step. Mirrors torch.optim's fused path
+        # (torch/optim/adam.py::_fused_adam).
+        torch._foreach_add_(state_steps, 1)
+        torch._fused_adamw_(
+            X, G, M, V, [],
+            state_steps,
+            amsgrad=False,
+            beta1=beta1_f, beta2=beta2_f,
+            lr=lr, weight_decay=wd_f, eps=eps_f,
+            maximize=False,
+            grad_scale=None, found_inf=None,
+        )
+    else:
+        # Legacy form. Cache the step scalar per device: ``torch.tensor(x, device="cuda")``
+        # from a Python float stages through pageable CPU memory and issues a blocking
+        # ``cudaMemcpy``; ``fill_`` on a cached 0-d CUDA tensor is an async kernel launch.
+        lr_f = float(lr)
+        step_t = _get_step_tensor(X[0].device)
+        step_t.fill_(float(step))
+        torch._fused_adamw_(
+            X, G, M, V, [],
+            [step_t] * n,
+            amsgrad=False,
+            beta1=beta1_f, beta2=beta2_f,
+            lr=lr_f, weight_decay=wd_f, eps=eps_f,
+            maximize=False,
+        )
 
     if do_cwd_correction:
         # mask == 0  <=>  sign(M_new) * sign(X_orig) < 0  (over-decayed).
         signs = torch._foreach_mul(M, X_orig)
         undo_masks = [(s < 0).to(x.dtype) for s, x in zip(signs, X_orig)]
         correction = torch._foreach_mul(X_orig, undo_masks)
-        torch._foreach_mul_(correction, lr_f * wd_f)
+        if state_steps is not None:
+            # Keep the LR scaling on-device (float(lr) would host-sync and bake the value).
+            torch._foreach_mul_(correction, wd_f)
+            correction = [c * lr for c in correction]
+        else:
+            torch._foreach_mul_(correction, float(lr) * wd_f)
         torch._foreach_add_(X, correction)
 
 
@@ -248,12 +280,13 @@ def adamw_update_foreach_async(
     beta1: Tensor,
     beta2: Tensor,
     weight_decay: Tensor,
-    step: int,
-    epsilon: float,
+    step: Optional[int] = None,
+    epsilon: float = 1e-8,
     cautious_wd: bool = False,
+    state_steps: Optional[List[Tensor]] = None,
 ) -> Generator[None, None, None]:
     adamw_update_foreach(
-        X, G, M, V, lr, beta1, beta2, weight_decay, step, epsilon, cautious_wd
+        X, G, M, V, lr, beta1, beta2, weight_decay, step, epsilon, cautious_wd, state_steps
     )
     yield
 

--- a/dion/scalar_opts.py
+++ b/dion/scalar_opts.py
@@ -156,10 +156,21 @@ def adamw_update_foreach(
     where ``mask = (sign(M_new · X_orig) >= 0)``. We add back the decay that
     was over-applied on elements where momentum and param disagree in sign.
     """
+    if (step is None) == (state_steps is None):
+        raise ValueError(
+            "adamw_update_foreach takes exactly one of step (legacy, baked into the "
+            "kernel) or state_steps (device counters, CUDA-graph-capturable)."
+        )
+    if state_steps is not None and not isinstance(lr, Tensor):
+        raise TypeError(
+            "the capturable form requires lr as a device tensor; a python float is read "
+            "at capture time and baked into the graph, freezing a scheduled LR."
+        )
     if not X:
         return
     n = len(X)
     assert n == len(G) == len(M) == len(V)
+    assert state_steps is None or n == len(state_steps)
 
     beta1_f = float(beta1)
     beta2_f = float(beta2)
@@ -174,10 +185,10 @@ def adamw_update_foreach(
         # Capturable form. ``state_steps`` are per-param device tensors we increment
         # on-device here (``_fused_adamw_`` reads but does not increment them), so the
         # bias-correction step advances inside a CUDA graph instead of freezing at capture.
-        # grad_scale/found_inf MUST be passed (as None) with a Tensor ``lr``: they select
-        # the capturable ``tensor_lr`` overload; omitting them resolves to a different
-        # overload that misreads the step. Mirrors torch.optim's fused path
-        # (torch/optim/adam.py::_fused_adam).
+        # A Tensor ``lr`` selects the ``_fused_adamw_.tensor_lr`` overload, which reads the
+        # LR on-device; the float-lr overload bakes it in at capture. Mirrors torch.optim's
+        # fused path (torch/optim/adam.py::_fused_adam), including passing grad_scale and
+        # found_inf explicitly as None.
         torch._foreach_add_(state_steps, 1)
         torch._fused_adamw_(
             X, G, M, V, [],
@@ -210,10 +221,14 @@ def adamw_update_foreach(
         undo_masks = [(s < 0).to(x.dtype) for s, x in zip(signs, X_orig)]
         correction = torch._foreach_mul(X_orig, undo_masks)
         if state_steps is not None:
-            # Keep the LR scaling on-device (float(lr) would host-sync and bake the value).
+            # Keep the LR scaling on-device: float(lr) would host-sync and bake the value.
+            # _foreach_mul_ takes the 0-d tensor directly, so this stays one dispatch
+            # rather than one multiply (and one allocation) per param.
             torch._foreach_mul_(correction, wd_f)
-            correction = [c * lr for c in correction]
+            torch._foreach_mul_(correction, lr)
         else:
+            # Fold the scalars host-side, as before: (lr * wd) in one multiply is not
+            # bit-identical to scaling by wd then lr, and the legacy path must not move.
             torch._foreach_mul_(correction, float(lr) * wd_f)
         torch._foreach_add_(X, correction)
 

--- a/dion/scalar_opts.py
+++ b/dion/scalar_opts.py
@@ -222,13 +222,11 @@ def adamw_update_foreach(
         correction = torch._foreach_mul(X_orig, undo_masks)
         if state_steps is not None:
             # Keep the LR scaling on-device: float(lr) would host-sync and bake the value.
-            # _foreach_mul_ takes the 0-d tensor directly, so this stays one dispatch
-            # rather than one multiply (and one allocation) per param.
-            torch._foreach_mul_(correction, wd_f)
-            torch._foreach_mul_(correction, lr)
+            # Fold (lr * wd) into one 0-d device scalar first, so the correction is a
+            # single foreach pass and the multiply order matches the legacy branch below
+            # -- scaling by wd and then by lr is not bit-identical to scaling by (lr*wd).
+            torch._foreach_mul_(correction, lr * wd_f)
         else:
-            # Fold the scalars host-side, as before: (lr * wd) in one multiply is not
-            # bit-identical to scaling by wd then lr, and the legacy path must not move.
             torch._foreach_mul_(correction, float(lr) * wd_f)
         torch._foreach_add_(X, correction)
 

--- a/tests/test_adamw_foreach.py
+++ b/tests/test_adamw_foreach.py
@@ -225,6 +225,53 @@ def test_empty_list():
     )
 
 
+@pytest.mark.parametrize("cautious_wd", [False, True])
+def test_capturable_form_matches_legacy_form(cautious_wd):
+    """The capturable form (device step counters + a device-tensor lr) must compute the
+    same update as the legacy form (baked step + float lr). Covers the CWD correction,
+    whose lr*wd scaling is folded differently on the two paths."""
+    from dion.scalar_opts import adamw_update_foreach
+    torch.manual_seed(0)
+    shapes = [(128,), (64, 32), (1,)]
+    X_leg = [torch.randn(*s, device=DEVICE) for s in shapes]
+    X_cap = [x.clone() for x in X_leg]
+    M_leg, V_leg = [torch.zeros_like(x) for x in X_leg], [torch.zeros_like(x) for x in X_leg]
+    M_cap, V_cap = [torch.zeros_like(x) for x in X_cap], [torch.zeros_like(x) for x in X_cap]
+    steps = [torch.zeros((), dtype=torch.float32, device=DEVICE) for _ in X_cap]
+
+    kw = dict(beta1=torch.tensor(0.9), beta2=torch.tensor(0.999),
+              weight_decay=torch.tensor(0.1), epsilon=1e-8, cautious_wd=cautious_wd)
+    for step in range(1, 6):
+        G = [torch.randn(*s, device=DEVICE) * 0.1 for s in shapes]
+        adamw_update_foreach(X_leg, G, M_leg, V_leg, lr=torch.tensor(1e-2),
+                             step=step, **kw)
+        adamw_update_foreach(X_cap, G, M_cap, V_cap,
+                             lr=torch.full((), 1e-2, device=DEVICE),
+                             state_steps=steps, **kw)
+        assert all(s.item() == step for s in steps), "device step counters out of sync"
+        for i, (a, b) in enumerate(zip(X_leg, X_cap)):
+            diff = (a - b).abs().max().item()
+            assert diff <= 1e-6, f"param {i} diverged at step {step}: {diff:.3e}"
+
+
+def test_step_form_arguments_are_mutually_exclusive():
+    from dion.scalar_opts import adamw_update_foreach
+    X = [torch.randn(8, device=DEVICE)]
+    kw = dict(G=[torch.randn(8, device=DEVICE)], M=[torch.zeros(8, device=DEVICE)],
+              V=[torch.zeros(8, device=DEVICE)], beta1=torch.tensor(0.9),
+              beta2=torch.tensor(0.999), weight_decay=torch.tensor(0.0), epsilon=1e-8)
+    lr_t = torch.full((), 1e-2, device=DEVICE)
+    steps = [torch.zeros((), dtype=torch.float32, device=DEVICE)]
+
+    with pytest.raises(ValueError, match="exactly one"):
+        adamw_update_foreach(X, lr=lr_t, **kw)
+    with pytest.raises(ValueError, match="exactly one"):
+        adamw_update_foreach(X, lr=lr_t, step=1, state_steps=steps, **kw)
+    # A float lr on the capturable path is read at capture time and baked into the graph.
+    with pytest.raises(TypeError, match="device tensor"):
+        adamw_update_foreach(X, lr=1e-2, state_steps=steps, **kw)
+
+
 def test_cwd_zero_wd_skips_correction():
     """With wd=0, CWD must be a no-op vs non-CWD (nothing to undo)."""
     from dion.scalar_opts import adamw_update_foreach

--- a/tests/test_cuda_graph.py
+++ b/tests/test_cuda_graph.py
@@ -47,17 +47,21 @@ def _grad_seq(params):
             for _ in range(STEPS)]
 
 
-def _run(params, opt, grad_seq, step_fn, lrs=None):
+def _run(params, opt, grad_seq, step_fn, lrs=None, assign_float_lr=False):
     # Stable .grad buffers (the graph pins them); refill in place, never reallocate.
     for p in params:
         p.grad = torch.zeros_like(p)
     for t, gs in enumerate(grad_seq):
         if lrs is not None:
-            # Update the LR *in place*, the way a torch LR scheduler does. group["lr"] is
-            # the device tensor the kernels read; reassigning a python float would swap the
-            # object out and leave the captured graph reading the stale one under replay.
+            # Two ways a caller sets the LR, both of which must reach the captured graph:
+            # in place (what a torch LR scheduler does to a tensor lr), or by assigning a
+            # plain float (the idiom of a hand-rolled schedule), which replaces the tensor
+            # the graph reads and so has to be pushed back into it before the next replay.
             for g in opt.param_groups:
-                g["lr"].fill_(lrs[t])
+                if assign_float_lr:
+                    g["lr"] = lrs[t]
+                else:
+                    g["lr"].fill_(lrs[t])
         for p, g in zip(params, gs):
             p.grad.copy_(g)
         step_fn()
@@ -130,6 +134,143 @@ def test_cudagraph_tracks_scheduled_lr(optimizer_cls):
         f"{optimizer_cls.__name__}: schedule looks frozen -- scheduled and constant runs "
         f"agree to {nontrivial:.3e}, so the test would pass even if the LR were baked"
     )
+
+
+@pytest.mark.parametrize("optimizer_cls", OPTIMIZERS)
+def test_cudagraph_tracks_lr_assigned_as_python_float(optimizer_cls):
+    # The other half of the LR contract: `for g in opt.param_groups: g["lr"] = x` -- how
+    # every hand-rolled warmup/decay sets the rate, and what torch's own scheduler does
+    # when the group's lr is not a tensor. It replaces the device tensor the graph reads
+    # with a float, so the wrapper has to push the value back into the persistent tensor
+    # before capturing and before each replay. Regression: it did not, and the assignment
+    # landing on the capture step left group["lr"] a float inside the capture, which
+    # recompiled the compiled update under an active capture and aborted it outright.
+    p0, o0 = _build(optimizer_cls)
+    base = float(o0.param_groups[0]["lr"])
+    grad_seq = _grad_seq(p0)
+    sched = [base * (0.25 + 1.5 * (t + 1) / STEPS) for t in range(STEPS)]
+    const = [base] * STEPS
+
+    pe, oe = _build(optimizer_cls)
+    final_eager = _run(pe, oe, grad_seq, oe.step, lrs=sched, assign_float_lr=True)
+
+    pg, og = _build(optimizer_cls)
+    wrap = CudaGraphOptimizer(og, warmup_steps=WARMUP)
+    final_graph = _run(pg, og, grad_seq, wrap.step, lrs=sched, assign_float_lr=True)
+
+    pc, oc = _build(optimizer_cls)
+    wrapc = CudaGraphOptimizer(oc, warmup_steps=WARMUP)
+    final_const = _run(pc, oc, grad_seq, wrapc.step, lrs=const, assign_float_lr=True)
+
+    tracks = max((a - b).abs().max().item() for a, b in zip(final_eager, final_graph))
+    nontrivial = max((a - b).abs().max().item() for a, b in zip(final_graph, final_const))
+    assert tracks <= 1e-5, (
+        f"{optimizer_cls.__name__}: graph did not track a float-assigned LR "
+        f"(diff {tracks:.3e})"
+    )
+    assert nontrivial > 1e-3, (
+        f"{optimizer_cls.__name__}: schedule looks frozen -- scheduled and constant runs "
+        f"agree to {nontrivial:.3e}, so the test would pass even if the LR were baked"
+    )
+    # The float must have been folded back into the one tensor the graph reads, not left
+    # sitting in the group where the next replay would ignore it.
+    assert all(torch.is_tensor(g["lr"]) for g in og.param_groups)
+
+
+def test_lr_tensor_identity_is_stable_across_reassignment():
+    # What makes replay correct is that the group keeps handing the kernels the *same*
+    # tensor object the graph recorded. Rebuilding it on each reassignment would leave
+    # every later replay reading a tensor nobody writes to any more.
+    params, opt = _build(Dion2)
+    _run(params, opt, _grad_seq(params)[:1], opt.step)
+    before = [g["lr"] for g in opt.param_groups]
+
+    for g in opt.param_groups:
+        g["lr"] = 0.007
+    opt._sync_lr_tensors()
+
+    for g, t in zip(opt.param_groups, before):
+        assert g["lr"] is t, "LR tensor was replaced instead of filled in place"
+        assert t.item() == pytest.approx(0.007)
+
+
+def test_empty_param_group_is_allowed():
+    # An empty group has no device to put an LR tensor on and no kernel to read it.
+    # It is legal in torch and was legal here before the LR moved on-device; keep it so.
+    torch.manual_seed(SEED)
+    weights = [torch.nn.Parameter(torch.randn(64, 128, device=DEVICE))]
+    opt = Dion2(
+        [{"params": weights}, {"params": [], "algorithm": "adamw"}],
+        distributed_mesh=None, lr=0.02,
+    )
+    weights[0].grad = torch.zeros_like(weights[0])
+    opt.step()
+    assert torch.is_tensor(opt.param_groups[0]["lr"])
+
+
+def test_add_param_group_rewarms_before_recapturing():
+    # A group added after capture has never been through an eager step, so its state,
+    # workspaces and compiled kernels are not warm. Re-capturing immediately allocates (or
+    # recompiles) inside the graph and fails; the wrapper must redo the warmup first.
+    params, opt = _build(Dion2)
+    wrap = CudaGraphOptimizer(opt, warmup_steps=2)
+    grad_seq = _grad_seq(params)
+    _run(params, opt, grad_seq[:5], wrap.step)
+    assert wrap._graph is not None
+
+    extra = torch.nn.Parameter(torch.randn(32, 32, device=DEVICE))
+    extra.grad = torch.zeros_like(extra)
+    wrap.add_param_group({"params": [extra]})
+    assert wrap._graph is None and wrap._step_count == 0
+
+    before = extra.detach().clone()
+    for gs in grad_seq[:4]:
+        for p, g in zip(params, gs):
+            p.grad.copy_(g)
+        extra.grad.normal_()
+        wrap.step()
+    assert not torch.equal(before, extra.detach()), "added param never got updated"
+
+
+def test_failed_capture_does_not_leave_a_replayable_graph():
+    # If capture dies (an allocation, a recompile, a host sync inside the step), the
+    # half-built graph must not be kept: replaying it later would apply garbage on every
+    # subsequent step, turning one loud error into silent corruption.
+    params, opt = _build(Dion2)
+    wrap = CudaGraphOptimizer(opt, warmup_steps=1)
+    for p in params:
+        p.grad = torch.zeros_like(p)
+    opt.step()
+
+    def boom(closure=None):
+        torch.zeros(4, device=DEVICE).add_(1)  # get some way into the capture first
+        raise RuntimeError("capture blew up")
+
+    opt.step = boom
+    with pytest.raises(RuntimeError, match="capture blew up"):
+        wrap.step()
+    assert wrap._graph is None
+
+
+def test_lr_sync_under_active_capture_is_an_error():
+    # _sync_lr_tensors writes to the device, so recording it into a graph would re-apply
+    # the capture-time LR on every replay and silently overwrite the scheduler. It must
+    # say so rather than do that.
+    params, opt = _build(Dion2)
+    for p in params:
+        p.grad = torch.zeros_like(p)
+    opt.step()
+
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, capture_error_mode="thread_local"):
+        torch.zeros(4, device=DEVICE).add_(1)  # keep the capture non-empty
+        for g in opt.param_groups:
+            g["lr"] = 0.5
+        with pytest.raises(RuntimeError, match="capture"):
+            opt._sync_lr_tensors()
+    del graph
+    torch.cuda.synchronize()
 
 
 @pytest.mark.parametrize("optimizer_cls", OPTIMIZERS)

--- a/tests/test_cuda_graph.py
+++ b/tests/test_cuda_graph.py
@@ -11,6 +11,9 @@ check that the wrapper is numerically correct:
   tensor the optimizer reads and the wrapper refreshes before each replay -- rather than
   freezing at the capture-time value.
 """
+import io
+import os
+
 import pytest
 import torch
 
@@ -21,6 +24,7 @@ DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 pytestmark = pytest.mark.skipif(DEVICE == "cpu", reason="requires CUDA")
 
 STEPS, WARMUP, SEED = 12, 3, 0
+DIST_STEPS = 6
 OPTIMIZERS = [Muon, NorMuon, Dion2, NorDion2]
 
 
@@ -55,6 +59,23 @@ def _run(params, opt, grad_seq, step_fn, lrs=None):
             p.grad.copy_(g)
         step_fn()
     return [p.detach().clone() for p in params]
+
+
+def _roundtrip(opt):
+    # The ordinary resume idiom: checkpoint to disk, reload via CPU, load_state_dict.
+    buf = io.BytesIO()
+    torch.save(opt.state_dict(), buf)
+    buf.seek(0)
+    return torch.load(buf, map_location="cpu", weights_only=False)
+
+
+def _resumed(optimizer_cls, presteps=3):
+    params, opt = _build(optimizer_cls)
+    _run(params, opt, _grad_seq(params)[:presteps], opt.step)
+    sd = _roundtrip(opt)
+    params, opt = _build(optimizer_cls)
+    opt.load_state_dict(sd)
+    return params, opt
 
 
 @pytest.mark.parametrize("optimizer_cls", OPTIMIZERS)
@@ -102,3 +123,184 @@ def test_cudagraph_tracks_scheduled_lr(optimizer_cls):
         f"{optimizer_cls.__name__}: schedule looks frozen -- scheduled and constant runs "
         f"agree to {nontrivial:.3e}, so the test would pass even if the LR were baked"
     )
+
+
+@pytest.mark.parametrize("optimizer_cls", OPTIMIZERS)
+def test_scheduled_lr_tracks_after_resume(optimizer_cls):
+    # Same contract as test_cudagraph_tracks_scheduled_lr, but on an optimizer restored
+    # from a checkpoint -- the state every real run is in after the first resume.
+    # Regression: the device LR tensors were serialized into param_groups, so
+    # load_state_dict() overwrote the live ones with the checkpoint's copies, which land
+    # on CPU under the usual map_location="cpu". A CPU LR still trains correctly eagerly,
+    # so nothing raises; it is read once at capture and baked into the graph, silently
+    # freezing the schedule under replay.
+    p0, o0 = _build(optimizer_cls)
+    base = o0.param_groups[0]["lr"]
+    grad_seq = _grad_seq(p0)
+    sched = [base * (0.25 + 1.5 * (t + 1) / STEPS) for t in range(STEPS)]
+    const = [base] * STEPS
+
+    pe, oe = _resumed(optimizer_cls)
+    final_eager = _run(pe, oe, grad_seq, oe.step, lrs=sched)
+
+    pg, og = _resumed(optimizer_cls)
+    wrap = CudaGraphOptimizer(og, warmup_steps=WARMUP)
+    final_graph = _run(pg, og, grad_seq, wrap.step, lrs=sched)
+
+    pc, oc = _resumed(optimizer_cls)
+    wrapc = CudaGraphOptimizer(oc, warmup_steps=WARMUP)
+    final_const = _run(pc, oc, grad_seq, wrapc.step, lrs=const)
+
+    tracks = max((a - b).abs().max().item() for a, b in zip(final_eager, final_graph))
+    nontrivial = max((a - b).abs().max().item() for a, b in zip(final_graph, final_const))
+    assert tracks <= 1e-5, (
+        f"{optimizer_cls.__name__}: resumed graph did not track the schedule "
+        f"(diff {tracks:.3e})"
+    )
+    assert nontrivial > 1e-3, (
+        f"{optimizer_cls.__name__}: schedule looks frozen -- scheduled and constant runs "
+        f"agree to {nontrivial:.3e}, so the test would pass even if the LR were baked"
+    )
+
+
+def test_state_dict_carries_no_device_lr_tensor():
+    # param_groups is serialized hyperparameter state. A device tensor in there rides into
+    # every checkpoint and comes back as the wrong-device tensor on resume.
+    params, opt = _build(Dion2)
+    _run(params, opt, _grad_seq(params)[:1], opt.step)
+    groups = opt.state_dict()["param_groups"]
+    assert all("_lr_dev" not in g for g in groups)
+    # ...and the live optimizer still has one, i.e. it was stripped, not disabled.
+    assert any("_lr_dev" in g for g in opt.param_groups)
+
+
+def test_resume_from_checkpoint_without_step_tensor():
+    # A checkpoint written before the AdamW step moved on-device has no "step_dev" entry.
+    # The host-side group["step"] is what to resume from: starting over at 0 replays
+    # AdamW's bias-correction warmup, spiking the effective LR after every resume.
+    params, opt = _build(Dion2)
+    _run(params, opt, _grad_seq(params), opt.step)
+    sd = _roundtrip(opt)
+    for entry in sd["state"].values():
+        entry.pop("step_dev", None)  # what an older build wrote
+
+    _, opt2 = _build(Dion2)
+    opt2.load_state_dict(sd)
+    steps = [s["step_dev"].item() for s in opt2.state.values() if "step_dev" in s]
+    assert steps, "adamw params should carry a device step counter after load"
+    assert all(s == STEPS for s in steps), f"expected step {STEPS}, got {steps}"
+
+
+def test_step_tensor_survives_bf16_param_resume():
+    # load_state_dict() casts state tensors to the owning param's dtype (its "step" special
+    # case keys off the literal name, which this is not). A bf16 counter silently stops
+    # incrementing at 256, freezing bias correction for the rest of training.
+    torch.manual_seed(SEED)
+    biases = [torch.nn.Parameter(torch.randn(64, device=DEVICE, dtype=torch.bfloat16))]
+    opt = Dion2([{"params": biases, "algorithm": "adamw"}], distributed_mesh=None, lr=0.02)
+    for p in biases:
+        p.grad = torch.zeros_like(p)
+    opt.step()
+
+    sd = _roundtrip(opt)
+    biases2 = [torch.nn.Parameter(torch.randn(64, device=DEVICE, dtype=torch.bfloat16))]
+    opt2 = Dion2(
+        [{"params": biases2, "algorithm": "adamw"}], distributed_mesh=None, lr=0.02
+    )
+    opt2.load_state_dict(sd)
+
+    step = next(s["step_dev"] for s in opt2.state.values() if "step_dev" in s)
+    assert step.dtype == torch.float32, f"step counter cast to {step.dtype}"
+
+    # It must still count where bf16 cannot: 256 + 1 == 256 in bf16.
+    step.fill_(300)
+    for p in biases2:
+        p.grad = torch.zeros_like(p)
+    opt2.step()
+    assert step.item() == 301, f"step counter stuck at {step.item()}"
+
+
+def test_host_step_counter_advances_under_replay():
+    # step()'s python group["step"] += 1 only runs when step() is traced, so replay must
+    # advance it host-side or every later checkpoint records a stale step.
+    params, opt = _build(Dion2)
+    wrap = CudaGraphOptimizer(opt, warmup_steps=WARMUP)
+    _run(params, opt, _grad_seq(params), wrap.step)
+    assert all(g["step"] == STEPS for g in opt.param_groups), (
+        f"host step counters froze at {[g['step'] for g in opt.param_groups]}, expected {STEPS}"
+    )
+
+
+def test_warmup_steps_must_allow_an_eager_step():
+    _, opt = _build(Dion2)
+    with pytest.raises(ValueError, match="warmup_steps"):
+        CudaGraphOptimizer(opt, warmup_steps=0)
+
+
+# ---- distributed: capture must hold through the megabatch all-to-all (NCCL) ----
+# The single-GPU tests above run with distributed_mesh=None, which never reaches the
+# all-to-all -- yet collapsing that dispatch on a sharded step is the whole point of
+# capturing. This runs the real 2-rank sharded path, captured, against an eager run.
+
+
+def _dist_worker(rank, world_size, port, mode, out_path):
+    import torch.distributed as dist
+    from torch.distributed.tensor import DeviceMesh, Shard, distribute_tensor
+
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    wrap = step_fn = None
+    try:
+        dev = torch.device(f"cuda:{rank}")
+        mesh = DeviceMesh("cuda", list(range(world_size)))
+        gen = torch.Generator(device=dev).manual_seed(1234)
+        w0 = torch.randn(64, 128, generator=gen, device=dev)
+        param = torch.nn.Parameter(distribute_tensor(w0, mesh, [Shard(0)]))
+        param.grad = distribute_tensor(torch.zeros(64, 128, device=dev), mesh, [Shard(0)])
+
+        opt = NorDion2(
+            [dict(params=[param])], distributed_mesh=mesh, lr=0.1, newton_schulz_func=None
+        )
+        wrap = None if mode == "eager" else CudaGraphOptimizer(opt, warmup_steps=2)
+        step_fn = opt.step if wrap is None else wrap.step
+
+        # Shard the grads up front: distribute_tensor issues its own collectives, and
+        # interleaving those with replay measures the harness, not the optimizer.
+        grads = [
+            distribute_tensor(torch.randn(64, 128, generator=gen, device=dev), mesh, [Shard(0)])
+            for _ in range(DIST_STEPS)
+        ]
+        for t, g in enumerate(grads):
+            param.grad.copy_(g)
+            for group in opt.param_groups:
+                group["lr"] = 0.1 * (0.25 + t / DIST_STEPS)  # scheduled, must track
+            step_fn()
+        torch.cuda.synchronize()
+
+        # full_tensor() is itself a collective: every rank must call it, or the ranks that
+        # skip it run ahead to teardown and the ones that called it block forever.
+        full = param.detach().full_tensor()
+        if rank == 0:
+            torch.save(full.cpu(), out_path)
+    finally:
+        # Release the captured graph before tearing the process group down: it holds the
+        # captured NCCL ops, and destroy_process_group() blocks while they are alive.
+        step_fn = wrap = None
+        torch.cuda.synchronize()
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires 2 GPUs")
+def test_cudagraph_matches_eager_on_sharded_megabatch(tmp_path):
+    mp = torch.multiprocessing
+    out = {}
+    # Unique port per spawn to avoid bind collisions with the previous group.
+    for port, mode in ((29655, "eager"), (29656, "graph")):
+        path = tmp_path / f"{mode}.pt"
+        mp.spawn(_dist_worker, args=(2, port, mode, str(path)), nprocs=2, join=True)
+        out[mode] = torch.load(path, weights_only=False)
+
+    diff = (out["eager"] - out["graph"]).abs().max().item()
+    assert diff <= 1e-5, f"sharded capture-vs-eager diff {diff:.3e}"

--- a/tests/test_cuda_graph.py
+++ b/tests/test_cuda_graph.py
@@ -531,3 +531,36 @@ def test_cudagraph_step_with_closure(optimizer_cls):
     diff = max((a - b).abs().max().item() for a, b in zip(final_eager, final_graph))
     assert diff <= 1e-5, f"{optimizer_cls.__name__}: closure step-vs-eager diff {diff:.3e}"
     assert all(l is not None for l in losses)
+
+
+@pytest.mark.parametrize("optimizer_cls", [Dion2, NorDion2])
+def test_cudagraph_matches_eager_filtered_triton(optimizer_cls):
+    # The filtered (fraction<1) + triton post-orthogonalize path -- the configuration we
+    # train with. Regression: dion2_post_orthogonalize_triton did a .item() on the device
+    # LR to pass the weight-decay/step scalars to the kernel, which is a host sync CUDA
+    # graph capture forbids (and would freeze a scheduled LR under replay). The scalars are
+    # now 0-d device tensors the kernel loads. Small tensors still exercise the kernel.
+    def build_filtered():
+        torch.manual_seed(SEED)
+        weights = [torch.nn.Parameter(torch.randn(64, 128, device=DEVICE)),
+                   torch.nn.Parameter(torch.randn(128, 64, device=DEVICE))]
+        biases = [torch.nn.Parameter(torch.randn(64, device=DEVICE)),
+                  torch.nn.Parameter(torch.randn(128, device=DEVICE))]
+        opt = optimizer_cls([
+            {"params": weights},
+            {"params": biases, "algorithm": "adamw"},
+        ], distributed_mesh=None, lr=0.02, fraction=0.25, triton_post_ortho=True)
+        return weights + biases, opt
+
+    p0, _ = build_filtered()
+    grad_seq = _grad_seq(p0)
+
+    pe, oe = build_filtered()
+    final_eager = _run(pe, oe, grad_seq, oe.step)
+
+    pg, og = build_filtered()
+    wrap = CudaGraphOptimizer(og, warmup_steps=WARMUP)
+    final_graph = _run(pg, og, grad_seq, wrap.step)
+
+    diff = max((a - b).abs().max().item() for a, b in zip(final_eager, final_graph))
+    assert diff <= 1e-5, f"{optimizer_cls.__name__} filtered+triton: capture-vs-eager diff {diff:.3e}"

--- a/tests/test_cuda_graph.py
+++ b/tests/test_cuda_graph.py
@@ -1,0 +1,104 @@
+"""CUDA-graph capture of the optimizer step (``dion.cuda_graph.CudaGraphOptimizer``).
+
+The megabatched Muon/NorMuon/Dion2/NorDion2 step is a fixed-shape computation (top-k
+selection changes which rows are chosen, not the shapes), so capturing it once and
+replaying collapses the per-matrix host dispatch to a single graph launch. These tests
+check that the wrapper is numerically correct:
+
+- capture+replay matches running the bare optimizer eagerly, step for step, for the
+  matrix (Muon/NorMuon/Dion2/NorDion2) path and the AdamW scalar path together; and
+- a per-step LR schedule takes effect under replay -- the LR is carried as a device
+  tensor the optimizer reads and the wrapper refreshes before each replay -- rather than
+  freezing at the capture-time value.
+"""
+import pytest
+import torch
+
+from dion import Dion2, Muon, NorDion2, NorMuon
+from dion.cuda_graph import CudaGraphOptimizer
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+pytestmark = pytest.mark.skipif(DEVICE == "cpu", reason="requires CUDA")
+
+STEPS, WARMUP, SEED = 12, 3, 0
+OPTIMIZERS = [Muon, NorMuon, Dion2, NorDion2]
+
+
+def _build(optimizer_cls):
+    torch.manual_seed(SEED)
+    weights = [torch.nn.Parameter(torch.randn(64, 128, device=DEVICE)),
+               torch.nn.Parameter(torch.randn(128, 64, device=DEVICE))]
+    biases = [torch.nn.Parameter(torch.randn(64, device=DEVICE)),
+              torch.nn.Parameter(torch.randn(128, device=DEVICE))]
+    opt = optimizer_cls([
+        {"params": weights},
+        {"params": biases, "algorithm": "adamw"},
+    ], distributed_mesh=None, lr=0.02)
+    return weights + biases, opt
+
+
+def _grad_seq(params):
+    gen = torch.Generator(device=DEVICE).manual_seed(7)
+    return [[torch.randn(p.shape, device=DEVICE, generator=gen) for p in params]
+            for _ in range(STEPS)]
+
+
+def _run(params, opt, grad_seq, step_fn, lrs=None):
+    # Stable .grad buffers (the graph pins them); refill in place, never reallocate.
+    for p in params:
+        p.grad = torch.zeros_like(p)
+    for t, gs in enumerate(grad_seq):
+        if lrs is not None:
+            for g in opt.param_groups:
+                g["lr"] = lrs[t]
+        for p, g in zip(params, gs):
+            p.grad.copy_(g)
+        step_fn()
+    return [p.detach().clone() for p in params]
+
+
+@pytest.mark.parametrize("optimizer_cls", OPTIMIZERS)
+def test_cudagraph_matches_eager(optimizer_cls):
+    p0, _ = _build(optimizer_cls)
+    grad_seq = _grad_seq(p0)
+
+    pe, oe = _build(optimizer_cls)
+    final_eager = _run(pe, oe, grad_seq, oe.step)
+
+    pg, og = _build(optimizer_cls)
+    wrap = CudaGraphOptimizer(og, warmup_steps=WARMUP)
+    final_graph = _run(pg, og, grad_seq, wrap.step)
+
+    diff = max((a - b).abs().max().item() for a, b in zip(final_eager, final_graph))
+    assert diff <= 1e-5, f"{optimizer_cls.__name__}: capture-vs-eager diff {diff:.3e}"
+
+
+@pytest.mark.parametrize("optimizer_cls", OPTIMIZERS)
+def test_cudagraph_tracks_scheduled_lr(optimizer_cls):
+    p0, o0 = _build(optimizer_cls)
+    base = o0.param_groups[0]["lr"]
+    grad_seq = _grad_seq(p0)
+    # A schedule that varies ~8x across the run (warmup then decay).
+    sched = [base * (0.25 + 1.5 * (t + 1) / STEPS) for t in range(STEPS)]
+    const = [base] * STEPS
+
+    pe, oe = _build(optimizer_cls)
+    final_eager = _run(pe, oe, grad_seq, oe.step, lrs=sched)
+
+    pg, og = _build(optimizer_cls)
+    wrap = CudaGraphOptimizer(og, warmup_steps=WARMUP)
+    final_graph = _run(pg, og, grad_seq, wrap.step, lrs=sched)
+
+    pc, oc = _build(optimizer_cls)
+    wrapc = CudaGraphOptimizer(oc, warmup_steps=WARMUP)
+    final_const = _run(pc, oc, grad_seq, wrapc.step, lrs=const)
+
+    tracks = max((a - b).abs().max().item() for a, b in zip(final_eager, final_graph))
+    nontrivial = max((a - b).abs().max().item() for a, b in zip(final_graph, final_const))
+    assert tracks <= 1e-5, (
+        f"{optimizer_cls.__name__}: graph did not track the schedule (diff {tracks:.3e})"
+    )
+    assert nontrivial > 1e-3, (
+        f"{optimizer_cls.__name__}: schedule looks frozen -- scheduled and constant runs "
+        f"agree to {nontrivial:.3e}, so the test would pass even if the LR were baked"
+    )

--- a/tests/test_cuda_graph.py
+++ b/tests/test_cuda_graph.py
@@ -53,8 +53,11 @@ def _run(params, opt, grad_seq, step_fn, lrs=None):
         p.grad = torch.zeros_like(p)
     for t, gs in enumerate(grad_seq):
         if lrs is not None:
+            # Update the LR *in place*, the way a torch LR scheduler does. group["lr"] is
+            # the device tensor the kernels read; reassigning a python float would swap the
+            # object out and leave the captured graph reading the stale one under replay.
             for g in opt.param_groups:
-                g["lr"] = lrs[t]
+                g["lr"].fill_(lrs[t])
         for p, g in zip(params, gs):
             p.grad.copy_(g)
         step_fn()
@@ -163,15 +166,62 @@ def test_scheduled_lr_tracks_after_resume(optimizer_cls):
     )
 
 
-def test_state_dict_carries_no_device_lr_tensor():
-    # param_groups is serialized hyperparameter state. A device tensor in there rides into
-    # every checkpoint and comes back as the wrong-device tensor on resume.
+def test_lr_is_device_tensor_but_checkpoints_as_float():
+    # Runtime: group["lr"] is the 0-d device fp32 tensor the kernels read (and a scheduler
+    # fills in place). Checkpoint: serialized as a plain float, so it stays portable and
+    # does not ride a CUDA tensor back onto the wrong device on resume.
     params, opt = _build(Dion2)
     _run(params, opt, _grad_seq(params)[:1], opt.step)
-    groups = opt.state_dict()["param_groups"]
-    assert all("_lr_dev" not in g for g in groups)
-    # ...and the live optimizer still has one, i.e. it was stripped, not disabled.
-    assert any("_lr_dev" in g for g in opt.param_groups)
+
+    for g in opt.param_groups:
+        lr = g["lr"]
+        assert torch.is_tensor(lr) and lr.is_cuda and lr.dtype == torch.float32 and lr.ndim == 0
+
+    for g in opt.state_dict()["param_groups"]:
+        assert type(g["lr"]) is float
+
+
+@pytest.mark.parametrize("optimizer_cls", OPTIMIZERS)
+def test_real_lr_scheduler_drives_captured_step(optimizer_cls):
+    # The elegance payoff: a stock torch LR scheduler on the inner optimizer drives the
+    # captured step with no wrapper LR plumbing, because it fills group["lr"] -- the exact
+    # device tensor the graph reads -- in place. Eager and captured runs must agree, and the
+    # captured run must actually move with the schedule (not freeze at the capture value).
+    grad_seq = _grad_seq(_build(optimizer_cls)[0])
+
+    def run(step_wrapped):
+        params, opt = _build(optimizer_cls)
+        # T_max small vs STEPS so the cosine sweeps a wide LR range across the run.
+        sched = torch.optim.lr_scheduler.CosineAnnealingLR(opt, T_max=4, eta_min=1e-4)
+        step = CudaGraphOptimizer(opt, warmup_steps=WARMUP).step if step_wrapped else opt.step
+        for p in params:
+            p.grad = torch.zeros_like(p)
+        for gs in grad_seq:
+            for p, g in zip(params, gs):
+                p.grad.copy_(g)
+            step()
+            sched.step()
+        return [p.detach().clone() for p in params]
+
+    final_eager = run(step_wrapped=False)
+    final_graph = run(step_wrapped=True)
+    diff = max((a - b).abs().max().item() for a, b in zip(final_eager, final_graph))
+    assert diff <= 1e-5, f"{optimizer_cls.__name__}: scheduled capture-vs-eager diff {diff:.3e}"
+
+    # Guard against a frozen LR: rerun the graph at a constant LR and require it to differ.
+    params, opt = _build(optimizer_cls)
+    for p in params:
+        p.grad = torch.zeros_like(p)
+    wrap = CudaGraphOptimizer(opt, warmup_steps=WARMUP)
+    for gs in grad_seq:
+        for p, g in zip(params, gs):
+            p.grad.copy_(g)
+        wrap.step()
+    frozen = max((a - b).abs().max().item() for a, b in zip(final_graph, params))
+    assert frozen > 1e-3, (
+        f"{optimizer_cls.__name__}: scheduled and constant-LR captured runs agree to "
+        f"{frozen:.3e} -- the schedule looks frozen under replay"
+    )
 
 
 def test_resume_from_checkpoint_without_step_tensor():
@@ -275,7 +325,10 @@ def _dist_worker(rank, world_size, port, mode, out_path):
         for t, g in enumerate(grads):
             param.grad.copy_(g)
             for group in opt.param_groups:
-                group["lr"] = 0.1 * (0.25 + t / DIST_STEPS)  # scheduled, must track
+                # In place (as a scheduler does): group["lr"] is the device tensor the
+                # captured graph reads; reassigning a float would leave replay on the stale
+                # tensor.
+                group["lr"].fill_(0.1 * (0.25 + t / DIST_STEPS))  # scheduled, must track
             step_fn()
         torch.cuda.synchronize()
 

--- a/tests/test_cuda_graph.py
+++ b/tests/test_cuda_graph.py
@@ -91,6 +91,10 @@ def test_cudagraph_matches_eager(optimizer_cls):
 
     pg, og = _build(optimizer_cls)
     wrap = CudaGraphOptimizer(og, warmup_steps=WARMUP)
+    # A framework (Lightning) both isinstance-checks the optimizer and reads its groups
+    # through the wrapper; the wrapper is-a Optimizer and shares the wrapped groups/state.
+    assert isinstance(wrap, torch.optim.Optimizer)
+    assert wrap.param_groups is og.param_groups and wrap.state is og.state
     final_graph = _run(pg, og, grad_seq, wrap.step)
 
     diff = max((a - b).abs().max().item() for a, b in zip(final_eager, final_graph))
@@ -357,3 +361,32 @@ def test_cudagraph_matches_eager_on_sharded_megabatch(tmp_path):
 
     diff = (out["eager"] - out["graph"]).abs().max().item()
     assert diff <= 1e-5, f"sharded capture-vs-eager diff {diff:.3e}"
+
+
+@pytest.mark.parametrize("optimizer_cls", OPTIMIZERS)
+def test_cudagraph_step_with_closure(optimizer_cls):
+    # Lightning's automatic optimization calls step(closure); the closure runs
+    # forward+backward (here it fills .grad in place) and returns the loss. The wrapped
+    # step must run the closure, apply the captured update, and hand back the loss.
+    p0, _ = _build(optimizer_cls)
+    grad_seq = _grad_seq(p0)
+
+    pe, oe = _build(optimizer_cls)
+    final_eager = _run(pe, oe, grad_seq, oe.step)
+
+    pg, og = _build(optimizer_cls)
+    wrap = CudaGraphOptimizer(og, warmup_steps=WARMUP)
+    for p in pg:
+        p.grad = torch.zeros_like(p)
+    losses = []
+    for gs in grad_seq:
+        def closure(gs=gs):
+            for p, g in zip(pg, gs):
+                p.grad.copy_(g)
+            return torch.full((), 0.5, device=DEVICE)
+        losses.append(wrap.step(closure))
+    final_graph = [p.detach().clone() for p in pg]
+
+    diff = max((a - b).abs().max().item() for a, b in zip(final_eager, final_graph))
+    assert diff <= 1e-5, f"{optimizer_cls.__name__}: closure step-vs-eager diff {diff:.3e}"
+    assert all(l is not None for l in losses)


### PR DESCRIPTION
## What

Adds `dion.cuda_graph.CudaGraphOptimizer`, a drop-in wrapper that captures `optimizer.step()` into a CUDA graph and replays it. The megabatched Muon/NorMuon/Dion2/NorDion2 step issues hundreds of small host ops per step for its per-matrix selection / error-feedback / normalization bookkeeping; on a sharded step that dispatch is a fixed per-step host cost that doesn't shrink with the data-parallel group. The step is fixed-shape (top-k selection changes which rows are chosen, not the shapes), so one capture + replay collapses the whole host dispatch — including the megabatch all-to-all (NCCL) and the symmetric-GEMM kernels — into a single graph launch, with **GPU (device) time unchanged**.

```python
opt = CudaGraphOptimizer(NorDion2(param_groups, ...), warmup_steps=10)
for batch in loader:
    loss = model(batch); loss.backward()
    opt.step()                          # eager for warmup_steps, then captured + replayed
    opt.zero_grad(set_to_none=False)    # keep .grad buffers stable for replay
```

## Making the step capturable

- **Scheduled LR.** Each param group carries its learning rate as a persistent device tensor (`megabatch_base._group_lr_tensor`), refreshed in place from the (scheduler-updated) python `group["lr"]` each step **outside** the graph (skipped while capturing; the wrapper refreshes before each replay). So a per-step LR schedule takes effect under replay instead of freezing at the capture-time value.
- **Capturable AdamW.** `adamw_update_foreach` gains a capturable form: per-param device step tensors incremented on-device, with `lr` read through the fused kernel's `tensor_lr` overload (`grad_scale=None, found_inf=None` select it — omitting them silently resolves to a different overload that misreads the step). The legacy `step: int` form (baked step + float lr) is **unchanged**, so existing callers — including the non-megabatched `Dion` — and `tests/test_adamw_foreach.py` are untouched.
- **Post-capture replay.** `CudaGraphOptimizer._capture` replays once immediately after capture: CUDA-graph capture *records* ops without executing them, so without this the captured step runs one step short.

## Numerics

`graph == eager` is **bit-exact** for the new code (both use the device-tensor LR), for a constant *and* a per-step-scheduled LR. Moving the matrix-path LR from a CPU wrapped-scalar to a device tensor changes bf16 type promotion in the update multiply (`neg_lr * U`), a ~1.5e-5-relative (bf16-rounding-class) shift versus the previous CPU-scalar path — below the optimizer's inherent bf16 noise, and it does not affect the AdamW path or the run-to-run determinism / parity tests.

## Testing

New `tests/test_cuda_graph.py`: capture-vs-eager and scheduled-LR-under-replay, for Muon/NorMuon/Dion2/NorDion2 (matrix + AdamW-scalar groups together) — 8 tests. Existing suites pass unchanged on the affected paths: `test_adamw_foreach` (13), `test_optimizers` (89), `test_dion2_post_ortho_triton` / `test_state_prepopulation` / `test_newton_shulz` / `test_polar_express` (114 passed, 16 skipped). The multi-GPU `test_dion2_selection_scope` / `test_megabatch_empty_shard` need a multi-GPU runner (CI).