### PR TITLE
Batch the Dion2/NorDion2 megabatch per-matrix scatter loops (bit-exact host reduction)

### DIFF
--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -527,17 +527,15 @@ def dion2_pre_orthogonalize(
         )
         selected_stacked = torch.gather(M_stacked, dim=-1, index=indices_expanded)
 
-    # Apply error feedback decay to selected slices in the original M tensors.
-    # We reuse the already-gathered slices and write them back (scaled) using
-    # scatter_, which places values into positions specified by the index tensor.
+    # Apply error-feedback decay to the selected slices, batched over the whole shape
+    # group: one scatter into the stacked momentum plus a foreach copy-back, instead of
+    # one ``scatter_`` per matrix. The per-matrix loop was a large share of the opt-step
+    # host dispatch (~one scatter kernel per weight matrix per step); ``indices_expanded``
+    # already has the batched (N, k, cols)/(N, rows, k) shape, and the selected slices are
+    # unique per row/column, so this is bit-exact with the per-tensor loop.
+    M_stacked.scatter_(dim=select_dim, index=indices_expanded, src=selected_stacked * ef_decay)
+    torch._foreach_copy_(M, list(M_stacked.unbind(dim=0)))
     indices_list = list(indices.unbind(dim=0))
-    selected_list = list(selected_stacked.unbind(dim=0))
-    for m, idx, selected in zip(M, indices_list, selected_list):
-        if select_dim == -2:
-            idx_exp = idx.unsqueeze(-1).expand(*idx.shape, m.size(-1))
-        else:
-            idx_exp = idx.unsqueeze(-2).expand(*idx.shape[:-1], m.size(-2), idx.shape[-1])
-        m.scatter_(dim=select_dim, index=idx_exp, src=selected * ef_decay)
 
     # Convert to bf16 and unstack for communication
     U_selected = list(selected_stacked.to(dtype=torch.bfloat16).unbind(dim=0))
@@ -679,20 +677,22 @@ def dion2_post_orthogonalize(
 
     # Convert U to match parameter dtype
     dtype = X[0].dtype
-    U = [u.to(dtype=dtype) for u in U]
-    # Apply weight update
     neg_lr = -adjusted_lr
-    U_scaled = [neg_lr * u for u in U]
-    # Apply the orthogonalized update to only the selected rows/columns.
-    # scatter_add_ accumulates values into positions specified by the index tensor:
-    #   x[..., idx_exp[..., i, j], j] += u_scaled[..., i, j]  (for select_dim == -2)
-    # where i ranges over the k selected rows and j over all columns.
-    for x, u_scaled, idx in zip(X, U_scaled, indices):
-        if select_dim == -2:
-            idx_exp = idx.unsqueeze(-1).expand_as(u_scaled)
-        else:
-            idx_exp = idx.unsqueeze(-2).expand_as(u_scaled)
-        x.scatter_add_(dim=select_dim, index=idx_exp, src=u_scaled)
+    # Apply the orthogonalized update to the selected rows/columns, batched over the
+    # whole shape group: stack X/U/indices and do one scatter_add over the batch instead
+    # of one scatter_add_ per weight matrix (the per-matrix loop was ~one kernel per
+    # matrix per step, a large share of the opt-step host dispatch). Selected indices are
+    # unique per slice, so scatter_add is collision-free and this is bit-exact with the
+    # per-tensor loop. scatter_add_ accumulates U into X at the selected positions.
+    Xs = torch.stack(X, dim=0)
+    U_scaled = (neg_lr * torch.stack(U, dim=0)).to(dtype)
+    idx = torch.stack(indices, dim=0)
+    if select_dim == -2:
+        idx_exp = idx.unsqueeze(-1).expand_as(U_scaled)
+    else:
+        idx_exp = idx.unsqueeze(-2).expand_as(U_scaled)
+    Xs.scatter_add_(dim=select_dim, index=idx_exp, src=U_scaled)
+    torch._foreach_copy_(X, list(Xs.unbind(dim=0)))
 
 
 @torch.compile(fullgraph=True)

--- a/dion/nordion2.py
+++ b/dion/nordion2.py
@@ -382,7 +382,7 @@ def nordion2_update_megabatch_async(
     U_stacked, V_stacked = nordion2_normalize_selected_stacked(
         U_stacked, V_stacked, indices, muon_beta2
     )
-    U_normed = [U_stacked[i] for i in range(N)]
+    U_normed = list(U_stacked.unbind(0))
     torch._foreach_copy_(V_local, list(V_stacked.unbind(0)))
 
     # Compute scaled learning rate


### PR DESCRIPTION
## What

The megabatched Dion2/NorDion2 optimizer step ran **one scatter kernel per weight matrix per step** — once for the error-feedback momentum update (`dion2_pre_orthogonalize`) and once for the write-back (`dion2_post_orthogonalize`). That per-matrix host dispatch is a large share of the opt-step's host cost. This batches each per-matrix loop, within a shape group, into a **single stacked scatter**: stack `M`/`X`/`U`/`indices`, do one `scatter_`/`scatter_add_` over the batch, then a `foreach` copy-back.

The selected indices are unique per slice, so the batched scatter is collision-free and **bit-exact** with the per-matrix loop.

## Why this over a CUDA graph

A CUDA-graph capture collapses host dispatch far more (~500×), but only with a **fixed** learning rate — the LR gets baked at capture, and making it capturable (device-tensor LR) regresses GPU time 10–30% because a device-scalar `scalar * update` drops out of PyTorch's vectorized elementwise kernel. This batching needs none of that: it's a pure launch-count reduction, so it **composes with a normal scheduled LR** and leaves the GPU kernels (and their vectorization) untouched.

## Results

Single-GPU, dion2 f=½, 24 layers, opt-step measured in isolation:

| | GPU (device) | CPU (host dispatch) |
|---|---|---|
| per-matrix loop | 16.5 ms | 7.5 ms |
| **batched** | 16.2 ms | **4.3 ms** (~1.7×) |

GPU time unchanged (noise); bit-exact updates (fixed-seed fingerprint `-7937.4657929559` dion2, `-7934.6272033966` nordion2). The absolute host reduction grows with the number of matrices per shape group (larger at multi-B scale).

## Testing

Existing `tests/test_optimizers.py` (parity / determinism / megabatch-same-shape) and `tests/test_adamw_foreach.py` pass unchanged (102 passed) — the megabatch-vs-reference parity tests exercise the batched write-back directly.