### PR TITLE
Batch the Dion2/NorDion2 megabatch per-matrix scatter loops (bit-exact host reduction)

### DIFF
--- a/dion/cuda_graph.py
+++ b/dion/cuda_graph.py
@@ -12,19 +12,30 @@ graph launch (GPU time unchanged), and the capture holds through the megabatch a
 Usage (drop-in around any optimizer whose step() is graph-safe -- no host syncs, fixed
 shapes, gradients living in stable ``.grad`` tensors):
 
-    opt = CudaGraphOptimizer(Dion2(param_groups, ...), warmup_steps=10)
+    inner = Dion2(param_groups, ...)
+    sched = torch.optim.lr_scheduler.CosineAnnealingLR(inner, T_max=...)  # NOT the wrapper
+    opt = CudaGraphOptimizer(inner, warmup_steps=10)
     for batch in loader:
         loss = model(batch); loss.backward()
         opt.step()                    # eager for warmup_steps, then captured+replayed
         opt.zero_grad(set_to_none=False)   # MUST keep .grad tensors stable for replay
+        sched.step()
 
 Requirements / caveats:
+  * LR schedulers must be constructed on the *inner* optimizer: torch's ``LRScheduler``
+    rejects anything failing ``isinstance(opt, torch.optim.Optimizer)``, which this
+    wrapper is not. Scheduling still works -- the scheduler writes ``group["lr"]`` and the
+    wrapper pushes that into the device LR tensors before each replay.
   * ``loss.backward()`` must accumulate into the same ``p.grad`` tensors each step, so
     call ``zero_grad(set_to_none=False)`` (the wrapper enforces this). The first
     backward allocates ``.grad``; capture pins those buffers.
   * The step must not do a host sync (``.item()``/``.cpu()``) or change tensor shapes
     across steps. Dion2/NorDion2's selection *count* is fixed; only indices/values vary,
     which replay handles (it re-reads the live tensors).
+  * On the sharded path the graph holds the captured megabatch all-to-all, so the NCCL
+    ops outlive the step. ``dist.destroy_process_group()`` blocks while they are alive:
+    drop the wrapper (and any graph it holds) before tearing the process group down at
+    the end of a run, or shutdown hangs.
   * torch.compile is neither needed nor wanted under a graph (the graph already removes
     dispatch, and a fullgraph compile of the unrolled per-matrix loops is what makes the
     first step take minutes at many layers). Disable it for the wrapped optimizer.
@@ -44,10 +55,26 @@ import torch
 
 class CudaGraphOptimizer:
     def __init__(self, optimizer, warmup_steps: int = 10):
+        if warmup_steps < 1:
+            raise ValueError(
+                f"warmup_steps must be >= 1, got {warmup_steps}. Capture needs at least "
+                "one eager step to have allocated the optimizer state, cuBLAS workspaces "
+                "and NCCL buffers; capturing the first step instead allocates them inside "
+                "the graph and fails deep in the backend."
+            )
         self.optimizer = optimizer
         self.warmup_steps = warmup_steps
         self._step_count = 0
         self._graph: Optional[torch.cuda.CUDAGraph] = None
+
+    def __getattr__(self, name):
+        # Delegate the rest of the Optimizer API (state, defaults, add_param_group, ...).
+        # Only called for attributes not found normally, so the overrides below still win.
+        # ``optimizer`` is guarded because __getattr__ runs before __init__ assigns it
+        # (e.g. during unpickling), which would otherwise recurse forever.
+        if name == "optimizer":
+            raise AttributeError(name)
+        return getattr(self.optimizer, name)
 
     @property
     def param_groups(self):
@@ -96,7 +123,13 @@ class CudaGraphOptimizer:
         if self._step_count < self.warmup_steps:
             self.optimizer.step()
         elif self._graph is None:
+            # step() runs (and so does its host-side bookkeeping) while being traced.
             self._capture()
         else:
             self._graph.replay()
+            # Replay executes only the recorded device work, so any host-side per-step
+            # bookkeeping in step() has to be advanced here instead.
+            advance = getattr(self.optimizer, "_advance_host_step_counters", None)
+            if advance is not None:
+                advance()
         self._step_count += 1

--- a/dion/cuda_graph.py
+++ b/dion/cuda_graph.py
@@ -1,0 +1,102 @@
+"""CUDA-graph capture for the optimizer step.
+
+The megabatched Muon/NorMuon/Dion2/NorDion2 optimizer step issues hundreds of small host
+ops per step for its per-matrix selection / error-feedback / normalization bookkeeping. On
+a sharded step that host dispatch (tens of ms at multi-B scale) is a fixed overhead that
+does not shrink with the data-parallel group, so it dominates the distributed step at
+small per-GPU compute. The step is a fixed-shape, repeated computation -- an ideal
+CUDA-graph target. Capturing it once and replaying collapses the host dispatch to a single
+graph launch (GPU time unchanged), and the capture holds through the megabatch all-to-all
+(NCCL) and the symmetric-GEMM (CuteDSL) kernels.
+
+Usage (drop-in around any optimizer whose step() is graph-safe -- no host syncs, fixed
+shapes, gradients living in stable ``.grad`` tensors):
+
+    opt = CudaGraphOptimizer(Dion2(param_groups, ...), warmup_steps=10)
+    for batch in loader:
+        loss = model(batch); loss.backward()
+        opt.step()                    # eager for warmup_steps, then captured+replayed
+        opt.zero_grad(set_to_none=False)   # MUST keep .grad tensors stable for replay
+
+Requirements / caveats:
+  * ``loss.backward()`` must accumulate into the same ``p.grad`` tensors each step, so
+    call ``zero_grad(set_to_none=False)`` (the wrapper enforces this). The first
+    backward allocates ``.grad``; capture pins those buffers.
+  * The step must not do a host sync (``.item()``/``.cpu()``) or change tensor shapes
+    across steps. Dion2/NorDion2's selection *count* is fixed; only indices/values vary,
+    which replay handles (it re-reads the live tensors).
+  * torch.compile is neither needed nor wanted under a graph (the graph already removes
+    dispatch, and a fullgraph compile of the unrolled per-matrix loops is what makes the
+    first step take minutes at many layers). Disable it for the wrapped optimizer.
+  * Both the matrix (Muon/NorMuon/Dion2/NorDion2) path and the AdamW *scalar* path
+    (embeddings / 1-D params) are capturable. Each group carries its learning rate as a
+    device tensor (``megabatch_base._group_lr_tensor``) that the wrapper refreshes before
+    each replay, so a *scheduled* LR takes effect under replay instead of freezing at the
+    capture value; and ``scalar_opts.adamw_update_foreach``'s capturable form keeps each
+    AdamW param's step as a device tensor and increments it on-device before the fused
+    kernel, so bias correction advances inside the graph. Verified bit-exact eager-vs-
+    replay for both a constant and a per-step-scheduled LR (``tests/test_cuda_graph.py``).
+"""
+
+from typing import Optional
+import torch
+
+
+class CudaGraphOptimizer:
+    def __init__(self, optimizer, warmup_steps: int = 10):
+        self.optimizer = optimizer
+        self.warmup_steps = warmup_steps
+        self._step_count = 0
+        self._graph: Optional[torch.cuda.CUDAGraph] = None
+
+    @property
+    def param_groups(self):
+        return self.optimizer.param_groups
+
+    def state_dict(self):
+        return self.optimizer.state_dict()
+
+    def load_state_dict(self, sd):
+        # Loading new state invalidates any captured graph (buffers may move).
+        self._graph = None
+        self._step_count = 0
+        return self.optimizer.load_state_dict(sd)
+
+    def zero_grad(self, set_to_none: bool = False):
+        # set_to_none=True would swap .grad for a fresh tensor each step, breaking the
+        # graph's pinned grad buffers. Force the stable-buffer path.
+        if set_to_none:
+            raise ValueError(
+                "CudaGraphOptimizer requires stable .grad buffers; call "
+                "zero_grad(set_to_none=False)."
+            )
+        self.optimizer.zero_grad(set_to_none=False)
+
+    def _capture(self):
+        # Capture exactly ONE step. Lazy allocations, cuBLAS workspaces and NCCL setup are
+        # already done by the warmup_steps eager steps, so nothing allocates inside the
+        # graph. Capture only RECORDS the ops onto the graph -- it does not execute them --
+        # so we replay once immediately to actually perform this step's update. Without
+        # that replay the trajectory would be one step short (params/state/step frozen at
+        # their pre-capture values for this call).
+        torch.cuda.synchronize()
+        self._graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(self._graph):
+            self.optimizer.step()
+        self._graph.replay()
+
+    def step(self):
+        # Push the current (possibly scheduled) LR into the wrapped optimizer's device LR
+        # tensors here, OUTSIDE the graph, so the captured step reads the live value on
+        # every replay. The optimizer's own in-step refresh is skipped while capturing, so
+        # this is the only refresh the replay path gets.
+        refresh = getattr(self.optimizer, "_refresh_lr_tensors", None)
+        if refresh is not None:
+            refresh()
+        if self._step_count < self.warmup_steps:
+            self.optimizer.step()
+        elif self._graph is None:
+            self._capture()
+        else:
+            self._graph.replay()
+        self._step_count += 1

--- a/dion/cuda_graph.py
+++ b/dion/cuda_graph.py
@@ -23,9 +23,13 @@ shapes, gradients living in stable ``.grad`` tensors):
 
 Requirements / caveats:
   * LR schedulers must be constructed on the *inner* optimizer: torch's ``LRScheduler``
-    rejects anything failing ``isinstance(opt, torch.optim.Optimizer)``, which this
-    wrapper is not. Scheduling still works -- the scheduler writes ``group["lr"]`` and the
-    wrapper pushes that into the device LR tensors before each replay.
+    rejects anything failing ``isinstance(opt, torch.optim.Optimizer)``, which this wrapper
+    is not. Scheduling still works with no wrapper plumbing -- ``group["lr"]`` is the device
+    tensor the captured graph reads, and the scheduler (bound to the inner optimizer, which
+    shares the same param_groups) fills it in place outside the graph, so every replay
+    re-reads the live value. A *scheduled* LR takes effect under replay only through such an
+    in-place update; reassigning a python float (``group["lr"] = 0.05``) swaps the tensor
+    out and leaves replay reading the stale one until the next eager step.
   * ``loss.backward()`` must accumulate into the same ``p.grad`` tensors each step, so
     call ``zero_grad(set_to_none=False)`` (the wrapper enforces this). The first
     backward allocates ``.grad``; capture pins those buffers.
@@ -41,12 +45,14 @@ Requirements / caveats:
     first step take minutes at many layers). Disable it for the wrapped optimizer.
   * Both the matrix (Muon/NorMuon/Dion2/NorDion2) path and the AdamW *scalar* path
     (embeddings / 1-D params) are capturable. Each group carries its learning rate as a
-    device tensor (``megabatch_base._group_lr_tensor``) that the wrapper refreshes before
-    each replay, so a *scheduled* LR takes effect under replay instead of freezing at the
-    capture value; and ``scalar_opts.adamw_update_foreach``'s capturable form keeps each
-    AdamW param's step as a device tensor and increments it on-device before the fused
-    kernel, so bias correction advances inside the graph. Verified bit-exact eager-vs-
-    replay for both a constant and a per-step-scheduled LR (``tests/test_cuda_graph.py``).
+    device tensor -- ``group["lr"]`` *is* that tensor -- which the kernels read directly, so
+    a ``torch.optim`` LR scheduler drives a captured step natively: it fills the tensor in
+    place outside the graph and every replay re-reads the live value, no refresh plumbing.
+    (Build the scheduler on the *inner* optimizer; ``group["lr"]`` is shared, so it updates
+    the exact tensor the captured graph reads.) The AdamW step is likewise a device tensor,
+    incremented on-device before the fused kernel so bias correction advances inside the
+    graph. Verified bit-exact eager-vs-replay for a constant and a per-step-scheduled LR,
+    including under a real ``CosineAnnealingLR`` (``tests/test_cuda_graph.py``).
 """
 
 from typing import Optional
@@ -113,13 +119,9 @@ class CudaGraphOptimizer:
         self._graph.replay()
 
     def step(self):
-        # Push the current (possibly scheduled) LR into the wrapped optimizer's device LR
-        # tensors here, OUTSIDE the graph, so the captured step reads the live value on
-        # every replay. The optimizer's own in-step refresh is skipped while capturing, so
-        # this is the only refresh the replay path gets.
-        refresh = getattr(self.optimizer, "_refresh_lr_tensors", None)
-        if refresh is not None:
-            refresh()
+        # No LR plumbing here: the wrapped optimizer carries each group's LR as the device
+        # tensor ``group["lr"]`` that the kernels read, and a scheduler fills it in place
+        # outside the graph, so every replay already re-reads the live value.
         if self._step_count < self.warmup_steps:
             self.optimizer.step()
         elif self._graph is None:

--- a/dion/cuda_graph.py
+++ b/dion/cuda_graph.py
@@ -21,10 +21,15 @@ shapes, gradients living in stable ``.grad`` tensors):
         opt.zero_grad(set_to_none=False)   # MUST keep .grad tensors stable for replay
         sched.step()
 
+Under a framework that drives automatic optimization with a closure (Lightning calls
+``opt.step(closure)``, the closure running forward+backward), ``step`` runs the closure
+first, then replays the captured update and returns its loss.
+
 Requirements / caveats:
-  * LR schedulers must be constructed on the *inner* optimizer: torch's ``LRScheduler``
-    rejects anything failing ``isinstance(opt, torch.optim.Optimizer)``, which this wrapper
-    is not. Scheduling still works with no wrapper plumbing -- ``group["lr"]`` is the device
+  * The wrapper is a ``torch.optim.Optimizer`` subclass (so ``isinstance`` holds for
+    Lightning and torch's ``LRScheduler``) that delegates all state to the inner optimizer;
+    a scheduler may bind to either, since they share ``param_groups``. Scheduling works with
+    no wrapper plumbing -- ``group["lr"]`` is the device
     tensor the captured graph reads, and the scheduler (bound to the inner optimizer, which
     shares the same param_groups) fills it in place outside the graph, so every replay
     re-reads the live value. A *scheduled* LR takes effect under replay only through such an
@@ -55,12 +60,15 @@ Requirements / caveats:
     including under a real ``CosineAnnealingLR`` (``tests/test_cuda_graph.py``).
 """
 
-from typing import Optional
+import warnings
+from collections import OrderedDict
+from typing import Callable, Optional
+
 import torch
 
 
-class CudaGraphOptimizer:
-    def __init__(self, optimizer, warmup_steps: int = 10):
+class CudaGraphOptimizer(torch.optim.Optimizer):
+    def __init__(self, optimizer: torch.optim.Optimizer, warmup_steps: int = 10):
         if warmup_steps < 1:
             raise ValueError(
                 f"warmup_steps must be >= 1, got {warmup_steps}. Capture needs at least "
@@ -68,10 +76,23 @@ class CudaGraphOptimizer:
                 "and NCCL buffers; capturing the first step instead allocates them inside "
                 "the graph and fails deep in the backend."
             )
+        # We deliberately do NOT call Optimizer.__init__: it would build a second, empty
+        # param_groups/state on this object. Subclassing is only so isinstance(self,
+        # Optimizer) holds (Lightning, torch's LRScheduler); every Optimizer attribute
+        # delegates to the wrapped optimizer via the overrides below and __getattr__. We
+        # still create the hook registries Optimizer.__init__ would, since torch reads them
+        # on state_dict()/step().
         self.optimizer = optimizer
         self.warmup_steps = warmup_steps
         self._step_count = 0
         self._graph: Optional[torch.cuda.CUDAGraph] = None
+        self._warned_set_to_none = False
+        self._optimizer_step_pre_hooks = OrderedDict()
+        self._optimizer_step_post_hooks = OrderedDict()
+        self._optimizer_state_dict_pre_hooks = OrderedDict()
+        self._optimizer_state_dict_post_hooks = OrderedDict()
+        self._optimizer_load_state_dict_pre_hooks = OrderedDict()
+        self._optimizer_load_state_dict_post_hooks = OrderedDict()
 
     def __getattr__(self, name):
         # Delegate the rest of the Optimizer API (state, defaults, add_param_group, ...).
@@ -86,6 +107,17 @@ class CudaGraphOptimizer:
     def param_groups(self):
         return self.optimizer.param_groups
 
+    @param_groups.setter
+    def param_groups(self, value):
+        self.optimizer.param_groups = value
+
+    def add_param_group(self, param_group):
+        # torch.optim.Optimizer defines add_param_group, so (unlike state/defaults) it is
+        # found on the base class and __getattr__ never delegates it -- override explicitly.
+        # A new group is not in the captured graph; drop it so the next step re-captures.
+        self._graph = None
+        return self.optimizer.add_param_group(param_group)
+
     def state_dict(self):
         return self.optimizer.state_dict()
 
@@ -97,11 +129,14 @@ class CudaGraphOptimizer:
 
     def zero_grad(self, set_to_none: bool = False):
         # set_to_none=True would swap .grad for a fresh tensor each step, breaking the
-        # graph's pinned grad buffers. Force the stable-buffer path.
-        if set_to_none:
-            raise ValueError(
-                "CudaGraphOptimizer requires stable .grad buffers; call "
-                "zero_grad(set_to_none=False)."
+        # graph's pinned grad buffers. Force the stable-buffer path; a framework that
+        # defaults to True (e.g. Lightning) gets a one-time warning, not a hard failure.
+        if set_to_none and not self._warned_set_to_none:
+            self._warned_set_to_none = True
+            warnings.warn(
+                "CudaGraphOptimizer needs stable .grad buffers for graph replay; "
+                "ignoring set_to_none=True and zeroing in place.",
+                RuntimeWarning,
             )
         self.optimizer.zero_grad(set_to_none=False)
 
@@ -118,10 +153,16 @@ class CudaGraphOptimizer:
             self.optimizer.step()
         self._graph.replay()
 
-    def step(self):
+    def step(self, closure: Optional[Callable] = None):
+        # Automatic-optimization frameworks (Lightning) call step(closure); the closure runs
+        # forward+backward, filling the stable .grad buffers the capture reads. Run it eagerly
+        # first, then apply the captured update and return its loss. replay() launches on the
+        # current stream -- where the closure's backward ran -- so the update is ordered after
+        # the fresh gradients.
         # No LR plumbing here: the wrapped optimizer carries each group's LR as the device
         # tensor ``group["lr"]`` that the kernels read, and a scheduler fills it in place
         # outside the graph, so every replay already re-reads the live value.
+        loss = closure() if closure is not None else None
         if self._step_count < self.warmup_steps:
             self.optimizer.step()
         elif self._graph is None:
@@ -135,3 +176,4 @@ class CudaGraphOptimizer:
             if advance is not None:
                 advance()
         self._step_count += 1
+        return loss

--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -430,13 +430,13 @@ def dion2_update_megabatch_async(
 # path then the stacked 3D batched path), which the batched pre/post scatter loops
 # hit via torch._foreach_copy_ over the unstacked result.  Disable both passes
 # (each is only a fusion-quality heuristic, so turning it off is safe) for any
-# version we don't know to be fixed.  The guard parses a (major, minor) tuple
-# because a plain string compare mis-orders multi-digit minors ("2.9" > "2.13")
-# and treats "2.13.0+cuXXX" as >= "2.13".
+# version we don't know to be fixed.  torch.__version__ is a TorchVersion, whose
+# comparisons are semantic rather than lexicographic: "2.9.0" < "2.14" is True and
+# a local build "2.14.0+cuXXX" is not < "2.14".  A "2.14.0.dev" nightly still is
+# (pre-releases sort first), which errs on the side of keeping the workaround.
 # https://github.com/pytorch/pytorch/issues/176591
 # TODO: drop the decorator (and tighten the bound) once the fix lands upstream.
-_torch_major_minor = tuple(int(p) for p in torch.__version__.split("+")[0].split(".")[:2])
-if _torch_major_minor < (2, 14):
+if torch.__version__ < "2.14":
     # Guard each flag with hasattr: loop_index_inversion_in_fusion is newer than
     # loop_ordering_after_fusion, so an older torch in this range may not define it.
     _foreach_fusion_flags = {
@@ -515,7 +515,14 @@ def dion2_pre_orthogonalize(
     # torch.compile-safe.
     if num_select == 0:
         U_selected = [m.to(dtype=torch.bfloat16) for m in M]
-        indices_list = [torch.empty(0, dtype=torch.long, device=M[0].device) for _ in M]
+        # Shape the empty index tensors like the real ones: (*batch_dims, k) with
+        # k == 0, where batch_dims are M's leading dims (empty for a 2-D param, the
+        # head dim for a 3-D one). The batched post-orthogonalize stacks these and
+        # expands the result against U, so a flat (0,) index would be rank-short by
+        # one for every 3-D+ param and raise on the expand.
+        indices_list = [
+            torch.empty(*m.shape[:-2], 0, dtype=torch.long, device=m.device) for m in M
+        ]
         return U_selected, indices_list
 
     M_stacked = torch.stack(M, dim=0)
@@ -703,6 +710,13 @@ def dion2_post_orthogonalize(
     # matrix per step, a large share of the opt-step host dispatch). Selected indices are
     # unique per slice, so scatter_add is collision-free and this is bit-exact with the
     # per-tensor loop. scatter_add_ accumulates U into X at the selected positions.
+    #
+    # NOTE: batching trades memory traffic for kernel count. The per-matrix loop touched
+    # only the k selected slices of each param; this reads and rewrites the whole shape
+    # group (stack in, foreach_copy_ back). Measured on one H100 (bf16 params, compiled,
+    # no capture): 256x(1024,1024) f=1/4 2.41 -> 1.69 ms, but 128x(2048,2048) f=1/2
+    # 2.69 -> 3.60 ms. Folding the weight decay into the stack to save a pass was tried
+    # and is slower still (inductor does not fuse the multiply into the stack lowering).
     Xs = torch.stack(X, dim=0)
     # Cast U up to the param dtype BEFORE scaling, matching the per-tensor loop
     # (``u.to(dtype)`` then multiply). neg_lr is 0-dim, so in eager ``neg_lr * U``

--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -142,7 +142,7 @@ class Dion2(DistributedOrthoBase):
                 continue
 
             update_args = dict(
-                lr=self._group_lr_tensor(group),
+                lr=group["lr"],
                 ef_decay=torch.tensor(group["ef_decay"]),
                 fraction=group["fraction"],
                 weight_decay=torch.tensor(group["weight_decay"]),

--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -527,17 +527,15 @@ def dion2_pre_orthogonalize(
         )
         selected_stacked = torch.gather(M_stacked, dim=-1, index=indices_expanded)
 
-    # Apply error feedback decay to selected slices in the original M tensors.
-    # We reuse the already-gathered slices and write them back (scaled) using
-    # scatter_, which places values into positions specified by the index tensor.
+    # Apply error-feedback decay to the selected slices, batched over the whole shape
+    # group: one scatter into the stacked momentum plus a foreach copy-back, instead of
+    # one ``scatter_`` per matrix. The per-matrix loop was a large share of the opt-step
+    # host dispatch (~one scatter kernel per weight matrix per step); ``indices_expanded``
+    # already has the batched (N, k, cols)/(N, rows, k) shape, and the selected slices are
+    # unique per row/column, so this is bit-exact with the per-tensor loop.
+    M_stacked.scatter_(dim=select_dim, index=indices_expanded, src=selected_stacked * ef_decay)
+    torch._foreach_copy_(M, list(M_stacked.unbind(dim=0)))
     indices_list = list(indices.unbind(dim=0))
-    selected_list = list(selected_stacked.unbind(dim=0))
-    for m, idx, selected in zip(M, indices_list, selected_list):
-        if select_dim == -2:
-            idx_exp = idx.unsqueeze(-1).expand(*idx.shape, m.size(-1))
-        else:
-            idx_exp = idx.unsqueeze(-2).expand(*idx.shape[:-1], m.size(-2), idx.shape[-1])
-        m.scatter_(dim=select_dim, index=idx_exp, src=selected * ef_decay)
 
     # Convert to bf16 and unstack for communication
     U_selected = list(selected_stacked.to(dtype=torch.bfloat16).unbind(dim=0))
@@ -679,20 +677,22 @@ def dion2_post_orthogonalize(
 
     # Convert U to match parameter dtype
     dtype = X[0].dtype
-    U = [u.to(dtype=dtype) for u in U]
-    # Apply weight update
     neg_lr = -adjusted_lr
-    U_scaled = [neg_lr * u for u in U]
-    # Apply the orthogonalized update to only the selected rows/columns.
-    # scatter_add_ accumulates values into positions specified by the index tensor:
-    #   x[..., idx_exp[..., i, j], j] += u_scaled[..., i, j]  (for select_dim == -2)
-    # where i ranges over the k selected rows and j over all columns.
-    for x, u_scaled, idx in zip(X, U_scaled, indices):
-        if select_dim == -2:
-            idx_exp = idx.unsqueeze(-1).expand_as(u_scaled)
-        else:
-            idx_exp = idx.unsqueeze(-2).expand_as(u_scaled)
-        x.scatter_add_(dim=select_dim, index=idx_exp, src=u_scaled)
+    # Apply the orthogonalized update to the selected rows/columns, batched over the
+    # whole shape group: stack X/U/indices and do one scatter_add over the batch instead
+    # of one scatter_add_ per weight matrix (the per-matrix loop was ~one kernel per
+    # matrix per step, a large share of the opt-step host dispatch). Selected indices are
+    # unique per slice, so scatter_add is collision-free and this is bit-exact with the
+    # per-tensor loop. scatter_add_ accumulates U into X at the selected positions.
+    Xs = torch.stack(X, dim=0)
+    U_scaled = (neg_lr * torch.stack(U, dim=0)).to(dtype)
+    idx = torch.stack(indices, dim=0)
+    if select_dim == -2:
+        idx_exp = idx.unsqueeze(-1).expand_as(U_scaled)
+    else:
+        idx_exp = idx.unsqueeze(-2).expand_as(U_scaled)
+    Xs.scatter_add_(dim=select_dim, index=idx_exp, src=U_scaled)
+    torch._foreach_copy_(X, list(Xs.unbind(dim=0)))
 
 
 @torch.compile(fullgraph=True)

--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -142,7 +142,7 @@ class Dion2(DistributedOrthoBase):
                 continue
 
             update_args = dict(
-                lr=torch.tensor(group["lr"]),
+                lr=self._group_lr_tensor(group),
                 ef_decay=torch.tensor(group["ef_decay"]),
                 fraction=group["fraction"],
                 weight_decay=torch.tensor(group["weight_decay"]),

--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -419,17 +419,34 @@ def dion2_update_megabatch_async(
         )
 
 
-# Workaround for a torch.compile bug in PyTorch ≤2.11's inductor backend:
-# the post-fusion loop reordering pass crashes when ForeachKernelSchedulerNode
-# appears inside a FusedSchedulerNode.  Only triggered by recompilation across
-# different tensor dimensionalities (e.g. 2D then 3D).
+# Workaround for a torch.compile bug in the inductor backend: a post-fusion pass
+# crashes with
+#   AttributeError: 'ForeachKernelSchedulerNode' object has no attribute '_body'
+# when a ForeachKernelSchedulerNode appears inside a FusedSchedulerNode.  Two
+# passes reach into node._body (which a ForeachKernelSchedulerNode lacks), so the
+# crash surfaces from whichever runs on a given torch: loop_ordering_after_fusion
+# on <=2.11, loop_index_inversion_in_fusion on 2.13.  It is triggered by
+# recompilation across tensor dimensionalities (the empty-shard 2D early-return
+# path then the stacked 3D batched path), which the batched pre/post scatter loops
+# hit via torch._foreach_copy_ over the unstacked result.  Disable both passes
+# (each is only a fusion-quality heuristic, so turning it off is safe) for any
+# version we don't know to be fixed.  The guard parses a (major, minor) tuple
+# because a plain string compare mis-orders multi-digit minors ("2.9" > "2.13")
+# and treats "2.13.0+cuXXX" as >= "2.13".
 # https://github.com/pytorch/pytorch/issues/176591
-# TODO: remove this decorator when pytorch/pytorch#176591 is fixed.
-_inductor_workaround = (
-    torch._inductor.config.patch(loop_ordering_after_fusion=False)
-    if torch.__version__ < "2.13"
-    else lambda fn: fn
-)
+# TODO: drop the decorator (and tighten the bound) once the fix lands upstream.
+_torch_major_minor = tuple(int(p) for p in torch.__version__.split("+")[0].split(".")[:2])
+if _torch_major_minor < (2, 14):
+    # Guard each flag with hasattr: loop_index_inversion_in_fusion is newer than
+    # loop_ordering_after_fusion, so an older torch in this range may not define it.
+    _foreach_fusion_flags = {
+        _name: False
+        for _name in ("loop_ordering_after_fusion", "loop_index_inversion_in_fusion")
+        if hasattr(torch._inductor.config, _name)
+    }
+    _inductor_workaround = torch._inductor.config.patch(**_foreach_fusion_flags)
+else:
+    _inductor_workaround = lambda fn: fn
 
 
 @_inductor_workaround
@@ -655,9 +672,11 @@ def dion2_post_orthogonalize_masked(
         x.add_((neg_lr * u).to(dtype))
 
 
-# NOTE: if this function starts failing with an InductorError on recompilation
-# across tensor ranks, apply the same _inductor_workaround used on
-# dion2_pre_orthogonalize above.  See pytorch/pytorch#176591.
+# Carries the same _inductor_workaround as dion2_pre_orthogonalize: the batched
+# write-back stacks X to 3D and copies back via torch._foreach_copy_, so on the
+# empty-shard path it recompiles across tensor dimensionalities and hits the
+# ForeachKernelSchedulerNode fusion crash (pytorch/pytorch#176591) without it.
+@_inductor_workaround
 @torch.compile(fullgraph=True)
 def dion2_post_orthogonalize(
     X: List[Tensor],
@@ -685,7 +704,13 @@ def dion2_post_orthogonalize(
     # unique per slice, so scatter_add is collision-free and this is bit-exact with the
     # per-tensor loop. scatter_add_ accumulates U into X at the selected positions.
     Xs = torch.stack(X, dim=0)
-    U_scaled = (neg_lr * torch.stack(U, dim=0)).to(dtype)
+    # Cast U up to the param dtype BEFORE scaling, matching the per-tensor loop
+    # (``u.to(dtype)`` then multiply). neg_lr is 0-dim, so in eager ``neg_lr * U``
+    # keeps U's bf16 dtype -- a same-category 0-dim operand does not upcast a
+    # dimensioned tensor -- and rounds the update to bf16; casting only after the
+    # multiply then relies on inductor fusing the cast to recover fp32. Casting
+    # first keeps the scaling in fp32 in both eager and compiled paths.
+    U_scaled = neg_lr * torch.stack(U, dim=0).to(dtype)
     idx = torch.stack(indices, dim=0)
     if select_dim == -2:
         idx_exp = idx.unsqueeze(-1).expand_as(U_scaled)

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -18,6 +18,10 @@ from .polar_express import polar_express, polar_express_triton
 from .opt_utils import AsyncRuntime, AsyncTask, to_local
 from .scalar_opts import adamw_update_foreach_async, lion_update_foreach_async
 
+# Param-group key holding the group's device LR tensor. Runtime scratch, not a
+# hyperparameter: state_dict() strips it and _group_lr_tensor() rebuilds it on demand.
+_LR_TENSOR_KEY = "_lr_dev"
+
 
 class DistributedOrthoBase(Optimizer):
     """
@@ -191,6 +195,17 @@ class DistributedOrthoBase(Optimizer):
             state["momentum"] = torch.zeros_like(param)
             if algo == "adamw":
                 state["variance"] = torch.zeros_like(param)
+        if algo == "adamw" and "step_dev" not in state:
+            # Device step counter for the capturable fused AdamW. The step has to live
+            # on-device for bias correction to advance under CUDA-graph replay, where
+            # step()'s host-side group["step"] increment does not run. Always fp32: the
+            # fused kernel requires it, and a param-dtype (bf16) counter would stop
+            # incrementing at 256. Initialized here rather than lazily at first use so it
+            # is present in state_dict() from construction, keeping the key set complete
+            # and rank-symmetric for distributed checkpointing (see __init__).
+            state["step_dev"] = torch.zeros(
+                (), dtype=torch.float32, device=to_local(param).device
+            )
         return state
 
     def _resolve_num_heads(self, group: dict) -> Optional[int]:
@@ -400,19 +415,76 @@ class DistributedOrthoBase(Optimizer):
         and the captured ops re-read it on every replay. float32 matches the dtype of the
         former ``torch.tensor(group["lr"])`` (so the update is unchanged) and is the dtype
         the fused AdamW kernel's ``tensor_lr`` overload requires."""
-        t = group.get("_lr_dev")
-        if t is None:
-            device = to_local(group["params"][0]).device
+        device = to_local(group["params"][0]).device
+        t = group.get(_LR_TENSOR_KEY)
+        # Rebuild on a device/dtype mismatch as well as on absence: a tensor restored from
+        # a checkpoint written by an older build lands on whatever device torch.load used,
+        # and a CPU LR is read once at capture and baked into the graph.
+        if t is None or t.device != device or t.dtype != dtype:
             t = torch.empty((), dtype=dtype, device=device)
             t.fill_(group["lr"])
-            group["_lr_dev"] = t
+            group[_LR_TENSOR_KEY] = t
         return t
 
     def _refresh_lr_tensors(self):
         for group in self.param_groups:
-            t = group.get("_lr_dev")
+            t = group.get(_LR_TENSOR_KEY)
             if t is not None:
                 t.fill_(group["lr"])
+
+    def _advance_host_step_counters(self):
+        """Advance the host-side ``group["step"]`` counters for a step that ran as a CUDA
+        graph replay. ``step()``'s python increment only runs when ``step()`` is actually
+        traced, so under replay the counter would otherwise freeze at its capture value and
+        be written stale into every subsequent checkpoint."""
+        for group in self.param_groups:
+            group["step"] += 1
+
+    def state_dict(self):
+        sd = super().state_dict()
+        # param_groups is serialized hyperparameter state; the cached device LR tensor is
+        # runtime scratch rebuilt from group["lr"], so keep it out of the checkpoint.
+        # Leaving it in writes a CUDA tensor into every checkpoint, and load_state_dict()
+        # copies the saved group dict over the live one -- resurrecting the LR tensor on
+        # whatever device torch.load() used (CPU, for the usual map_location="cpu" resume).
+        # A CPU LR tensor still trains eagerly, so the damage is silent: it is read once at
+        # capture and baked in, freezing a scheduled LR under replay.
+        for group in sd["param_groups"]:
+            group.pop(_LR_TENSOR_KEY, None)
+        return sd
+
+    def load_state_dict(self, state_dict):
+        super().load_state_dict(state_dict)
+        for group in self.param_groups:
+            # Drop any LR tensor a checkpoint from an older build carried in; the next
+            # _group_lr_tensor() call rebuilds it from the restored python group["lr"].
+            group.pop(_LR_TENSOR_KEY, None)
+            if group["algorithm"] != "adamw":
+                continue
+            for param in group["params"]:
+                state = self.state.get(param)
+                if state is not None:
+                    self._restore_step_tensor(state, param, group)
+
+    def _restore_step_tensor(self, state: dict, param: Tensor, group: dict) -> None:
+        """Repair a loaded AdamW device step counter.
+
+        Two ways ``Optimizer.load_state_dict()`` leaves it wrong. It casts state tensors to
+        the owning param's dtype (its ``step`` special case keys off the literal name, which
+        this is not), and a bf16 counter silently stops incrementing at 256 -- 256 + 1 == 256
+        in bf16. And a checkpoint written before the counter moved on-device has no entry at
+        all; there the host-side ``group["step"]`` is the value to resume from, since
+        restarting at 0 would replay AdamW's bias-correction warmup and spike the effective
+        LR on the first steps after every resume.
+        """
+        step = state.get("step_dev")
+        device = to_local(param).device
+        if step is None:
+            step = torch.empty((), dtype=torch.float32, device=device)
+            step.fill_(float(group["step"]))
+        elif step.dtype != torch.float32 or step.device != device:
+            step = step.to(dtype=torch.float32, device=device)
+        state["step_dev"] = step
 
     def _create_ortho_tasks(
         self, param_groups: List[dict]
@@ -457,15 +529,7 @@ class DistributedOrthoBase(Optimizer):
             states = [self._get_or_initialize_state(p, "adamw") for p in params]
             momentums = [s["momentum"] for s in states]
             variances = [s["variance"] for s in states]
-            # Per-param device step tensors for the capturable fused AdamW: the kernel
-            # increments each on-device and bias-corrects from it, so the step is not a
-            # host value baked into a CUDA graph at capture (which would freeze the bias
-            # correction under replay). Persisted in optimizer state.
-            step_tensors = []
-            for s, p in zip(states, params):
-                if "step_dev" not in s:
-                    s["step_dev"] = torch.zeros((), dtype=torch.float32, device=to_local(p).device)
-                step_tensors.append(s["step_dev"])
+            step_tensors = [s["step_dev"] for s in states]
 
             yield AsyncTask(
                 adamw_update_foreach_async(

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -18,10 +18,6 @@ from .polar_express import polar_express, polar_express_triton
 from .opt_utils import AsyncRuntime, AsyncTask, to_local
 from .scalar_opts import adamw_update_foreach_async, lion_update_foreach_async
 
-# Param-group key holding the group's device LR tensor. Runtime scratch, not a
-# hyperparameter: state_dict() strips it and _group_lr_tensor() rebuilds it on demand.
-_LR_TENSOR_KEY = "_lr_dev"
-
 
 class DistributedOrthoBase(Optimizer):
     """
@@ -130,6 +126,7 @@ class DistributedOrthoBase(Optimizer):
         # the (possibly overridden) _get_or_initialize_state.
         self._state_prepopulated = False
         for group in self.param_groups:
+            self._ensure_lr_tensor(group)
             self._prepopulate_group_state(group)
         self._state_prepopulated = True
 
@@ -145,6 +142,7 @@ class DistributedOrthoBase(Optimizer):
         # add_param_group calls that Optimizer.__init__ makes before this class
         # finishes setup; the __init__ loop above pre-populates those groups.
         if getattr(self, "_state_prepopulated", False):
+            self._ensure_lr_tensor(self.param_groups[-1])
             self._prepopulate_group_state(self.param_groups[-1])
 
     @torch.no_grad()
@@ -155,12 +153,14 @@ class DistributedOrthoBase(Optimizer):
             with torch.enable_grad():
                 loss = closure()
 
-        # Push the (scheduler-updated) python LR into each group's persistent device LR
-        # tensor, so a CUDA-graph capture of this step reads a live LR under replay rather
-        # than baking the capture-time value. Skipped while capturing: the fill must stay
-        # OUTSIDE the graph, so CudaGraphOptimizer refreshes before each replay instead.
+        # The LR is carried as a device tensor the kernels read directly (see
+        # _ensure_lr_tensor); a scheduler updates it in place outside the graph and every
+        # replay re-reads the live value. Re-materialize it here in case a caller assigned a
+        # python float since the last step. Skipped while capturing -- it must not allocate
+        # inside the graph, and warmup has already made it a tensor by then.
         if not torch.cuda.is_current_stream_capturing():
-            self._refresh_lr_tensors()
+            for group in self.param_groups:
+                self._ensure_lr_tensor(group)
 
         ortho_groups = []
         lion_groups = []
@@ -407,30 +407,27 @@ class DistributedOrthoBase(Optimizer):
 
         return is_batch_sharded, is_matrix_sharded, sharded_tensor_dim
 
-    def _group_lr_tensor(self, group: dict, dtype: torch.dtype = torch.float32) -> Tensor:
-        """Persistent device LR tensor for a group. Passing the LR as a device tensor the
-        optimizer reads (rather than a python float / CPU scalar baked into the kernels)
-        is what lets ``CudaGraphOptimizer`` capture the step under a scheduled LR: the
-        value is refreshed in place each step by ``_refresh_lr_tensors`` outside the graph,
-        and the captured ops re-read it on every replay. float32 matches the dtype of the
-        former ``torch.tensor(group["lr"])`` (so the update is unchanged) and is the dtype
-        the fused AdamW kernel's ``tensor_lr`` overload requires."""
-        device = to_local(group["params"][0]).device
-        t = group.get(_LR_TENSOR_KEY)
-        # Rebuild on a device/dtype mismatch as well as on absence: a tensor restored from
-        # a checkpoint written by an older build lands on whatever device torch.load used,
-        # and a CPU LR is read once at capture and baked into the graph.
-        if t is None or t.device != device or t.dtype != dtype:
-            t = torch.empty((), dtype=dtype, device=device)
-            t.fill_(group["lr"])
-            group[_LR_TENSOR_KEY] = t
-        return t
+    def _ensure_lr_tensor(self, group: dict) -> Tensor:
+        """Make ``group["lr"]`` a persistent 0-d device float32 tensor and return it.
 
-    def _refresh_lr_tensors(self):
-        for group in self.param_groups:
-            t = group.get(_LR_TENSOR_KEY)
-            if t is not None:
-                t.fill_(group["lr"])
+        The LR is carried as a device tensor the kernels read directly, so a ``torch.optim``
+        LR scheduler -- which updates a tensor ``lr`` in place -- drives a captured step
+        natively: the scheduler fills this tensor outside the graph and every replay re-reads
+        it, with no refresh plumbing. This is a no-op once the tensor exists on the right
+        device (the steady state, including right after a scheduler ``fill_``), so it adds no
+        per-step host sync. It rebuilds the tensor when the value is a python float (fresh
+        construction, or a caller assigning ``group["lr"] = 0.05``) or a wrong-device/dtype
+        tensor (restored from a checkpoint via ``map_location="cpu"``). float32 is what the
+        former ``torch.tensor(group["lr"])`` produced and the dtype the fused AdamW
+        ``tensor_lr`` overload requires. Construct any LR scheduler AFTER the optimizer (and
+        after ``load_state_dict``) so it binds to this tensor; a scheduler holding an earlier
+        reference would fill a tensor the kernels no longer read."""
+        device = to_local(group["params"][0]).device
+        lr = group["lr"]
+        if isinstance(lr, Tensor) and lr.device == device and lr.dtype == torch.float32:
+            return lr
+        group["lr"] = torch.full((), float(lr), dtype=torch.float32, device=device)
+        return group["lr"]
 
     def _advance_host_step_counters(self):
         """Advance the host-side ``group["step"]`` counters for a step that ran as a CUDA
@@ -442,23 +439,26 @@ class DistributedOrthoBase(Optimizer):
 
     def state_dict(self):
         sd = super().state_dict()
-        # param_groups is serialized hyperparameter state; the cached device LR tensor is
-        # runtime scratch rebuilt from group["lr"], so keep it out of the checkpoint.
-        # Leaving it in writes a CUDA tensor into every checkpoint, and load_state_dict()
-        # copies the saved group dict over the live one -- resurrecting the LR tensor on
-        # whatever device torch.load() used (CPU, for the usual map_location="cpu" resume).
-        # A CPU LR tensor still trains eagerly, so the damage is silent: it is read once at
-        # capture and baked in, freezing a scheduled LR under replay.
+        # lr is carried at runtime as a device tensor; serialize it as a plain float so
+        # checkpoints stay portable (no device baggage, human-readable, matches pre-feature
+        # checkpoints), and load_state_dict() rebuilds the device tensor. Serializing the
+        # tensor instead would ride a CUDA tensor into every checkpoint and come back on
+        # whatever device torch.load() used -- a CPU LR that still trains eagerly but is read
+        # once at capture and baked in, silently freezing a scheduled LR under replay.
+        # super().state_dict() copies each group dict, so replacing "lr" here does not touch
+        # the live optimizer.
         for group in sd["param_groups"]:
-            group.pop(_LR_TENSOR_KEY, None)
+            lr = group.get("lr")
+            if isinstance(lr, Tensor):
+                group["lr"] = float(lr)
         return sd
 
     def load_state_dict(self, state_dict):
         super().load_state_dict(state_dict)
         for group in self.param_groups:
-            # Drop any LR tensor a checkpoint from an older build carried in; the next
-            # _group_lr_tensor() call rebuilds it from the restored python group["lr"].
-            group.pop(_LR_TENSOR_KEY, None)
+            # Rebuild the device LR tensor from the loaded value (a float from a normal
+            # checkpoint, or a wrong-device tensor from one written by an earlier build).
+            self._ensure_lr_tensor(group)
             if group["algorithm"] != "adamw":
                 continue
             for param in group["params"]:
@@ -509,7 +509,7 @@ class DistributedOrthoBase(Optimizer):
                     X=to_local(params),
                     G=to_local(gradients),
                     M=to_local(momentums),
-                    lr=self._group_lr_tensor(group),
+                    lr=group["lr"],
                     beta1=torch.tensor(group["beta1"]),
                     beta2=torch.tensor(group["beta2"]),
                     weight_decay=torch.tensor(group["weight_decay"]),
@@ -537,7 +537,7 @@ class DistributedOrthoBase(Optimizer):
                     G=to_local(gradients),
                     M=to_local(momentums),
                     V=to_local(variances),
-                    lr=self._group_lr_tensor(group, torch.float32),
+                    lr=group["lr"],
                     beta1=torch.tensor(group["beta1"]),
                     beta2=torch.tensor(group["beta2"]),
                     weight_decay=torch.tensor(group["weight_decay"]),

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -151,6 +151,13 @@ class DistributedOrthoBase(Optimizer):
             with torch.enable_grad():
                 loss = closure()
 
+        # Push the (scheduler-updated) python LR into each group's persistent device LR
+        # tensor, so a CUDA-graph capture of this step reads a live LR under replay rather
+        # than baking the capture-time value. Skipped while capturing: the fill must stay
+        # OUTSIDE the graph, so CudaGraphOptimizer refreshes before each replay instead.
+        if not torch.cuda.is_current_stream_capturing():
+            self._refresh_lr_tensors()
+
         ortho_groups = []
         lion_groups = []
         adamw_groups = []
@@ -385,6 +392,28 @@ class DistributedOrthoBase(Optimizer):
 
         return is_batch_sharded, is_matrix_sharded, sharded_tensor_dim
 
+    def _group_lr_tensor(self, group: dict, dtype: torch.dtype = torch.float32) -> Tensor:
+        """Persistent device LR tensor for a group. Passing the LR as a device tensor the
+        optimizer reads (rather than a python float / CPU scalar baked into the kernels)
+        is what lets ``CudaGraphOptimizer`` capture the step under a scheduled LR: the
+        value is refreshed in place each step by ``_refresh_lr_tensors`` outside the graph,
+        and the captured ops re-read it on every replay. float32 matches the dtype of the
+        former ``torch.tensor(group["lr"])`` (so the update is unchanged) and is the dtype
+        the fused AdamW kernel's ``tensor_lr`` overload requires."""
+        t = group.get("_lr_dev")
+        if t is None:
+            device = to_local(group["params"][0]).device
+            t = torch.empty((), dtype=dtype, device=device)
+            t.fill_(group["lr"])
+            group["_lr_dev"] = t
+        return t
+
+    def _refresh_lr_tensors(self):
+        for group in self.param_groups:
+            t = group.get("_lr_dev")
+            if t is not None:
+                t.fill_(group["lr"])
+
     def _create_ortho_tasks(
         self, param_groups: List[dict]
     ) -> Generator["AsyncTask", None, None]:
@@ -408,7 +437,7 @@ class DistributedOrthoBase(Optimizer):
                     X=to_local(params),
                     G=to_local(gradients),
                     M=to_local(momentums),
-                    lr=torch.tensor(group["lr"]),
+                    lr=self._group_lr_tensor(group),
                     beta1=torch.tensor(group["beta1"]),
                     beta2=torch.tensor(group["beta2"]),
                     weight_decay=torch.tensor(group["weight_decay"]),
@@ -428,6 +457,15 @@ class DistributedOrthoBase(Optimizer):
             states = [self._get_or_initialize_state(p, "adamw") for p in params]
             momentums = [s["momentum"] for s in states]
             variances = [s["variance"] for s in states]
+            # Per-param device step tensors for the capturable fused AdamW: the kernel
+            # increments each on-device and bias-corrects from it, so the step is not a
+            # host value baked into a CUDA graph at capture (which would freeze the bias
+            # correction under replay). Persisted in optimizer state.
+            step_tensors = []
+            for s, p in zip(states, params):
+                if "step_dev" not in s:
+                    s["step_dev"] = torch.zeros((), dtype=torch.float32, device=to_local(p).device)
+                step_tensors.append(s["step_dev"])
 
             yield AsyncTask(
                 adamw_update_foreach_async(
@@ -435,11 +473,11 @@ class DistributedOrthoBase(Optimizer):
                     G=to_local(gradients),
                     M=to_local(momentums),
                     V=to_local(variances),
-                    lr=torch.tensor(group["lr"]),
+                    lr=self._group_lr_tensor(group, torch.float32),
                     beta1=torch.tensor(group["beta1"]),
                     beta2=torch.tensor(group["beta2"]),
                     weight_decay=torch.tensor(group["weight_decay"]),
-                    step=torch.tensor(group["step"]),
+                    state_steps=step_tensors,
                     epsilon=torch.tensor(group["epsilon"]),
                     cautious_wd=group.get("cautious_wd", False),
                 )

--- a/dion/muon.py
+++ b/dion/muon.py
@@ -125,7 +125,7 @@ class Muon(DistributedOrthoBase):
                 continue
 
             update_args = dict(
-                lr=torch.tensor(group["lr"]),
+                lr=self._group_lr_tensor(group),
                 momentum=torch.tensor(group["mu"]),
                 weight_decay=torch.tensor(group["weight_decay"]),
                 epsilon=torch.tensor(group["epsilon"]),

--- a/dion/muon.py
+++ b/dion/muon.py
@@ -125,7 +125,7 @@ class Muon(DistributedOrthoBase):
                 continue
 
             update_args = dict(
-                lr=self._group_lr_tensor(group),
+                lr=group["lr"],
                 momentum=torch.tensor(group["mu"]),
                 weight_decay=torch.tensor(group["weight_decay"]),
                 epsilon=torch.tensor(group["epsilon"]),

--- a/dion/nordion2.py
+++ b/dion/nordion2.py
@@ -168,7 +168,7 @@ class NorDion2(DistributedOrthoBase):
                 continue
 
             update_args = dict(
-                lr=torch.tensor(group["lr"]),
+                lr=self._group_lr_tensor(group),
                 fraction=group["fraction"],
                 momentum=torch.tensor(group["mu"]),
                 muon_beta2=torch.tensor(group["muon_beta2"]),

--- a/dion/nordion2.py
+++ b/dion/nordion2.py
@@ -168,7 +168,7 @@ class NorDion2(DistributedOrthoBase):
                 continue
 
             update_args = dict(
-                lr=self._group_lr_tensor(group),
+                lr=group["lr"],
                 fraction=group["fraction"],
                 momentum=torch.tensor(group["mu"]),
                 muon_beta2=torch.tensor(group["muon_beta2"]),

--- a/dion/nordion2.py
+++ b/dion/nordion2.py
@@ -382,7 +382,7 @@ def nordion2_update_megabatch_async(
     U_stacked, V_stacked = nordion2_normalize_selected_stacked(
         U_stacked, V_stacked, indices, muon_beta2
     )
-    U_normed = [U_stacked[i] for i in range(N)]
+    U_normed = list(U_stacked.unbind(0))
     torch._foreach_copy_(V_local, list(V_stacked.unbind(0)))
 
     # Compute scaled learning rate

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -148,7 +148,7 @@ class NorMuon(DistributedOrthoBase):
                 continue
 
             update_args = dict(
-                lr=torch.tensor(group["lr"]),
+                lr=self._group_lr_tensor(group),
                 momentum=torch.tensor(group["mu"]),
                 muon_beta2=torch.tensor(group["muon_beta2"]),
                 weight_decay=torch.tensor(group["weight_decay"]),

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -148,7 +148,7 @@ class NorMuon(DistributedOrthoBase):
                 continue
 
             update_args = dict(
-                lr=self._group_lr_tensor(group),
+                lr=group["lr"],
                 momentum=torch.tensor(group["mu"]),
                 muon_beta2=torch.tensor(group["muon_beta2"]),
                 weight_decay=torch.tensor(group["weight_decay"]),

--- a/dion/scalar_opts.py
+++ b/dion/scalar_opts.py
@@ -1,6 +1,6 @@
 import torch
 from torch import Tensor
-from typing import Generator, List
+from typing import Generator, List, Optional
 
 
 @torch.compile(fullgraph=True)
@@ -127,15 +127,24 @@ def adamw_update_foreach(
     beta1: Tensor,  # Beta 1 (scalar tensor or float)
     beta2: Tensor,  # Beta 2 (scalar tensor or float)
     weight_decay: Tensor,  # Weight decay (scalar tensor or float)
-    step: int,
-    epsilon: float,
+    step: Optional[int] = None,  # legacy scalar step (baked; not CUDA-graph-capturable)
+    epsilon: float = 1e-8,
     cautious_wd: bool = False,
+    state_steps: Optional[List[Tensor]] = None,  # per-param device step tensors (capturable)
 ):
-    """AdamW update for a list of tensors.
+    """AdamW update for a list of tensors, dispatched through ``torch._fused_adamw_``
+    (a multi-tensor-apply kernel, avoiding the ~6-call ``torch._foreach_*`` chain that
+    otherwise dispatches one aten op per tensor on the CPU side).
 
-    Dispatches through ``torch._fused_adamw_``, which is already a
-    multi-tensor-apply kernel; avoids the ~6-call ``torch._foreach_*`` chain
-    that otherwise dispatches one aten op per tensor on the CPU side.
+    Two forms, selected by which step argument is given:
+
+    * **Legacy** (``step`` = python int): the bias-correction step is baked into a cached
+      0-d device tensor at call time, and ``lr`` is passed as a float. Simple, but NOT
+      CUDA-graph-capturable -- both freeze at the capture-time value under replay.
+    * **Capturable** (``state_steps`` = list of per-param device step tensors, and ``lr``
+      a device tensor): the step is incremented on-device and ``lr`` is read through the
+      fused kernel's ``tensor_lr`` overload, so both advance inside a CUDA graph. This is
+      the form ``megabatch_base`` passes so a wrapped step is graph-capturable.
 
     Cautious weight decay (https://arxiv.org/pdf/2510.12402) is applied as a
     post-step correction rather than inside the kernel:
@@ -152,7 +161,6 @@ def adamw_update_foreach(
     n = len(X)
     assert n == len(G) == len(M) == len(V)
 
-    lr_f = float(lr)
     beta1_f = float(beta1)
     beta2_f = float(beta2)
     wd_f = float(weight_decay)
@@ -162,27 +170,51 @@ def adamw_update_foreach(
     if do_cwd_correction:
         X_orig = [x.clone() for x in X]
 
-    # Cache the step scalar per device. ``torch.tensor(x, device="cuda")``
-    # from a Python float stages through pageable CPU memory and issues a
-    # blocking ``cudaMemcpy``, which defeats the point of going fused.
-    # ``fill_`` on a cached 0-d CUDA tensor is a kernel launch — async.
-    step_t = _get_step_tensor(X[0].device)
-    step_t.fill_(float(step))
-    torch._fused_adamw_(
-        X, G, M, V, [],
-        [step_t] * n,
-        amsgrad=False,
-        beta1=beta1_f, beta2=beta2_f,
-        lr=lr_f, weight_decay=wd_f, eps=eps_f,
-        maximize=False,
-    )
+    if state_steps is not None:
+        # Capturable form. ``state_steps`` are per-param device tensors we increment
+        # on-device here (``_fused_adamw_`` reads but does not increment them), so the
+        # bias-correction step advances inside a CUDA graph instead of freezing at capture.
+        # grad_scale/found_inf MUST be passed (as None) with a Tensor ``lr``: they select
+        # the capturable ``tensor_lr`` overload; omitting them resolves to a different
+        # overload that misreads the step. Mirrors torch.optim's fused path
+        # (torch/optim/adam.py::_fused_adam).
+        torch._foreach_add_(state_steps, 1)
+        torch._fused_adamw_(
+            X, G, M, V, [],
+            state_steps,
+            amsgrad=False,
+            beta1=beta1_f, beta2=beta2_f,
+            lr=lr, weight_decay=wd_f, eps=eps_f,
+            maximize=False,
+            grad_scale=None, found_inf=None,
+        )
+    else:
+        # Legacy form. Cache the step scalar per device: ``torch.tensor(x, device="cuda")``
+        # from a Python float stages through pageable CPU memory and issues a blocking
+        # ``cudaMemcpy``; ``fill_`` on a cached 0-d CUDA tensor is an async kernel launch.
+        lr_f = float(lr)
+        step_t = _get_step_tensor(X[0].device)
+        step_t.fill_(float(step))
+        torch._fused_adamw_(
+            X, G, M, V, [],
+            [step_t] * n,
+            amsgrad=False,
+            beta1=beta1_f, beta2=beta2_f,
+            lr=lr_f, weight_decay=wd_f, eps=eps_f,
+            maximize=False,
+        )
 
     if do_cwd_correction:
         # mask == 0  <=>  sign(M_new) * sign(X_orig) < 0  (over-decayed).
         signs = torch._foreach_mul(M, X_orig)
         undo_masks = [(s < 0).to(x.dtype) for s, x in zip(signs, X_orig)]
         correction = torch._foreach_mul(X_orig, undo_masks)
-        torch._foreach_mul_(correction, lr_f * wd_f)
+        if state_steps is not None:
+            # Keep the LR scaling on-device (float(lr) would host-sync and bake the value).
+            torch._foreach_mul_(correction, wd_f)
+            correction = [c * lr for c in correction]
+        else:
+            torch._foreach_mul_(correction, float(lr) * wd_f)
         torch._foreach_add_(X, correction)
 
 
@@ -248,12 +280,13 @@ def adamw_update_foreach_async(
     beta1: Tensor,
     beta2: Tensor,
     weight_decay: Tensor,
-    step: int,
-    epsilon: float,
+    step: Optional[int] = None,
+    epsilon: float = 1e-8,
     cautious_wd: bool = False,
+    state_steps: Optional[List[Tensor]] = None,
 ) -> Generator[None, None, None]:
     adamw_update_foreach(
-        X, G, M, V, lr, beta1, beta2, weight_decay, step, epsilon, cautious_wd
+        X, G, M, V, lr, beta1, beta2, weight_decay, step, epsilon, cautious_wd, state_steps
     )
     yield
 

--- a/dion/scalar_opts.py
+++ b/dion/scalar_opts.py
@@ -156,10 +156,21 @@ def adamw_update_foreach(
     where ``mask = (sign(M_new · X_orig) >= 0)``. We add back the decay that
     was over-applied on elements where momentum and param disagree in sign.
     """
+    if (step is None) == (state_steps is None):
+        raise ValueError(
+            "adamw_update_foreach takes exactly one of step (legacy, baked into the "
+            "kernel) or state_steps (device counters, CUDA-graph-capturable)."
+        )
+    if state_steps is not None and not isinstance(lr, Tensor):
+        raise TypeError(
+            "the capturable form requires lr as a device tensor; a python float is read "
+            "at capture time and baked into the graph, freezing a scheduled LR."
+        )
     if not X:
         return
     n = len(X)
     assert n == len(G) == len(M) == len(V)
+    assert state_steps is None or n == len(state_steps)
 
     beta1_f = float(beta1)
     beta2_f = float(beta2)
@@ -174,10 +185,10 @@ def adamw_update_foreach(
         # Capturable form. ``state_steps`` are per-param device tensors we increment
         # on-device here (``_fused_adamw_`` reads but does not increment them), so the
         # bias-correction step advances inside a CUDA graph instead of freezing at capture.
-        # grad_scale/found_inf MUST be passed (as None) with a Tensor ``lr``: they select
-        # the capturable ``tensor_lr`` overload; omitting them resolves to a different
-        # overload that misreads the step. Mirrors torch.optim's fused path
-        # (torch/optim/adam.py::_fused_adam).
+        # A Tensor ``lr`` selects the ``_fused_adamw_.tensor_lr`` overload, which reads the
+        # LR on-device; the float-lr overload bakes it in at capture. Mirrors torch.optim's
+        # fused path (torch/optim/adam.py::_fused_adam), including passing grad_scale and
+        # found_inf explicitly as None.
         torch._foreach_add_(state_steps, 1)
         torch._fused_adamw_(
             X, G, M, V, [],
@@ -210,10 +221,14 @@ def adamw_update_foreach(
         undo_masks = [(s < 0).to(x.dtype) for s, x in zip(signs, X_orig)]
         correction = torch._foreach_mul(X_orig, undo_masks)
         if state_steps is not None:
-            # Keep the LR scaling on-device (float(lr) would host-sync and bake the value).
+            # Keep the LR scaling on-device: float(lr) would host-sync and bake the value.
+            # _foreach_mul_ takes the 0-d tensor directly, so this stays one dispatch
+            # rather than one multiply (and one allocation) per param.
             torch._foreach_mul_(correction, wd_f)
-            correction = [c * lr for c in correction]
+            torch._foreach_mul_(correction, lr)
         else:
+            # Fold the scalars host-side, as before: (lr * wd) in one multiply is not
+            # bit-identical to scaling by wd then lr, and the legacy path must not move.
             torch._foreach_mul_(correction, float(lr) * wd_f)
         torch._foreach_add_(X, correction)
 

--- a/tests/test_cuda_graph.py
+++ b/tests/test_cuda_graph.py
@@ -11,6 +11,9 @@ check that the wrapper is numerically correct:
   tensor the optimizer reads and the wrapper refreshes before each replay -- rather than
   freezing at the capture-time value.
 """
+import io
+import os
+
 import pytest
 import torch
 
@@ -21,6 +24,7 @@ DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 pytestmark = pytest.mark.skipif(DEVICE == "cpu", reason="requires CUDA")
 
 STEPS, WARMUP, SEED = 12, 3, 0
+DIST_STEPS = 6
 OPTIMIZERS = [Muon, NorMuon, Dion2, NorDion2]
 
 
@@ -55,6 +59,23 @@ def _run(params, opt, grad_seq, step_fn, lrs=None):
             p.grad.copy_(g)
         step_fn()
     return [p.detach().clone() for p in params]
+
+
+def _roundtrip(opt):
+    # The ordinary resume idiom: checkpoint to disk, reload via CPU, load_state_dict.
+    buf = io.BytesIO()
+    torch.save(opt.state_dict(), buf)
+    buf.seek(0)
+    return torch.load(buf, map_location="cpu", weights_only=False)
+
+
+def _resumed(optimizer_cls, presteps=3):
+    params, opt = _build(optimizer_cls)
+    _run(params, opt, _grad_seq(params)[:presteps], opt.step)
+    sd = _roundtrip(opt)
+    params, opt = _build(optimizer_cls)
+    opt.load_state_dict(sd)
+    return params, opt
 
 
 @pytest.mark.parametrize("optimizer_cls", OPTIMIZERS)
@@ -102,3 +123,184 @@ def test_cudagraph_tracks_scheduled_lr(optimizer_cls):
         f"{optimizer_cls.__name__}: schedule looks frozen -- scheduled and constant runs "
         f"agree to {nontrivial:.3e}, so the test would pass even if the LR were baked"
     )
+
+
+@pytest.mark.parametrize("optimizer_cls", OPTIMIZERS)
+def test_scheduled_lr_tracks_after_resume(optimizer_cls):
+    # Same contract as test_cudagraph_tracks_scheduled_lr, but on an optimizer restored
+    # from a checkpoint -- the state every real run is in after the first resume.
+    # Regression: the device LR tensors were serialized into param_groups, so
+    # load_state_dict() overwrote the live ones with the checkpoint's copies, which land
+    # on CPU under the usual map_location="cpu". A CPU LR still trains correctly eagerly,
+    # so nothing raises; it is read once at capture and baked into the graph, silently
+    # freezing the schedule under replay.
+    p0, o0 = _build(optimizer_cls)
+    base = o0.param_groups[0]["lr"]
+    grad_seq = _grad_seq(p0)
+    sched = [base * (0.25 + 1.5 * (t + 1) / STEPS) for t in range(STEPS)]
+    const = [base] * STEPS
+
+    pe, oe = _resumed(optimizer_cls)
+    final_eager = _run(pe, oe, grad_seq, oe.step, lrs=sched)
+
+    pg, og = _resumed(optimizer_cls)
+    wrap = CudaGraphOptimizer(og, warmup_steps=WARMUP)
+    final_graph = _run(pg, og, grad_seq, wrap.step, lrs=sched)
+
+    pc, oc = _resumed(optimizer_cls)
+    wrapc = CudaGraphOptimizer(oc, warmup_steps=WARMUP)
+    final_const = _run(pc, oc, grad_seq, wrapc.step, lrs=const)
+
+    tracks = max((a - b).abs().max().item() for a, b in zip(final_eager, final_graph))
+    nontrivial = max((a - b).abs().max().item() for a, b in zip(final_graph, final_const))
+    assert tracks <= 1e-5, (
+        f"{optimizer_cls.__name__}: resumed graph did not track the schedule "
+        f"(diff {tracks:.3e})"
+    )
+    assert nontrivial > 1e-3, (
+        f"{optimizer_cls.__name__}: schedule looks frozen -- scheduled and constant runs "
+        f"agree to {nontrivial:.3e}, so the test would pass even if the LR were baked"
+    )
+
+
+def test_state_dict_carries_no_device_lr_tensor():
+    # param_groups is serialized hyperparameter state. A device tensor in there rides into
+    # every checkpoint and comes back as the wrong-device tensor on resume.
+    params, opt = _build(Dion2)
+    _run(params, opt, _grad_seq(params)[:1], opt.step)
+    groups = opt.state_dict()["param_groups"]
+    assert all("_lr_dev" not in g for g in groups)
+    # ...and the live optimizer still has one, i.e. it was stripped, not disabled.
+    assert any("_lr_dev" in g for g in opt.param_groups)
+
+
+def test_resume_from_checkpoint_without_step_tensor():
+    # A checkpoint written before the AdamW step moved on-device has no "step_dev" entry.
+    # The host-side group["step"] is what to resume from: starting over at 0 replays
+    # AdamW's bias-correction warmup, spiking the effective LR after every resume.
+    params, opt = _build(Dion2)
+    _run(params, opt, _grad_seq(params), opt.step)
+    sd = _roundtrip(opt)
+    for entry in sd["state"].values():
+        entry.pop("step_dev", None)  # what an older build wrote
+
+    _, opt2 = _build(Dion2)
+    opt2.load_state_dict(sd)
+    steps = [s["step_dev"].item() for s in opt2.state.values() if "step_dev" in s]
+    assert steps, "adamw params should carry a device step counter after load"
+    assert all(s == STEPS for s in steps), f"expected step {STEPS}, got {steps}"
+
+
+def test_step_tensor_survives_bf16_param_resume():
+    # load_state_dict() casts state tensors to the owning param's dtype (its "step" special
+    # case keys off the literal name, which this is not). A bf16 counter silently stops
+    # incrementing at 256, freezing bias correction for the rest of training.
+    torch.manual_seed(SEED)
+    biases = [torch.nn.Parameter(torch.randn(64, device=DEVICE, dtype=torch.bfloat16))]
+    opt = Dion2([{"params": biases, "algorithm": "adamw"}], distributed_mesh=None, lr=0.02)
+    for p in biases:
+        p.grad = torch.zeros_like(p)
+    opt.step()
+
+    sd = _roundtrip(opt)
+    biases2 = [torch.nn.Parameter(torch.randn(64, device=DEVICE, dtype=torch.bfloat16))]
+    opt2 = Dion2(
+        [{"params": biases2, "algorithm": "adamw"}], distributed_mesh=None, lr=0.02
+    )
+    opt2.load_state_dict(sd)
+
+    step = next(s["step_dev"] for s in opt2.state.values() if "step_dev" in s)
+    assert step.dtype == torch.float32, f"step counter cast to {step.dtype}"
+
+    # It must still count where bf16 cannot: 256 + 1 == 256 in bf16.
+    step.fill_(300)
+    for p in biases2:
+        p.grad = torch.zeros_like(p)
+    opt2.step()
+    assert step.item() == 301, f"step counter stuck at {step.item()}"
+
+
+def test_host_step_counter_advances_under_replay():
+    # step()'s python group["step"] += 1 only runs when step() is traced, so replay must
+    # advance it host-side or every later checkpoint records a stale step.
+    params, opt = _build(Dion2)
+    wrap = CudaGraphOptimizer(opt, warmup_steps=WARMUP)
+    _run(params, opt, _grad_seq(params), wrap.step)
+    assert all(g["step"] == STEPS for g in opt.param_groups), (
+        f"host step counters froze at {[g['step'] for g in opt.param_groups]}, expected {STEPS}"
+    )
+
+
+def test_warmup_steps_must_allow_an_eager_step():
+    _, opt = _build(Dion2)
+    with pytest.raises(ValueError, match="warmup_steps"):
+        CudaGraphOptimizer(opt, warmup_steps=0)
+
+
+# ---- distributed: capture must hold through the megabatch all-to-all (NCCL) ----
+# The single-GPU tests above run with distributed_mesh=None, which never reaches the
+# all-to-all -- yet collapsing that dispatch on a sharded step is the whole point of
+# capturing. This runs the real 2-rank sharded path, captured, against an eager run.
+
+
+def _dist_worker(rank, world_size, port, mode, out_path):
+    import torch.distributed as dist
+    from torch.distributed.tensor import DeviceMesh, Shard, distribute_tensor
+
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    wrap = step_fn = None
+    try:
+        dev = torch.device(f"cuda:{rank}")
+        mesh = DeviceMesh("cuda", list(range(world_size)))
+        gen = torch.Generator(device=dev).manual_seed(1234)
+        w0 = torch.randn(64, 128, generator=gen, device=dev)
+        param = torch.nn.Parameter(distribute_tensor(w0, mesh, [Shard(0)]))
+        param.grad = distribute_tensor(torch.zeros(64, 128, device=dev), mesh, [Shard(0)])
+
+        opt = NorDion2(
+            [dict(params=[param])], distributed_mesh=mesh, lr=0.1, newton_schulz_func=None
+        )
+        wrap = None if mode == "eager" else CudaGraphOptimizer(opt, warmup_steps=2)
+        step_fn = opt.step if wrap is None else wrap.step
+
+        # Shard the grads up front: distribute_tensor issues its own collectives, and
+        # interleaving those with replay measures the harness, not the optimizer.
+        grads = [
+            distribute_tensor(torch.randn(64, 128, generator=gen, device=dev), mesh, [Shard(0)])
+            for _ in range(DIST_STEPS)
+        ]
+        for t, g in enumerate(grads):
+            param.grad.copy_(g)
+            for group in opt.param_groups:
+                group["lr"] = 0.1 * (0.25 + t / DIST_STEPS)  # scheduled, must track
+            step_fn()
+        torch.cuda.synchronize()
+
+        # full_tensor() is itself a collective: every rank must call it, or the ranks that
+        # skip it run ahead to teardown and the ones that called it block forever.
+        full = param.detach().full_tensor()
+        if rank == 0:
+            torch.save(full.cpu(), out_path)
+    finally:
+        # Release the captured graph before tearing the process group down: it holds the
+        # captured NCCL ops, and destroy_process_group() blocks while they are alive.
+        step_fn = wrap = None
+        torch.cuda.synchronize()
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires 2 GPUs")
+def test_cudagraph_matches_eager_on_sharded_megabatch(tmp_path):
+    mp = torch.multiprocessing
+    out = {}
+    # Unique port per spawn to avoid bind collisions with the previous group.
+    for port, mode in ((29655, "eager"), (29656, "graph")):
+        path = tmp_path / f"{mode}.pt"
+        mp.spawn(_dist_worker, args=(2, port, mode, str(path)), nprocs=2, join=True)
+        out[mode] = torch.load(path, weights_only=False)
+
+    diff = (out["eager"] - out["graph"]).abs().max().item()
+    assert diff <= 1e-5, f"sharded capture-vs-eager diff {diff:.3e}"

--- a/tests/test_cuda_graph.py
+++ b/tests/test_cuda_graph.py
@@ -34,8 +34,12 @@ def _build(optimizer_cls):
                torch.nn.Parameter(torch.randn(128, 64, device=DEVICE))]
     biases = [torch.nn.Parameter(torch.randn(64, device=DEVICE)),
               torch.nn.Parameter(torch.randn(128, device=DEVICE))]
+    # Pin fraction < 1 for the filtered optimizers rather than leaning on the class
+    # default: filtering is what puts the selection/scatter path in the captured
+    # region, so a default change to 1.0 would silently drop that coverage.
+    filtered = {"fraction": 0.25} if optimizer_cls in (Dion2, NorDion2) else {}
     opt = optimizer_cls([
-        {"params": weights},
+        {"params": weights, **filtered},
         {"params": biases, "algorithm": "adamw"},
     ], distributed_mesh=None, lr=0.02)
     return weights + biases, opt

--- a/tests/test_cuda_graph.py
+++ b/tests/test_cuda_graph.py
@@ -1,0 +1,104 @@
+"""CUDA-graph capture of the optimizer step (``dion.cuda_graph.CudaGraphOptimizer``).
+
+The megabatched Muon/NorMuon/Dion2/NorDion2 step is a fixed-shape computation (top-k
+selection changes which rows are chosen, not the shapes), so capturing it once and
+replaying collapses the per-matrix host dispatch to a single graph launch. These tests
+check that the wrapper is numerically correct:
+
+- capture+replay matches running the bare optimizer eagerly, step for step, for the
+  matrix (Muon/NorMuon/Dion2/NorDion2) path and the AdamW scalar path together; and
+- a per-step LR schedule takes effect under replay -- the LR is carried as a device
+  tensor the optimizer reads and the wrapper refreshes before each replay -- rather than
+  freezing at the capture-time value.
+"""
+import pytest
+import torch
+
+from dion import Dion2, Muon, NorDion2, NorMuon
+from dion.cuda_graph import CudaGraphOptimizer
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+pytestmark = pytest.mark.skipif(DEVICE == "cpu", reason="requires CUDA")
+
+STEPS, WARMUP, SEED = 12, 3, 0
+OPTIMIZERS = [Muon, NorMuon, Dion2, NorDion2]
+
+
+def _build(optimizer_cls):
+    torch.manual_seed(SEED)
+    weights = [torch.nn.Parameter(torch.randn(64, 128, device=DEVICE)),
+               torch.nn.Parameter(torch.randn(128, 64, device=DEVICE))]
+    biases = [torch.nn.Parameter(torch.randn(64, device=DEVICE)),
+              torch.nn.Parameter(torch.randn(128, device=DEVICE))]
+    opt = optimizer_cls([
+        {"params": weights},
+        {"params": biases, "algorithm": "adamw"},
+    ], distributed_mesh=None, lr=0.02)
+    return weights + biases, opt
+
+
+def _grad_seq(params):
+    gen = torch.Generator(device=DEVICE).manual_seed(7)
+    return [[torch.randn(p.shape, device=DEVICE, generator=gen) for p in params]
+            for _ in range(STEPS)]
+
+
+def _run(params, opt, grad_seq, step_fn, lrs=None):
+    # Stable .grad buffers (the graph pins them); refill in place, never reallocate.
+    for p in params:
+        p.grad = torch.zeros_like(p)
+    for t, gs in enumerate(grad_seq):
+        if lrs is not None:
+            for g in opt.param_groups:
+                g["lr"] = lrs[t]
+        for p, g in zip(params, gs):
+            p.grad.copy_(g)
+        step_fn()
+    return [p.detach().clone() for p in params]
+
+
+@pytest.mark.parametrize("optimizer_cls", OPTIMIZERS)
+def test_cudagraph_matches_eager(optimizer_cls):
+    p0, _ = _build(optimizer_cls)
+    grad_seq = _grad_seq(p0)
+
+    pe, oe = _build(optimizer_cls)
+    final_eager = _run(pe, oe, grad_seq, oe.step)
+
+    pg, og = _build(optimizer_cls)
+    wrap = CudaGraphOptimizer(og, warmup_steps=WARMUP)
+    final_graph = _run(pg, og, grad_seq, wrap.step)
+
+    diff = max((a - b).abs().max().item() for a, b in zip(final_eager, final_graph))
+    assert diff <= 1e-5, f"{optimizer_cls.__name__}: capture-vs-eager diff {diff:.3e}"
+
+
+@pytest.mark.parametrize("optimizer_cls", OPTIMIZERS)
+def test_cudagraph_tracks_scheduled_lr(optimizer_cls):
+    p0, o0 = _build(optimizer_cls)
+    base = o0.param_groups[0]["lr"]
+    grad_seq = _grad_seq(p0)
+    # A schedule that varies ~8x across the run (warmup then decay).
+    sched = [base * (0.25 + 1.5 * (t + 1) / STEPS) for t in range(STEPS)]
+    const = [base] * STEPS
+
+    pe, oe = _build(optimizer_cls)
+    final_eager = _run(pe, oe, grad_seq, oe.step, lrs=sched)
+
+    pg, og = _build(optimizer_cls)
+    wrap = CudaGraphOptimizer(og, warmup_steps=WARMUP)
+    final_graph = _run(pg, og, grad_seq, wrap.step, lrs=sched)
+
+    pc, oc = _build(optimizer_cls)
+    wrapc = CudaGraphOptimizer(oc, warmup_steps=WARMUP)
+    final_const = _run(pc, oc, grad_seq, wrapc.step, lrs=const)
+
+    tracks = max((a - b).abs().max().item() for a, b in zip(final_eager, final_graph))
+    nontrivial = max((a - b).abs().max().item() for a, b in zip(final_graph, final_const))
+    assert tracks <= 1e-5, (
+        f"{optimizer_cls.__name__}: graph did not track the schedule (diff {tracks:.3e})"
+    )
+    assert nontrivial > 1e-3, (
+        f"{optimizer_cls.__name__}: schedule looks frozen -- scheduled and constant runs "
+        f"agree to {nontrivial:.3e}, so the test would pass even if the LR were baked"
+    )

--- a/tests/test_cuda_graph.py
+++ b/tests/test_cuda_graph.py
@@ -53,8 +53,11 @@ def _run(params, opt, grad_seq, step_fn, lrs=None):
         p.grad = torch.zeros_like(p)
     for t, gs in enumerate(grad_seq):
         if lrs is not None:
+            # Update the LR *in place*, the way a torch LR scheduler does. group["lr"] is
+            # the device tensor the kernels read; reassigning a python float would swap the
+            # object out and leave the captured graph reading the stale one under replay.
             for g in opt.param_groups:
-                g["lr"] = lrs[t]
+                g["lr"].fill_(lrs[t])
         for p, g in zip(params, gs):
             p.grad.copy_(g)
         step_fn()
@@ -163,15 +166,62 @@ def test_scheduled_lr_tracks_after_resume(optimizer_cls):
     )
 
 
-def test_state_dict_carries_no_device_lr_tensor():
-    # param_groups is serialized hyperparameter state. A device tensor in there rides into
-    # every checkpoint and comes back as the wrong-device tensor on resume.
+def test_lr_is_device_tensor_but_checkpoints_as_float():
+    # Runtime: group["lr"] is the 0-d device fp32 tensor the kernels read (and a scheduler
+    # fills in place). Checkpoint: serialized as a plain float, so it stays portable and
+    # does not ride a CUDA tensor back onto the wrong device on resume.
     params, opt = _build(Dion2)
     _run(params, opt, _grad_seq(params)[:1], opt.step)
-    groups = opt.state_dict()["param_groups"]
-    assert all("_lr_dev" not in g for g in groups)
-    # ...and the live optimizer still has one, i.e. it was stripped, not disabled.
-    assert any("_lr_dev" in g for g in opt.param_groups)
+
+    for g in opt.param_groups:
+        lr = g["lr"]
+        assert torch.is_tensor(lr) and lr.is_cuda and lr.dtype == torch.float32 and lr.ndim == 0
+
+    for g in opt.state_dict()["param_groups"]:
+        assert type(g["lr"]) is float
+
+
+@pytest.mark.parametrize("optimizer_cls", OPTIMIZERS)
+def test_real_lr_scheduler_drives_captured_step(optimizer_cls):
+    # The elegance payoff: a stock torch LR scheduler on the inner optimizer drives the
+    # captured step with no wrapper LR plumbing, because it fills group["lr"] -- the exact
+    # device tensor the graph reads -- in place. Eager and captured runs must agree, and the
+    # captured run must actually move with the schedule (not freeze at the capture value).
+    grad_seq = _grad_seq(_build(optimizer_cls)[0])
+
+    def run(step_wrapped):
+        params, opt = _build(optimizer_cls)
+        # T_max small vs STEPS so the cosine sweeps a wide LR range across the run.
+        sched = torch.optim.lr_scheduler.CosineAnnealingLR(opt, T_max=4, eta_min=1e-4)
+        step = CudaGraphOptimizer(opt, warmup_steps=WARMUP).step if step_wrapped else opt.step
+        for p in params:
+            p.grad = torch.zeros_like(p)
+        for gs in grad_seq:
+            for p, g in zip(params, gs):
+                p.grad.copy_(g)
+            step()
+            sched.step()
+        return [p.detach().clone() for p in params]
+
+    final_eager = run(step_wrapped=False)
+    final_graph = run(step_wrapped=True)
+    diff = max((a - b).abs().max().item() for a, b in zip(final_eager, final_graph))
+    assert diff <= 1e-5, f"{optimizer_cls.__name__}: scheduled capture-vs-eager diff {diff:.3e}"
+
+    # Guard against a frozen LR: rerun the graph at a constant LR and require it to differ.
+    params, opt = _build(optimizer_cls)
+    for p in params:
+        p.grad = torch.zeros_like(p)
+    wrap = CudaGraphOptimizer(opt, warmup_steps=WARMUP)
+    for gs in grad_seq:
+        for p, g in zip(params, gs):
+            p.grad.copy_(g)
+        wrap.step()
+    frozen = max((a - b).abs().max().item() for a, b in zip(final_graph, params))
+    assert frozen > 1e-3, (
+        f"{optimizer_cls.__name__}: scheduled and constant-LR captured runs agree to "
+        f"{frozen:.3e} -- the schedule looks frozen under replay"
+    )
 
 
 def test_resume_from_checkpoint_without_step_tensor():
@@ -275,7 +325,10 @@ def _dist_worker(rank, world_size, port, mode, out_path):
         for t, g in enumerate(grads):
             param.grad.copy_(g)
             for group in opt.param_groups:
-                group["lr"] = 0.1 * (0.25 + t / DIST_STEPS)  # scheduled, must track
+                # In place (as a scheduler does): group["lr"] is the device tensor the
+                # captured graph reads; reassigning a float would leave replay on the stale
+                # tensor.
+                group["lr"].fill_(0.1 * (0.25 + t / DIST_STEPS))  # scheduled, must track
             step_fn()
         torch.cuda.synchronize()
 

--- a/tests/test_cuda_graph.py
+++ b/tests/test_cuda_graph.py
@@ -91,6 +91,10 @@ def test_cudagraph_matches_eager(optimizer_cls):
 
     pg, og = _build(optimizer_cls)
     wrap = CudaGraphOptimizer(og, warmup_steps=WARMUP)
+    # A framework (Lightning) both isinstance-checks the optimizer and reads its groups
+    # through the wrapper; the wrapper is-a Optimizer and shares the wrapped groups/state.
+    assert isinstance(wrap, torch.optim.Optimizer)
+    assert wrap.param_groups is og.param_groups and wrap.state is og.state
     final_graph = _run(pg, og, grad_seq, wrap.step)
 
     diff = max((a - b).abs().max().item() for a, b in zip(final_eager, final_graph))
@@ -357,3 +361,32 @@ def test_cudagraph_matches_eager_on_sharded_megabatch(tmp_path):
 
     diff = (out["eager"] - out["graph"]).abs().max().item()
     assert diff <= 1e-5, f"sharded capture-vs-eager diff {diff:.3e}"
+
+
+@pytest.mark.parametrize("optimizer_cls", OPTIMIZERS)
+def test_cudagraph_step_with_closure(optimizer_cls):
+    # Lightning's automatic optimization calls step(closure); the closure runs
+    # forward+backward (here it fills .grad in place) and returns the loss. The wrapped
+    # step must run the closure, apply the captured update, and hand back the loss.
+    p0, _ = _build(optimizer_cls)
+    grad_seq = _grad_seq(p0)
+
+    pe, oe = _build(optimizer_cls)
+    final_eager = _run(pe, oe, grad_seq, oe.step)
+
+    pg, og = _build(optimizer_cls)
+    wrap = CudaGraphOptimizer(og, warmup_steps=WARMUP)
+    for p in pg:
+        p.grad = torch.zeros_like(p)
+    losses = []
+    for gs in grad_seq:
+        def closure(gs=gs):
+            for p, g in zip(pg, gs):
+                p.grad.copy_(g)
+            return torch.full((), 0.5, device=DEVICE)
+        losses.append(wrap.step(closure))
+    final_graph = [p.detach().clone() for p in pg]
+
+    diff = max((a - b).abs().max().item() for a, b in zip(final_eager, final_graph))
+    assert diff <= 1e-5, f"{optimizer_cls.__name__}: closure step-vs-eager diff {diff:.3e}"
+    assert all(l is not None for l in losses)

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -314,6 +314,54 @@ class TestDion2:
         params = _make_params([(64, 128)] * 5)
         _run_steps(Dion2, params, dict(lr=0.01))
 
+    def test_post_orthogonalize_batched_matches_per_matrix(self):
+        """The batched write-back must be bit-exact with the per-matrix scatter_add
+        for fp32 params and a bf16 update -- the PR's core bit-exactness claim.
+
+        The existing determinism tests only compare the batched path against itself
+        (same seed), so nothing pins the batched compiled path to an independent
+        per-matrix fp32 reference. This does, across both select_dim orientations.
+        """
+        from dion.dion2 import dion2_post_orthogonalize
+
+        for select_dim in (-2, -1):
+            torch.manual_seed(7)
+            n, rows, cols, k = 5, 16, 12, 3
+            X0 = [
+                torch.randn(rows, cols, dtype=torch.float32, device=DEVICE)
+                for _ in range(n)
+            ]
+            if select_dim == -2:
+                U = [torch.randn(k, cols, dtype=torch.bfloat16, device=DEVICE) for _ in range(n)]
+                norm_len = rows
+            else:
+                U = [torch.randn(rows, k, dtype=torch.bfloat16, device=DEVICE) for _ in range(n)]
+                norm_len = cols
+            indices = [torch.randperm(norm_len, device=DEVICE)[:k] for _ in range(n)]
+            base_lr = torch.tensor(0.01, dtype=torch.float32, device=DEVICE)
+            adjusted_lr = torch.tensor(0.003, dtype=torch.float32, device=DEVICE)
+            weight_decay = torch.tensor(0.1, dtype=torch.float32, device=DEVICE)
+
+            # Per-matrix reference: weight decay, then cast U to the param dtype
+            # BEFORE scaling so the multiply runs in fp32.
+            X_ref = [x.clone() for x in X0]
+            torch._foreach_mul_(X_ref, 1 - base_lr * weight_decay)
+            neg_lr = -adjusted_lr
+            for x, u, idx in zip(X_ref, U, indices):
+                u_scaled = neg_lr * u.to(x.dtype)
+                if select_dim == -2:
+                    idx_exp = idx.unsqueeze(-1).expand_as(u_scaled)
+                else:
+                    idx_exp = idx.unsqueeze(-2).expand_as(u_scaled)
+                x.scatter_add_(dim=select_dim, index=idx_exp, src=u_scaled)
+
+            X_test = [x.clone() for x in X0]
+            dion2_post_orthogonalize(
+                X_test, U, indices, base_lr, adjusted_lr, weight_decay, select_dim
+            )
+            for xt, xr in zip(X_test, X_ref):
+                assert torch.equal(xt, xr)
+
     def test_select_dim_rows_vs_cols(self):
         """Tall matrices select columns, wide select rows."""
         from dion import Dion2

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -9,6 +9,7 @@ Tests cover:
 - Step timing: optimizer step takes measurable wall-clock time
 """
 
+import math
 import os
 import pytest
 import time
@@ -361,6 +362,76 @@ class TestDion2:
             )
             for xt, xr in zip(X_test, X_ref):
                 assert torch.equal(xt, xr)
+
+    def test_pre_orthogonalize_batched_ef_decay_matches_per_matrix(self):
+        """The batched error-feedback scatter must be bit-exact with the per-matrix
+        one, the other half of the PR's bit-exactness claim.
+
+        Only the post-orthogonalize write-back had a reference test; the momentum
+        decay is a separate scatter (into the stacked momentum, then copied back)
+        with its own index-expansion logic per select_dim.
+        """
+        from dion.dion2 import dion2_pre_orthogonalize
+
+        for select_dim in (-2, -1):
+            torch.manual_seed(11)
+            n, rows, cols, fraction = 5, 16, 12, 0.25
+            M0 = [torch.randn(rows, cols, device=DEVICE) for _ in range(n)]
+            G = [torch.randn(rows, cols, device=DEVICE) for _ in range(n)]
+            ef_decay = torch.tensor(0.9, dtype=torch.float32, device=DEVICE)
+
+            # Per-matrix reference, mirroring the loop the batched scatter replaced.
+            M_ref = [m.clone() for m in M0]
+            torch._foreach_add_(M_ref, G)
+            norm_dim = -1 if select_dim == -2 else -2
+            num_select = M_ref[0].size(select_dim)
+            k = max(1, int(math.ceil(fraction * num_select)))
+            U_ref = []
+            for m in M_ref:
+                _, idx = torch.topk(m.norm(p=1, dim=norm_dim), k, dim=-1, sorted=False)
+                if select_dim == -2:
+                    idx_exp = idx.unsqueeze(-1).expand(*idx.shape, m.size(-1))
+                else:
+                    idx_exp = idx.unsqueeze(-2).expand(*idx.shape[:-1], m.size(-2), k)
+                selected = torch.gather(m, dim=select_dim, index=idx_exp)
+                U_ref.append(selected.to(torch.bfloat16))
+                m.scatter_(dim=select_dim, index=idx_exp, src=selected * ef_decay)
+
+            M_test = [m.clone() for m in M0]
+            U_test, _ = dion2_pre_orthogonalize(
+                G, M_test, fraction, ef_decay, select_dim
+            )
+            for mt, mr in zip(M_test, M_ref):
+                assert torch.equal(mt, mr)
+            for ut, ur in zip(U_test, U_ref):
+                assert torch.equal(ut, ur)
+
+    def test_empty_shard_indices_keep_batch_dims_for_3d_params(self):
+        """An empty local shard of a 3D+ param must produce (*batch, 0) indices.
+
+        The batched post-orthogonalize stacks the index tensors and expands the
+        result against U, so a flat (0,) index -- correct only for 2D params -- is
+        rank-short by one for a 3D param and raises on the expand. The per-matrix
+        loop it replaced tolerated the short rank by accident, so nothing else
+        covers this combination.
+        """
+        from dion.dion2 import dion2_pre_orthogonalize, dion2_post_orthogonalize
+
+        n, heads, cols = 3, 4, 16
+        # Row-sharded 3D param whose local shard has zero rows (world_size > rows).
+        M = [torch.randn(heads, 0, cols, device=DEVICE) for _ in range(n)]
+        G = [torch.randn(heads, 0, cols, device=DEVICE) for _ in range(n)]
+        X = [torch.randn(heads, 0, cols, device=DEVICE) for _ in range(n)]
+        ef_decay = torch.tensor(0.9, dtype=torch.float32, device=DEVICE)
+
+        U, indices = dion2_pre_orthogonalize(G, M, 0.25, ef_decay, -2)
+        assert all(idx.shape == (heads, 0) for idx in indices), (
+            f"expected (heads, 0) index tensors, got {[tuple(i.shape) for i in indices]}"
+        )
+
+        lr = torch.tensor(0.01, dtype=torch.float32, device=DEVICE)
+        wd = torch.tensor(0.0, dtype=torch.float32, device=DEVICE)
+        dion2_post_orthogonalize(X, U, indices, lr, lr, wd, -2)
 
     def test_select_dim_rows_vs_cols(self):
         """Tall matrices select columns, wide select rows."""


### PR DESCRIPTION
Supersedes #105 (its head branch was rebased onto #104, so GitHub would not let it reopen). **Stacked on #104** (`jcl/cudagraph-capturable-optstep`): this branch contains #104's commits too, so the reviewable diff for *this* PR is the two scatter-batching commits on top — review #104 first.

## What

Batch the Dion2/NorDion2 megabatch per-matrix `scatter_` / `scatter_add_` loops into a single scatter over the stacked shape-group (bit-exact host reduction).

## Why this is required for CUDA-graph capture (not just perf)

Benchmarking #104's capture path on the real architecture showed the per-matrix scatter loop **cannot be CUDA-graph-captured**. With #104 alone, every filtered Dion2/NorDion2 configuration (`f = 1/2`, `1/4`) aborts capture with `CUDA error: operation failed due to a previous error during capture`, at every scale (1B–14B), single-device and 8-GPU sharded alike; unfiltered configurations capture fine. The hundreds of small per-matrix scatter kernels + temporaries the loop feeds into one capture are what fail; the batched scatter is graph-safe.

Filtering is the configuration we train with, so capturing it is the point — #104 + this PR together are the shipping path. The ~4.7% GPU cost is on the filtered compute and is dwarfed by capture's host savings (the filtered step drops ~6× at 1B once capturable). A filtered-capture regression test is included so this stays covered.
