### PR TITLE
cuda_graph: release(), refuse capture with grad-less params, and a live weight decay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ All notable changes to this project are documented in this file.
   holds the captured megabatch all-to-all, and `dist.destroy_process_group()` blocks
   while those NCCL ops are alive, so a framework that keeps optimizers alive past the
   end of training otherwise hangs at process exit. Previously the only ways to drop a
-  graph were `add_param_group` / `load_state_dict`, both with side effects.
+  graph were `add_param_group` / `load_state_dict`, both with side effects. Those two
+  now route through `release()` as well, so they also synchronize and destroy the
+  graph rather than dropping a reference and leaving the NCCL ops to a refcount.
 
 - A per-group `weight_decay` supplied as a Tensor (`weight_decay=torch.tensor(0.01)`)
   is carried as a persistent device tensor like the learning rate, so filling it in
@@ -21,9 +23,18 @@ All notable changes to this project are documented in this file.
   Opt-in via the Tensor: on the AdamW scalar path a live weight decay cannot ride
   `torch._fused_adamw_`, whose `weight_decay` is a float in every overload, so it is
   applied as a separate pass and rounds `X` once more. A float `weight_decay` keeps
-  the previous fused path unchanged.
+  the previous fused path unchanged. The opt-in latches, so it also works when the
+  Tensor is assigned to the group after construction, and a later float assignment
+  refills the tensor instead of dropping the group back to a baked value. Opting in
+  after the graph exists is too late to honor, and `CudaGraphOptimizer` raises instead
+  of letting the schedule silently do nothing.
 
 ### Fixed
+
+- `adamw_update_foreach` dropped the cautious-weight-decay correction entirely when it
+  was given a device-tensor `weight_decay` on the legacy (`step=`) path: the kernel is
+  handed `weight_decay=0` there, and the correction was scaled by that float, so
+  `cautious_wd=True` silently degraded to plain weight decay.
 
 - CUDA-graph capture now refuses to run while any `requires_grad` parameter still has
   `.grad=None`. The step only touches parameters with a gradient, so capture freezes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `CudaGraphOptimizer.release()` drops the captured graph (and restarts the warmup,
+  so a later capture is not taken with cold buffers). On the sharded path the graph
+  holds the captured megabatch all-to-all, and `dist.destroy_process_group()` blocks
+  while those NCCL ops are alive, so a framework that keeps optimizers alive past the
+  end of training otherwise hangs at process exit. Previously the only ways to drop a
+  graph were `add_param_group` / `load_state_dict`, both with side effects.
+
+- A per-group `weight_decay` supplied as a Tensor (`weight_decay=torch.tensor(0.01)`)
+  is carried as a persistent device tensor like the learning rate, so filling it in
+  place drives a CUDA-graph-captured step. This makes schedule-coupled weight decay
+  (Defazio 2506.02285, AdamC / Muon-C), which rescales `weight_decay` every step,
+  usable under capture — previously it was silently frozen at its capture-step value.
+  Opt-in via the Tensor: on the AdamW scalar path a live weight decay cannot ride
+  `torch._fused_adamw_`, whose `weight_decay` is a float in every overload, so it is
+  applied as a separate pass and rounds `X` once more. A float `weight_decay` keeps
+  the previous fused path unchanged.
+
+### Fixed
+
+- CUDA-graph capture now refuses to run while any `requires_grad` parameter still has
+  `.grad=None`. The step only touches parameters with a gradient, so capture freezes
+  the participating set: a parameter starved of gradients through the warmup steps (a
+  modality cadence that runs text-only batches, expert routing that skips an expert)
+  was left out of the graph and silently stopped being updated for the rest of the
+  run. Freeze such parameters explicitly with `requires_grad=False`, or raise
+  `warmup_steps` past the schedule that starves them.
+
 ### Changed
 
 - The FSDP2 row-sharded `selection_scope` default (both `Dion2` and `NorDion2`)

--- a/dion/cuda_graph.py
+++ b/dion/cuda_graph.py
@@ -36,6 +36,16 @@ Requirements / caveats:
     asks the inner optimizer to push any such value back into the persistent tensor.
     Optimizers outside this family have no such hook, so any hyperparameter they read as a
     host-side python value -- an LR included -- is baked in at capture and stops changing.
+  * ``lr`` is the only group hyperparameter carried live by default. Every other scalar
+    (``weight_decay``, ``mu``, ``beta1``, ``epsilon``, ...) reaches the kernels as a host
+    value and is baked in at capture, so a callback that rewrites one per step -- e.g.
+    schedule-coupled weight decay, which scales ``weight_decay`` with the LR -- would freeze
+    it at its capture-step value with no error. ``weight_decay`` can opt in: pass a Tensor
+    for it (``weight_decay=torch.tensor(0.01)``) and it is carried as a persistent device
+    tensor like the LR, so filling it in place drives a captured step. That is opt-in
+    because on the AdamW scalar path it cannot ride ``torch._fused_adamw_``, whose
+    ``weight_decay`` is a float in every overload, so it is applied as a separate pass and
+    rounds ``X`` once more than the default.
   * ``loss.backward()`` must accumulate into the same ``p.grad`` tensors each step, so
     call ``zero_grad(set_to_none=False)`` (the wrapper enforces this). The first
     backward allocates ``.grad``; capture pins those buffers.
@@ -43,13 +53,14 @@ Requirements / caveats:
     across steps. Dion2/NorDion2's selection *count* is fixed; only indices/values vary,
     which replay handles (it re-reads the live tensors).
   * Which parameters take part is fixed at capture time: the step skips params whose
-    ``.grad`` is None, so a param that is frozen (or gets no tokens) during the warmup
-    steps is left out of the graph and stops being updated for the rest of the run, with
-    no error. Wrap only a step whose set of grad-carrying params is stable.
+    ``.grad`` is None, so a param that gets no tokens during the warmup steps would be left
+    out of the graph and stop being updated for the rest of the run. Capture refuses to run
+    while any ``requires_grad`` param still has ``.grad=None``, so this fails loudly instead;
+    raise ``warmup_steps`` past whatever schedule starves the param, or freeze it explicitly.
   * On the sharded path the graph holds the captured megabatch all-to-all, so the NCCL
     ops outlive the step. ``dist.destroy_process_group()`` blocks while they are alive:
-    drop the wrapper (and any graph it holds) before tearing the process group down at
-    the end of a run, or shutdown hangs.
+    call ``release()`` before tearing the process group down at the end of a run, or
+    shutdown hangs.
   * torch.compile is neither needed nor wanted under a graph (the graph already removes
     dispatch, and a fullgraph compile of the unrolled per-matrix loops is what makes the
     first step take minutes at many layers). Disable it for the wrapped optimizer.
@@ -162,6 +173,45 @@ class CudaGraphOptimizer(torch.optim.Optimizer):
             )
         self.optimizer.zero_grad(set_to_none=False)
 
+    def release(self) -> None:
+        """Drop the captured graph, so the next step captures afresh after a new warmup.
+
+        Call this before ``dist.destroy_process_group()``: on the sharded path the graph holds
+        the captured megabatch all-to-all, and destroying the process group blocks while those
+        NCCL ops are alive. A framework that keeps optimizers alive past the end of training
+        (Lightning's ``Strategy.teardown`` only moves their state to CPU, and the process group
+        is then destroyed from an ``atexit`` handler) hangs at exit without this.
+        """
+        if self._graph is None:
+            return
+        # Do not tear a graph down underneath an in-flight replay.
+        torch.cuda.synchronize()
+        self._graph = None
+        # The next capture needs its own warmup: whatever made the caller release may also
+        # have invalidated the buffers and workspaces the previous warmup had touched.
+        self._step_count = 0
+
+    def _check_params_have_grads(self):
+        # The step only touches params with a gradient, so capture freezes the participating
+        # set: a param whose .grad is still None here is left out of the graph and silently
+        # stops being updated for the rest of the run. Catching that is worth one host-side
+        # pass over the param groups, once, at capture. Params excluded on purpose
+        # (requires_grad=False) are not the failure this guards against.
+        missing = sum(
+            1
+            for group in self.param_groups
+            for param in group["params"]
+            if param.requires_grad and param.grad is None
+        )
+        if missing:
+            raise RuntimeError(
+                f"{missing} parameter(s) require a gradient but have .grad=None at CUDA graph "
+                "capture, so replay would never update them. Capture after every parameter has "
+                "taken part in a backward pass -- raise warmup_steps past whatever schedule "
+                "(modality cadence, expert routing) starves them -- or set requires_grad=False "
+                "on the ones that are meant to be frozen."
+            )
+
     def _capture(self):
         # Capture exactly ONE step. Lazy allocations, cuBLAS workspaces and NCCL setup are
         # already done by the warmup_steps eager steps, so nothing allocates inside the
@@ -169,6 +219,7 @@ class CudaGraphOptimizer(torch.optim.Optimizer):
         # so we replay once immediately to actually perform this step's update. Without
         # that replay the trajectory would be one step short (params/state/step frozen at
         # their pre-capture values for this call).
+        self._check_params_have_grads()
         torch.cuda.synchronize()
         graph = torch.cuda.CUDAGraph()
         with torch.cuda.graph(graph, capture_error_mode=self.capture_error_mode):
@@ -186,7 +237,7 @@ class CudaGraphOptimizer(torch.optim.Optimizer):
         # replaces it with a float the graph will never see. step() reconciles that on the
         # eager path; under capture/replay it either does not run at all (replay) or runs
         # with capture already underway (capture), so do it here, before either.
-        sync = getattr(self.optimizer, "_sync_lr_tensors", None)
+        sync = getattr(self.optimizer, "_sync_hyperparam_tensors", None)
         if sync is not None:
             sync()
 

--- a/dion/cuda_graph.py
+++ b/dion/cuda_graph.py
@@ -45,7 +45,9 @@ Requirements / caveats:
     tensor like the LR, so filling it in place drives a captured step. That is opt-in
     because on the AdamW scalar path it cannot ride ``torch._fused_adamw_``, whose
     ``weight_decay`` is a float in every overload, so it is applied as a separate pass and
-    rounds ``X`` once more than the default.
+    rounds ``X`` once more than the default. Opt in before the first capture -- afterwards
+    the graph has already baked the host value, and the wrapper raises rather than let a
+    late opt-in look like it took effect.
   * ``loss.backward()`` must accumulate into the same ``p.grad`` tensors each step, so
     call ``zero_grad(set_to_none=False)`` (the wrapper enforces this). The first
     backward allocates ``.grad``; capture pins those buffers.
@@ -114,6 +116,9 @@ class CudaGraphOptimizer(torch.optim.Optimizer):
         self.capture_error_mode = capture_error_mode
         self._step_count = 0
         self._graph: Optional[torch.cuda.CUDAGraph] = None
+        # How many persistent hyperparameter tensors the inner optimizer held when the
+        # graph was captured; see _check_live_hyperparams_unchanged.
+        self._captured_hyperparam_count = 0
         self._warned_set_to_none = False
         self._optimizer_step_pre_hooks = OrderedDict()
         self._optimizer_step_post_hooks = OrderedDict()
@@ -143,12 +148,11 @@ class CudaGraphOptimizer(torch.optim.Optimizer):
         # torch.optim.Optimizer defines add_param_group, so (unlike state/defaults) it is
         # found on the base class and __getattr__ never delegates it -- override explicitly.
         # A new group is not in the captured graph; drop it so the next step re-captures.
-        # Restart the warmup as well: the new group's state, workspaces and comm buffers
-        # have never been touched by an eager step, and re-capturing straight away would
-        # allocate (or recompile) them inside the graph -- the failure warmup_steps exists
-        # to prevent.
-        self._graph = None
-        self._step_count = 0
+        # release() restarts the warmup as well: the new group's state, workspaces and comm
+        # buffers have never been touched by an eager step, and re-capturing straight away
+        # would allocate (or recompile) them inside the graph -- the failure warmup_steps
+        # exists to prevent.
+        self.release()
         return self.optimizer.add_param_group(param_group)
 
     def state_dict(self):
@@ -156,8 +160,7 @@ class CudaGraphOptimizer(torch.optim.Optimizer):
 
     def load_state_dict(self, sd):
         # Loading new state invalidates any captured graph (buffers may move).
-        self._graph = None
-        self._step_count = 0
+        self.release()
         return self.optimizer.load_state_dict(sd)
 
     def zero_grad(self, set_to_none: bool = False):
@@ -181,15 +184,45 @@ class CudaGraphOptimizer(torch.optim.Optimizer):
         NCCL ops are alive. A framework that keeps optimizers alive past the end of training
         (Lightning's ``Strategy.teardown`` only moves their state to CPU, and the process group
         is then destroyed from an ``atexit`` handler) hangs at exit without this.
+
+        Also the single place a captured graph is dropped: ``add_param_group`` and
+        ``load_state_dict`` invalidate the graph and go through here too, so they get the
+        same synchronize-and-destroy instead of leaving live NCCL ops to a refcount.
         """
-        if self._graph is None:
+        graph, self._graph = self._graph, None
+        self._captured_hyperparam_count = 0
+        # The next capture needs its own warmup: whatever made the caller release may also
+        # have invalidated the buffers and workspaces the previous warmup had touched.
+        # Unconditional, so a release() during the warmup restarts it as documented.
+        self._step_count = 0
+        if graph is None:
             return
         # Do not tear a graph down underneath an in-flight replay.
         torch.cuda.synchronize()
-        self._graph = None
-        # The next capture needs its own warmup: whatever made the caller release may also
-        # have invalidated the buffers and workspaces the previous warmup had touched.
-        self._step_count = 0
+        # Destroy the graph here rather than leaving it to refcounting. The whole point of
+        # release() is that the captured NCCL ops are gone before destroy_process_group(),
+        # and any stray reference -- an exception traceback holding the capturing frame, a
+        # debugger, a profiler -- would otherwise keep them alive past this call.
+        graph.reset()
+
+    def _live_hyperparam_count(self) -> int:
+        tensors = getattr(self.optimizer, "_hyperparam_tensors", None)
+        return len(tensors) if tensors is not None else 0
+
+    def _check_live_hyperparams_unchanged(self):
+        # A group hyperparameter opted into being carried live (weight_decay=Tensor is the
+        # way in) gets a fresh persistent device tensor the moment it opts in. Doing that
+        # after capture is too late: the graph baked the old host value and never reads the
+        # new tensor, so the schedule the caller just wired up would silently do nothing.
+        # The count only ever grows, so comparing it is enough -- and it is an int compare
+        # per replay rather than a host-side walk of the param groups.
+        if self._live_hyperparam_count() != self._captured_hyperparam_count:
+            raise RuntimeError(
+                "a param group started carrying a hyperparameter as a live device tensor "
+                "after the CUDA graph was captured (weight_decay=Tensor is the way in). "
+                "The captured graph baked the previous host value and cannot read the new "
+                "tensor. Opt in before the first capture, or call release() to re-capture."
+            )
 
     def _check_params_have_grads(self):
         # The step only touches params with a gradient, so capture freezes the participating
@@ -197,19 +230,24 @@ class CudaGraphOptimizer(torch.optim.Optimizer):
         # stops being updated for the rest of the run. Catching that is worth one host-side
         # pass over the param groups, once, at capture. Params excluded on purpose
         # (requires_grad=False) are not the failure this guards against.
-        missing = sum(
-            1
-            for group in self.param_groups
-            for param in group["params"]
+        missing = [
+            f"group {index}[{position}] shape {tuple(param.shape)}"
+            for index, group in enumerate(self.param_groups)
+            for position, param in enumerate(group["params"])
             if param.requires_grad and param.grad is None
-        )
+        ]
         if missing:
+            # Params carry no names here, so point at where they sit in the groups -- enough
+            # to find them again in whatever built the groups.
+            shown = ", ".join(missing[:5])
+            if len(missing) > 5:
+                shown += f", ... (+{len(missing) - 5} more)"
             raise RuntimeError(
-                f"{missing} parameter(s) require a gradient but have .grad=None at CUDA graph "
-                "capture, so replay would never update them. Capture after every parameter has "
-                "taken part in a backward pass -- raise warmup_steps past whatever schedule "
-                "(modality cadence, expert routing) starves them -- or set requires_grad=False "
-                "on the ones that are meant to be frozen."
+                f"{len(missing)} parameter(s) require a gradient but have .grad=None at CUDA "
+                f"graph capture, so replay would never update them: {shown}. Capture after "
+                "every parameter has taken part in a backward pass -- raise warmup_steps past "
+                "whatever schedule (modality cadence, expert routing) starves them -- or set "
+                "requires_grad=False on the ones that are meant to be frozen."
             )
 
     def _capture(self):
@@ -228,6 +266,7 @@ class CudaGraphOptimizer(torch.optim.Optimizer):
         # is not replayable, and holding it here would turn one loud capture error into
         # every later step silently replaying garbage.
         self._graph = graph
+        self._captured_hyperparam_count = self._live_hyperparam_count()
         graph.replay()
 
     def _sync_host_hyperparams(self):
@@ -259,6 +298,7 @@ class CudaGraphOptimizer(torch.optim.Optimizer):
                 # step() runs (and so does its host-side bookkeeping) while being traced.
                 self._capture()
             else:
+                self._check_live_hyperparams_unchanged()
                 self._graph.replay()
                 # Replay executes only the recorded device work, so any host-side per-step
                 # bookkeeping in step() has to be advanced here instead.

--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -13,7 +13,7 @@ from .megabatch_base import (
     adjust_lr_spectral_norm,
     adjust_lr_rms_norm,
 )
-from .opt_utils import AsyncTask, to_local
+from .opt_utils import AsyncTask, as_scalar_tensor, to_local
 
 
 class Dion2(DistributedOrthoBase):
@@ -145,7 +145,7 @@ class Dion2(DistributedOrthoBase):
                 lr=group["lr"],
                 ef_decay=torch.tensor(group["ef_decay"]),
                 fraction=group["fraction"],
-                weight_decay=torch.tensor(group["weight_decay"]),
+                weight_decay=as_scalar_tensor(group["weight_decay"]),
                 epsilon=torch.tensor(group["epsilon"]),
                 flatten=group["flatten"],
                 adjust_lr=group["adjust_lr"],

--- a/dion/dion2.py
+++ b/dion/dion2.py
@@ -29,7 +29,9 @@ class Dion2(DistributedOrthoBase):
         fraction: Fraction of submatrix to orthogonalize per update (0 < fraction <= 1).
         ef_decay: Error-feedback decay factor applied to selected submatrix.
         betas: Tuple of (beta1, beta2) for AdamW and Lion algorithms.
-        weight_decay: Weight decay factor.
+        weight_decay: Weight decay factor. Pass a Tensor to carry it as a persistent
+            device tensor the kernels read live, so filling it in place drives a
+            CUDA-graph-captured step (see dion.cuda_graph); a float is baked at capture.
         epsilon: Small value to avoid division by zero.
         adjust_lr: How to adjust the learning rate for Muon updates ("spectral_norm" or "rms_norm" or None).
             "spectral_norm": Adjust based on spectral norm, for learning rate transfer across model scale.
@@ -63,7 +65,7 @@ class Dion2(DistributedOrthoBase):
         fraction: float = 0.25,
         ef_decay: float = 0.95,
         betas: Tuple[float, float] = (0.9, 0.95),
-        weight_decay: float = 0.01,
+        weight_decay: Union[float, Tensor] = 0.01,
         epsilon: float = 1e-8,
         adjust_lr: Optional[str] = "spectral_norm",
         flatten: bool = False,

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -128,11 +128,10 @@ class DistributedOrthoBase(Optimizer):
         # Persistent per-group hyperparameter device tensors, keyed by (group index, name).
         # Held here (not only in the group) so the tensor identity survives a caller
         # reassigning group["lr"]; see _ensure_hyperparam_tensor. Which names are carried
-        # this way is decided once per group, before any reassignment can hide the opt-in.
+        # this way is per group and latching; see _live_hyperparams.
         self._hyperparam_tensors: dict = {}
         self._live_hyperparams_by_group: dict = {}
-        for index, group in enumerate(self.param_groups):
-            self._live_hyperparams(index)
+        for group in self.param_groups:
             self._prepopulate_group_state(group)
         self._sync_hyperparam_tensors()
         self._state_prepopulated = True
@@ -422,19 +421,29 @@ class DistributedOrthoBase(Optimizer):
         ``lr`` is always live -- carrying it as a tensor is what lets a ``torch.optim``
         scheduler drive a captured step. ``weight_decay`` is live only when the caller
         supplied a Tensor for it (at construction, ``weight_decay=torch.tensor(0.01)``, or
-        by assigning one to the group before the first step). That opt-in keeps the default
-        float path bit-identical to before: on the AdamW scalar path a live weight decay
-        cannot ride ``torch._fused_adamw_``, whose ``weight_decay`` argument is a float in
-        every overload, so it has to be applied as a separate pass and rounds once more.
+        by assigning one to the group any time before the graph is captured). That opt-in
+        keeps the default float path bit-identical to before: on the AdamW scalar path a
+        live weight decay cannot ride ``torch._fused_adamw_``, whose ``weight_decay``
+        argument is a float in every overload, so it has to be applied as a separate pass
+        and rounds once more.
+
+        The opt-in *latches*: the check re-runs until a Tensor is seen, and never after.
+        So an opt-in made after construction still takes effect, while a later
+        ``group["weight_decay"] = 0.05`` refills the persistent tensor (as it does for the
+        LR) instead of quietly dropping the group back to a value baked in at capture.
+        Opting in after a graph exists is too late to be honored -- the graph already baked
+        the float -- and ``CudaGraphOptimizer`` raises rather than let that pass silently.
 
         Every *other* group scalar (``mu``, ``beta1``, ``epsilon``, ...) reaches the kernels
         as a host value and is baked in at capture. Nothing schedules those today; if
         something does, add it here rather than mutating it behind a captured graph.
         """
         live = self._live_hyperparams_by_group.get(index)
-        if live is None:
-            opted_in = isinstance(self.param_groups[index].get("weight_decay"), Tensor)
-            live = ("lr", "weight_decay") if opted_in else ("lr",)
+        if live is None or "weight_decay" not in live:
+            if isinstance(self.param_groups[index].get("weight_decay"), Tensor):
+                live = ("lr", "weight_decay")
+            elif live is None:
+                live = ("lr",)
             self._live_hyperparams_by_group[index] = live
         return live
 
@@ -500,7 +509,6 @@ class DistributedOrthoBase(Optimizer):
         for index in range(len(self.param_groups)):
             for name in self._live_hyperparams(index):
                 self._ensure_hyperparam_tensor(index, name)
-
 
     def _advance_host_step_counters(self):
         """Advance the host-side ``group["step"]`` counters for a step that ran as a CUDA

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -15,7 +15,7 @@ from .newton_schulz_triton import (
     zeropower_via_newtonschulz5,
 )
 from .polar_express import polar_express, polar_express_triton
-from .opt_utils import AsyncRuntime, AsyncTask, to_local
+from .opt_utils import AsyncRuntime, AsyncTask, as_scalar_tensor, to_local
 from .scalar_opts import adamw_update_foreach_async, lion_update_foreach_async
 
 
@@ -125,13 +125,16 @@ class DistributedOrthoBase(Optimizer):
         # loop), generalized here to the whole DistributedOrthoBase family via
         # the (possibly overridden) _get_or_initialize_state.
         self._state_prepopulated = False
-        # Persistent per-group LR device tensors, keyed by param group index. Held here
-        # (not only in group["lr"]) so the tensor identity survives a caller reassigning
-        # group["lr"]; see _ensure_lr_tensor.
-        self._lr_tensors: dict = {}
+        # Persistent per-group hyperparameter device tensors, keyed by (group index, name).
+        # Held here (not only in the group) so the tensor identity survives a caller
+        # reassigning group["lr"]; see _ensure_hyperparam_tensor. Which names are carried
+        # this way is decided once per group, before any reassignment can hide the opt-in.
+        self._hyperparam_tensors: dict = {}
+        self._live_hyperparams_by_group: dict = {}
         for index, group in enumerate(self.param_groups):
-            self._ensure_lr_tensor(index)
+            self._live_hyperparams(index)
             self._prepopulate_group_state(group)
+        self._sync_hyperparam_tensors()
         self._state_prepopulated = True
 
     def _prepopulate_group_state(self, group: dict) -> None:
@@ -146,7 +149,9 @@ class DistributedOrthoBase(Optimizer):
         # add_param_group calls that Optimizer.__init__ makes before this class
         # finishes setup; the __init__ loop above pre-populates those groups.
         if getattr(self, "_state_prepopulated", False):
-            self._ensure_lr_tensor(len(self.param_groups) - 1)
+            index = len(self.param_groups) - 1
+            for name in self._live_hyperparams(index):
+                self._ensure_hyperparam_tensor(index, name)
             self._prepopulate_group_state(self.param_groups[-1])
 
     @torch.no_grad()
@@ -158,12 +163,12 @@ class DistributedOrthoBase(Optimizer):
                 loss = closure()
 
         # The LR is carried as a device tensor the kernels read directly (see
-        # _ensure_lr_tensor); a scheduler updates it in place outside the graph and every
+        # _ensure_hyperparam_tensor); a scheduler updates it in place outside the graph and every
         # replay re-reads the live value. Push in anything a caller assigned to
         # group["lr"] as a plain float since the last step. A no-op (and so safe under
         # graph capture) once the tensor is in place, which the wrapper guarantees by
         # calling this itself before capturing.
-        self._sync_lr_tensors()
+        self._sync_hyperparam_tensors()
 
         ortho_groups = []
         lion_groups = []
@@ -410,21 +415,44 @@ class DistributedOrthoBase(Optimizer):
 
         return is_batch_sharded, is_matrix_sharded, sharded_tensor_dim
 
-    def _ensure_lr_tensor(self, index: int) -> Optional[Tensor]:
-        """Make ``param_groups[index]["lr"]`` this group's persistent 0-d device float32
+    def _live_hyperparams(self, index: int) -> Tuple[str, ...]:
+        """Names of ``param_groups[index]``'s hyperparameters carried as persistent device
+        tensors, so a captured graph re-reads them on every replay instead of baking them in.
+
+        ``lr`` is always live -- carrying it as a tensor is what lets a ``torch.optim``
+        scheduler drive a captured step. ``weight_decay`` is live only when the caller
+        supplied a Tensor for it (at construction, ``weight_decay=torch.tensor(0.01)``, or
+        by assigning one to the group before the first step). That opt-in keeps the default
+        float path bit-identical to before: on the AdamW scalar path a live weight decay
+        cannot ride ``torch._fused_adamw_``, whose ``weight_decay`` argument is a float in
+        every overload, so it has to be applied as a separate pass and rounds once more.
+
+        Every *other* group scalar (``mu``, ``beta1``, ``epsilon``, ...) reaches the kernels
+        as a host value and is baked in at capture. Nothing schedules those today; if
+        something does, add it here rather than mutating it behind a captured graph.
+        """
+        live = self._live_hyperparams_by_group.get(index)
+        if live is None:
+            opted_in = isinstance(self.param_groups[index].get("weight_decay"), Tensor)
+            live = ("lr", "weight_decay") if opted_in else ("lr",)
+            self._live_hyperparams_by_group[index] = live
+        return live
+
+    def _ensure_hyperparam_tensor(self, index: int, name: str) -> Optional[Tensor]:
+        """Make ``param_groups[index][name]`` this group's persistent 0-d device float32
         tensor and return it (``None`` for a group with no parameters, which has no device
         to put it on and no kernel to read it).
 
-        The LR is carried as a device tensor the kernels read directly, so a ``torch.optim``
+        The value is carried as a device tensor the kernels read directly, so a ``torch.optim``
         LR scheduler -- which updates a tensor ``lr`` in place -- drives a captured step
         natively: the scheduler fills this tensor outside the graph and every replay re-reads
-        it, with no refresh plumbing. float32 is what the former ``torch.tensor(group["lr"])``
+        it, with no refresh plumbing. float32 is what the former ``torch.tensor(group[name])``
         produced and the dtype the fused AdamW ``tensor_lr`` overload requires.
 
         The tensor is allocated once per group and thereafter only ever filled, never
         replaced. That identity is what makes replay correct: a captured graph reads the
         tensor recorded at capture time, so handing the group a *different* tensor would
-        leave every later replay on the stale one. Anything else found under ``lr`` -- a
+        leave every later replay on the stale one. Anything else found under ``name`` -- a
         python float from construction or from the ``group["lr"] = 0.05`` idiom of a
         hand-rolled schedule, or a wrong-device tensor restored from a checkpoint via
         ``map_location="cpu"`` -- is copied into the persistent tensor and the tensor put
@@ -436,41 +464,43 @@ class DistributedOrthoBase(Optimizer):
         if not params:
             return None
 
-        lr = group["lr"]
-        tensor = self._lr_tensors.get(index)
-        if lr is tensor:
+        value = group[name]
+        tensor = self._hyperparam_tensors.get((index, name))
+        if value is tensor:
             return tensor
 
         # Everything below writes to the device, so it must not run under graph capture:
-        # a recorded fill_ would re-apply the capture-time LR on every replay, silently
+        # a recorded fill_ would re-apply the capture-time value on every replay, silently
         # overwriting whatever the scheduler had set.
         if torch.cuda.is_available() and torch.cuda.is_current_stream_capturing():
             raise RuntimeError(
-                f"param group {index} has a learning rate that is not its persistent "
-                f"device tensor ({type(lr).__name__}), and CUDA graph capture is already "
-                "underway so it cannot be refreshed. Sync the learning rate before "
+                f"param group {index} has a {name} that is not its persistent "
+                f"device tensor ({type(value).__name__}), and CUDA graph capture is already "
+                f"underway so it cannot be refreshed. Sync {name} before "
                 "capturing (CudaGraphOptimizer does this for you)."
             )
 
         device = to_local(params[0]).device
         if tensor is None or tensor.device != device:
             tensor = torch.empty((), dtype=torch.float32, device=device)
-            self._lr_tensors[index] = tensor
-        if isinstance(lr, Tensor):
-            tensor.copy_(lr)
+            self._hyperparam_tensors[(index, name)] = tensor
+        if isinstance(value, Tensor):
+            tensor.copy_(value)
         else:
-            tensor.fill_(lr)
-        group["lr"] = tensor
+            tensor.fill_(value)
+        group[name] = tensor
         return tensor
 
-    def _sync_lr_tensors(self) -> None:
-        """Push each group's host-side ``lr`` into the persistent device tensor the kernels
-        (and any captured CUDA graph) read. Called at the top of ``step()``, and by
+    def _sync_hyperparam_tensors(self) -> None:
+        """Push each group's host-side hyperparameters into the persistent device tensors the
+        kernels (and any captured CUDA graph) read. Called at the top of ``step()``, and by
         ``CudaGraphOptimizer`` before it captures or replays -- under replay ``step()``
         never runs, so this is the only thing that carries a ``group["lr"] = 0.05``
         assignment through to the graph."""
         for index in range(len(self.param_groups)):
-            self._ensure_lr_tensor(index)
+            for name in self._live_hyperparams(index):
+                self._ensure_hyperparam_tensor(index, name)
+
 
     def _advance_host_step_counters(self):
         """Advance the host-side ``group["step"]`` counters for a step that ran as a CUDA
@@ -501,9 +531,9 @@ class DistributedOrthoBase(Optimizer):
 
     def load_state_dict(self, state_dict):
         super().load_state_dict(state_dict)
-        # Refill the device LR tensors from the loaded values (a float from a normal
+        # Refill the device hyperparameter tensors from the loaded values (a float from a normal
         # checkpoint, or a wrong-device tensor from one written by an earlier build).
-        self._sync_lr_tensors()
+        self._sync_hyperparam_tensors()
         for group in self.param_groups:
             if group["algorithm"] != "adamw":
                 continue
@@ -558,7 +588,7 @@ class DistributedOrthoBase(Optimizer):
                     lr=group["lr"],
                     beta1=torch.tensor(group["beta1"]),
                     beta2=torch.tensor(group["beta2"]),
-                    weight_decay=torch.tensor(group["weight_decay"]),
+                    weight_decay=as_scalar_tensor(group["weight_decay"]),
                     cautious_wd=group.get("cautious_wd", False),
                 )
             )
@@ -586,7 +616,7 @@ class DistributedOrthoBase(Optimizer):
                     lr=group["lr"],
                     beta1=torch.tensor(group["beta1"]),
                     beta2=torch.tensor(group["beta2"]),
-                    weight_decay=torch.tensor(group["weight_decay"]),
+                    weight_decay=as_scalar_tensor(group["weight_decay"]),
                     state_steps=step_tensors,
                     epsilon=torch.tensor(group["epsilon"]),
                     cautious_wd=group.get("cautious_wd", False),

--- a/dion/muon.py
+++ b/dion/muon.py
@@ -14,7 +14,7 @@ from .megabatch_base import (
     adjust_lr_rms_norm,
     compute_split_lr_scales,
 )
-from .opt_utils import AsyncTask, to_local
+from .opt_utils import AsyncTask, as_scalar_tensor, to_local
 
 
 class Muon(DistributedOrthoBase):
@@ -127,7 +127,7 @@ class Muon(DistributedOrthoBase):
             update_args = dict(
                 lr=group["lr"],
                 momentum=torch.tensor(group["mu"]),
-                weight_decay=torch.tensor(group["weight_decay"]),
+                weight_decay=as_scalar_tensor(group["weight_decay"]),
                 epsilon=torch.tensor(group["epsilon"]),
                 nesterov=group["nesterov"],
                 flatten=group["flatten"],

--- a/dion/muon.py
+++ b/dion/muon.py
@@ -29,7 +29,9 @@ class Muon(DistributedOrthoBase):
             For element-wise update rules, this is the actual learning rate and no additional scaling is done.
         mu: Momentum factor for Muon algorithm.
         betas: Tuple of (beta1, beta2) for AdamW and Lion algorithms.
-        weight_decay: Weight decay factor.
+        weight_decay: Weight decay factor. Pass a Tensor to carry it as a persistent
+            device tensor the kernels read live, so filling it in place drives a
+            CUDA-graph-captured step (see dion.cuda_graph); a float is baked at capture.
         cautious_wd: Whether to apply weight decay only where update and parameter signs align.
         epsilon: Small value to avoid division by zero.
         nesterov: Whether to use Nesterov momentum.
@@ -63,7 +65,7 @@ class Muon(DistributedOrthoBase):
         lr: float = 0.01,
         mu: float = 0.95,
         betas: Tuple[float, float] = (0.9, 0.95),
-        weight_decay: float = 0.01,
+        weight_decay: Union[float, Tensor] = 0.01,
         cautious_wd: bool = False,
         epsilon: float = 1e-8,
         nesterov: bool = False,

--- a/dion/nordion2.py
+++ b/dion/nordion2.py
@@ -13,7 +13,7 @@ from .megabatch_base import (
     adjust_lr_spectral_norm,
     adjust_lr_rms_norm,
 )
-from .opt_utils import AsyncTask, to_local
+from .opt_utils import AsyncTask, as_scalar_tensor, to_local
 from .dion2 import (
     dion2_pre_orthogonalize,
     dion2_post_orthogonalize,
@@ -172,7 +172,7 @@ class NorDion2(DistributedOrthoBase):
                 fraction=group["fraction"],
                 momentum=torch.tensor(group["mu"]),
                 muon_beta2=torch.tensor(group["muon_beta2"]),
-                weight_decay=torch.tensor(group["weight_decay"]),
+                weight_decay=as_scalar_tensor(group["weight_decay"]),
                 epsilon=torch.tensor(group["epsilon"]),
                 flatten=group["flatten"],
                 adjust_lr=group["adjust_lr"],

--- a/dion/nordion2.py
+++ b/dion/nordion2.py
@@ -37,7 +37,9 @@ class NorDion2(DistributedOrthoBase):
         mu: Momentum factor for NorDion2 algorithm.
         muon_beta2: Second beta parameter for NorDion2 algorithm's adaptive updates.
         betas: Tuple of (beta1, beta2) for AdamW and Lion algorithms.
-        weight_decay: Weight decay factor.
+        weight_decay: Weight decay factor. Pass a Tensor to carry it as a persistent
+            device tensor the kernels read live, so filling it in place drives a
+            CUDA-graph-captured step (see dion.cuda_graph); a float is baked at capture.
         epsilon: Small value to avoid division by zero.
         adjust_lr: How to adjust the learning rate for Muon updates ("spectral_norm" or "rms_norm" or None).
             "spectral_norm": Adjust based on spectral norm, for learning rate transfer across model scale.
@@ -71,7 +73,7 @@ class NorDion2(DistributedOrthoBase):
         mu: float = 0.95,
         muon_beta2: float = 0.95,
         betas: Tuple[float, float] = (0.9, 0.95),
-        weight_decay: float = 0.01,
+        weight_decay: Union[float, Tensor] = 0.01,
         epsilon: float = 1e-8,
         adjust_lr: Optional[str] = "spectral_norm",
         flatten: bool = False,

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -13,7 +13,7 @@ from .megabatch_base import (
     adjust_lr_rms_norm,
     compute_split_lr_scales,
 )
-from .opt_utils import AsyncTask, to_local
+from .opt_utils import AsyncTask, as_scalar_tensor, to_local
 from .muon import muon_update_pre_orthogonalize, muon_update_post_orthogonalize
 
 
@@ -151,7 +151,7 @@ class NorMuon(DistributedOrthoBase):
                 lr=group["lr"],
                 momentum=torch.tensor(group["mu"]),
                 muon_beta2=torch.tensor(group["muon_beta2"]),
-                weight_decay=torch.tensor(group["weight_decay"]),
+                weight_decay=as_scalar_tensor(group["weight_decay"]),
                 epsilon=torch.tensor(group["epsilon"]),
                 nesterov=group["nesterov"],
                 flatten=group["flatten"],

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -30,7 +30,9 @@ class NorMuon(DistributedOrthoBase):
         mu: Momentum factor for NorMuon algorithm.
         muon_beta2: Second beta parameter for NorMuon algorithm's adaptive updates.
         betas: Tuple of (beta1, beta2) for AdamW and Lion algorithms.
-        weight_decay: Weight decay factor.
+        weight_decay: Weight decay factor. Pass a Tensor to carry it as a persistent
+            device tensor the kernels read live, so filling it in place drives a
+            CUDA-graph-captured step (see dion.cuda_graph); a float is baked at capture.
         cautious_wd: Whether to apply weight decay only where update and parameter signs align.
         epsilon: Small value to avoid division by zero.
         nesterov: Whether to use Nesterov momentum.
@@ -67,7 +69,7 @@ class NorMuon(DistributedOrthoBase):
         mu: float = 0.95,
         muon_beta2: float = 0.95,
         betas: Tuple[float, float] = (0.9, 0.95),
-        weight_decay: float = 0.01,
+        weight_decay: Union[float, Tensor] = 0.01,
         cautious_wd: bool = False,
         epsilon: float = 1e-8,
         nesterov: bool = False,

--- a/dion/opt_utils.py
+++ b/dion/opt_utils.py
@@ -11,6 +11,18 @@ def lm_head_lr_scale(scalar_opt: str, model_dim: int) -> float:
     return 1 / math.sqrt(model_dim) if scalar_opt == "lion" else 1.0
 
 
+def as_scalar_tensor(value: Union[Tensor, float]) -> Tensor:
+    """Wrap a group hyperparameter for the kernels, leaving an existing tensor alone.
+
+    A group whose hyperparameter is carried as a persistent device tensor
+    (``DistributedOrthoBase._ensure_hyperparam_tensor``) must reach the kernels as *that*
+    tensor, so a captured CUDA graph re-reads the live value on every replay. Re-wrapping it
+    with ``torch.tensor()`` would copy, and a copy made during capture freezes the value.
+    A plain float still becomes a host scalar tensor, exactly as before.
+    """
+    return value if isinstance(value, Tensor) else torch.tensor(value)
+
+
 def to_local(tensor: Union[Tensor, List[Tensor]]) -> Union[Tensor, List[Tensor]]:
     """
     Convert a single DTensor or list of DTensors to local tensors.

--- a/dion/scalar_opts.py
+++ b/dion/scalar_opts.py
@@ -238,14 +238,20 @@ def adamw_update_foreach(
         signs = torch._foreach_mul(M, X_orig)
         undo_masks = [(s < 0).to(x.dtype) for s, x in zip(signs, X_orig)]
         correction = torch._foreach_mul(X_orig, undo_masks)
-        if state_steps is not None:
+        # Fold (lr * wd) into one scalar first, so the correction is a single foreach pass
+        # and the multiply order is the same in every branch -- scaling by wd and then by
+        # lr is not bit-identical to scaling by (lr*wd).
+        if decay_outside:
+            # ``wd_f`` is 0 here (the kernel was handed no decay), so the coefficient has
+            # to come off the device tensor -- on the legacy path too, where using wd_f
+            # would zero the correction and silently degrade CWD to plain weight decay.
+            coeff = lr * weight_decay
+        elif state_steps is not None:
             # Keep the LR scaling on-device: float(lr) would host-sync and bake the value.
-            # Fold (lr * wd) into one 0-d device scalar first, so the correction is a
-            # single foreach pass and the multiply order matches the legacy branch below
-            # -- scaling by wd and then by lr is not bit-identical to scaling by (lr*wd).
-            torch._foreach_mul_(correction, lr * (weight_decay if decay_outside else wd_f))
+            coeff = lr * wd_f
         else:
-            torch._foreach_mul_(correction, float(lr) * wd_f)
+            coeff = float(lr) * wd_f
+        torch._foreach_mul_(correction, coeff)
         torch._foreach_add_(X, correction)
 
 

--- a/dion/scalar_opts.py
+++ b/dion/scalar_opts.py
@@ -146,6 +146,12 @@ def adamw_update_foreach(
       fused kernel's ``tensor_lr`` overload, so both advance inside a CUDA graph. This is
       the form ``megabatch_base`` passes so a wrapped step is graph-capturable.
 
+    ``weight_decay`` as a *device* tensor selects a third variation, orthogonal to the two
+    above: the fused kernel's ``weight_decay`` is a float in every overload, so the decoupled
+    decay is applied as its own ``_foreach_mul_`` pass and the kernel is handed ``wd=0``. That
+    keeps a scheduled weight decay live under CUDA-graph replay, at the cost of one extra pass
+    and one extra rounding of ``X``. A float (or CPU scalar tensor) keeps the fused path.
+
     Cautious weight decay (https://arxiv.org/pdf/2510.12402) is applied as a
     post-step correction rather than inside the kernel:
 
@@ -174,12 +180,24 @@ def adamw_update_foreach(
 
     beta1_f = float(beta1)
     beta2_f = float(beta2)
-    wd_f = float(weight_decay)
     eps_f = float(epsilon)
 
-    do_cwd_correction = cautious_wd and wd_f > 0.0
+    # ``_fused_adamw_`` takes weight_decay as a float in every overload (unlike lr, which has
+    # a tensor_lr overload), so a device-tensor weight decay cannot be read by the kernel.
+    # Apply the decoupled decay as its own pass and hand the kernel wd=0. Costs one extra
+    # foreach pass and one extra rounding of X, which is why a tensor weight decay is opt-in
+    # rather than the default -- see DistributedOrthoBase._live_hyperparams.
+    decay_outside = isinstance(weight_decay, Tensor) and weight_decay.device.type != "cpu"
+    wd_f = 0.0 if decay_outside else float(weight_decay)
+
+    # A device-tensor wd is taken as non-zero without checking: reading it would host-sync,
+    # which capture forbids. Costs a wasted correction pass in the wd=0 case.
+    do_cwd_correction = cautious_wd and (decay_outside or wd_f > 0.0)
     if do_cwd_correction:
         X_orig = [x.clone() for x in X]
+
+    if decay_outside:
+        torch._foreach_mul_(X, 1 - lr * weight_decay)
 
     if state_steps is not None:
         # Capturable form. ``state_steps`` are per-param device tensors we increment
@@ -225,7 +243,7 @@ def adamw_update_foreach(
             # Fold (lr * wd) into one 0-d device scalar first, so the correction is a
             # single foreach pass and the multiply order matches the legacy branch below
             # -- scaling by wd and then by lr is not bit-identical to scaling by (lr*wd).
-            torch._foreach_mul_(correction, lr * wd_f)
+            torch._foreach_mul_(correction, lr * (weight_decay if decay_outside else wd_f))
         else:
             torch._foreach_mul_(correction, float(lr) * wd_f)
         torch._foreach_add_(X, correction)

--- a/tests/test_adamw_foreach.py
+++ b/tests/test_adamw_foreach.py
@@ -290,6 +290,67 @@ def test_cwd_zero_wd_skips_correction():
     assert torch.equal(X1[0], X2[0])
 
 
+@pytest.mark.parametrize("cautious_wd", [False, True])
+@pytest.mark.parametrize("capturable", [False, True])
+def test_device_tensor_weight_decay_matches_the_float_path(cautious_wd, capturable):
+    """A *device* tensor weight decay takes the decoupled decay off ``_fused_adamw_`` (whose
+    weight_decay is a float in every overload) and applies it as its own pass, so a captured
+    graph re-reads it. Same update either way -- one extra rounding of X apart. The CWD
+    correction has to follow the decay onto the device tensor: reading the (now zero) float
+    scalar instead silently degrades cautious weight decay to plain weight decay."""
+    from dion.scalar_opts import adamw_update_foreach
+
+    def run(wd):
+        torch.manual_seed(0)
+        X = [torch.randn(64, 32, device=DEVICE), torch.randn(16, device=DEVICE)]
+        G = [torch.randn_like(x) * 0.1 for x in X]
+        M = [torch.randn_like(x) * 0.01 for x in X]
+        V = [torch.rand_like(x).abs() * 0.01 for x in X]
+        kw = dict(beta1=torch.tensor(0.9), beta2=torch.tensor(0.999),
+                  weight_decay=wd, epsilon=1e-8, cautious_wd=cautious_wd)
+        if capturable:
+            steps = [torch.ones((), dtype=torch.float32, device=DEVICE) for _ in X]
+            adamw_update_foreach(X, G, M, V, lr=torch.full((), 0.1, device=DEVICE),
+                                 state_steps=steps, **kw)
+        else:
+            adamw_update_foreach(X, G, M, V, lr=0.1, step=2, **kw)
+        return X
+
+    wd = 0.3
+    baked = run(wd)
+    live = run(torch.full((), wd, device=DEVICE))
+    for b, l in zip(baked, live):
+        torch.testing.assert_close(b, l, rtol=0, atol=1e-6)
+
+
+def test_cwd_on_the_live_weight_decay_path_is_not_plain_decay():
+    """Regression: with a device-tensor wd the kernel is handed wd=0, so a correction scaled
+    by that float is identically zero and CWD collapses into plain weight decay."""
+    from dion.scalar_opts import adamw_update_foreach
+
+    def run(cautious, capturable):
+        torch.manual_seed(0)
+        X = [torch.randn(64, 32, device=DEVICE)]
+        G = [torch.randn_like(X[0]) * 0.1]
+        M = [torch.randn_like(X[0]) * 0.01]
+        V = [torch.rand_like(X[0]).abs() * 0.01]
+        kw = dict(beta1=torch.tensor(0.9), beta2=torch.tensor(0.999),
+                  weight_decay=torch.full((), 0.3, device=DEVICE),
+                  epsilon=1e-8, cautious_wd=cautious)
+        if capturable:
+            adamw_update_foreach(X, G, M, V, lr=torch.full((), 0.1, device=DEVICE),
+                                 state_steps=[torch.ones((), dtype=torch.float32,
+                                                         device=DEVICE)], **kw)
+        else:
+            adamw_update_foreach(X, G, M, V, lr=0.1, step=2, **kw)
+        return X[0]
+
+    for capturable in (False, True):
+        gap = (run(True, capturable) - run(False, capturable)).abs().max().item()
+        form = "capturable" if capturable else "legacy"
+        assert gap > 1e-3, f"{form}: CWD is indistinguishable from plain decay (gap {gap:.3e})"
+
+
 class TestIntegration:
     def test_normuon_with_adamw_scalars(self):
         from dion import NorMuon

--- a/tests/test_cuda_graph.py
+++ b/tests/test_cuda_graph.py
@@ -490,7 +490,12 @@ def _dist_worker(rank, world_size, port, mode, out_path):
             torch.save(full.cpu(), out_path)
     finally:
         # Release the captured graph before tearing the process group down: it holds the
-        # captured NCCL ops, and destroy_process_group() blocks while they are alive.
+        # captured NCCL ops, and destroy_process_group() blocks while they are alive. This
+        # is the scenario release() exists for, and the only place it runs against a real
+        # sharded graph -- dropping the reference and hoping for a collection is the idiom
+        # it replaced. A release() that failed to drop the ops hangs the spawn here.
+        if wrap is not None:
+            wrap.release()
         step_fn = wrap = None
         torch.cuda.synchronize()
         dist.destroy_process_group()
@@ -655,9 +660,92 @@ def test_cudagraph_tracks_scheduled_weight_decay(optimizer_cls):
 def test_float_weight_decay_stays_baked_and_is_not_tensorized():
     # The default path must be untouched: no device tensor, no extra decay pass.
     _, opt = _build(Dion2)
+    opt._sync_hyperparam_tensors()
 
     for group in opt.param_groups:
         assert not isinstance(group["weight_decay"], torch.Tensor)
+    assert all(name != "weight_decay" for _, name in opt._hyperparam_tensors)
+
+
+def test_weight_decay_opt_in_latches_after_construction():
+    # The opt-in is the Tensor, not the moment it is supplied: a group constructed with a
+    # float still opts in if a Tensor is assigned before the graph is captured. Without the
+    # latch the assignment looks like it worked (the group holds a Tensor) while the group
+    # is not tracked, so the kernels read whatever tensor the caller last handed over --
+    # not the one a captured graph recorded.
+    _, opt = _build(Dion2)
+    for group in opt.param_groups:
+        group["weight_decay"] = torch.tensor(0.03, device=DEVICE)
+    opt._sync_hyperparam_tensors()
+
+    for index, group in enumerate(opt.param_groups):
+        assert "weight_decay" in opt._live_hyperparams(index)
+        assert group["weight_decay"] is opt._hyperparam_tensors[(index, "weight_decay")]
+
+    # Latched: a later float assignment refills that tensor rather than turning the group
+    # back into a baked one, which under replay would silently stop tracking.
+    before = [group["weight_decay"] for group in opt.param_groups]
+    for group in opt.param_groups:
+        group["weight_decay"] = 0.01
+    opt._sync_hyperparam_tensors()
+
+    for group, tensor in zip(opt.param_groups, before):
+        assert group["weight_decay"] is tensor
+        assert tensor.item() == pytest.approx(0.01)
+
+
+def test_live_weight_decay_survives_a_resume():
+    # state_dict() serializes every 0-d group tensor as a plain float for portability, so
+    # the resumed groups come back holding floats. The opt-in has to outlive that: a run
+    # resumed onto a baked weight decay would silently stop tracking its schedule.
+    presteps, sched = 3, [0.3 - 0.025 * t for t in range(STEPS)]
+    params, opt = _build_live_wd(Dion2)
+    grad_seq = _grad_seq(params)
+    _run_wds(params, opt, grad_seq[:presteps], opt.step, sched)
+    sd = _roundtrip(opt)
+    assert not isinstance(sd["param_groups"][0]["weight_decay"], torch.Tensor)
+
+    def resume():
+        p, o = _build_live_wd(Dion2)
+        o.load_state_dict(_roundtrip(opt))
+        return p, o
+
+    pg, og = resume()
+    for index, group in enumerate(og.param_groups):
+        assert "weight_decay" in og._live_hyperparams(index)
+        assert group["weight_decay"] is og._hyperparam_tensors[(index, "weight_decay")]
+    wrap = CudaGraphOptimizer(og, warmup_steps=WARMUP)
+    final_graph = _run_wds(pg, og, grad_seq[presteps:], wrap.step, sched[presteps:])
+
+    pe, oe = resume()
+    final_eager = _run_wds(pe, oe, grad_seq[presteps:], oe.step, sched[presteps:])
+
+    diff = max((a - b).abs().max().item() for a, b in zip(final_eager, final_graph))
+    assert diff <= 1e-5, f"resumed graph did not track the weight-decay schedule ({diff:.3e})"
+
+
+def test_opting_in_to_a_live_weight_decay_after_capture_is_an_error():
+    # Too late to honor: the graph baked the float. Raise rather than let the caller's
+    # schedule quietly drive a tensor no replay ever reads.
+    params, opt = _build(Dion2)
+    wrap = CudaGraphOptimizer(opt, warmup_steps=1)
+    for p in params:
+        p.grad = torch.zeros_like(p)
+
+    wrap.step()
+    wrap.step()
+    assert wrap._graph is not None
+
+    opt.param_groups[0]["weight_decay"] = torch.tensor(0.03, device=DEVICE)
+    with pytest.raises(RuntimeError, match="after the CUDA graph was captured"):
+        wrap.step()
+
+    # release() is the documented way through: re-warm, re-capture, and it tracks.
+    wrap.release()
+    wrap.step()
+    wrap.step()
+    assert wrap._graph is not None
+    assert opt.param_groups[0]["weight_decay"] is opt._hyperparam_tensors[(0, "weight_decay")]
 
 
 def test_capture_refuses_a_parameter_without_a_gradient():
@@ -707,3 +795,20 @@ def test_release_drops_the_graph_and_rewarms():
     assert wrap._graph is None
     wrap.step()
     assert wrap._graph is not None
+
+
+def test_release_restarts_the_warmup_before_any_capture():
+    # Documented contract is "drops the graph and restarts the warmup"; with no graph yet
+    # only the second half applies, and skipping it would let the next step capture on a
+    # warmup the caller just invalidated.
+    params, opt = _build(Dion2)
+    wrap = CudaGraphOptimizer(opt, warmup_steps=3)
+    for p in params:
+        p.grad = torch.zeros_like(p)
+
+    wrap.step()
+    wrap.step()
+    assert wrap._graph is None and wrap._step_count == 2
+
+    wrap.release()
+    assert wrap._step_count == 0

--- a/tests/test_cuda_graph.py
+++ b/tests/test_cuda_graph.py
@@ -23,6 +23,12 @@ from dion.cuda_graph import CudaGraphOptimizer
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 pytestmark = pytest.mark.skipif(DEVICE == "cpu", reason="requires CUDA")
 
+# Bump torch.compile cache size to avoid recompilation failures when the same compiled
+# function sees different input shapes and hyperparameter types across tests (matching
+# test_optimizers.py). Exhausting it here is not a soft fallback: a recompile attempted
+# under an active capture aborts the capture outright.
+torch._dynamo.config.cache_size_limit = 64
+
 STEPS, WARMUP, SEED = 12, 3, 0
 DIST_STEPS = 6
 OPTIMIZERS = [Muon, NorMuon, Dion2, NorDion2]
@@ -187,7 +193,7 @@ def test_lr_tensor_identity_is_stable_across_reassignment():
 
     for g in opt.param_groups:
         g["lr"] = 0.007
-    opt._sync_lr_tensors()
+    opt._sync_hyperparam_tensors()
 
     for g, t in zip(opt.param_groups, before):
         assert g["lr"] is t, "LR tensor was replaced instead of filled in place"
@@ -268,7 +274,7 @@ def test_lr_sync_under_active_capture_is_an_error():
         for g in opt.param_groups:
             g["lr"] = 0.5
         with pytest.raises(RuntimeError, match="capture"):
-            opt._sync_lr_tensors()
+            opt._sync_hyperparam_tensors()
     del graph
     torch.cuda.synchronize()
 
@@ -564,3 +570,140 @@ def test_cudagraph_matches_eager_filtered_triton(optimizer_cls):
 
     diff = max((a - b).abs().max().item() for a, b in zip(final_eager, final_graph))
     assert diff <= 1e-5, f"{optimizer_cls.__name__} filtered+triton: capture-vs-eager diff {diff:.3e}"
+
+
+def _build_live_wd(optimizer_cls, weight_decay=0.03):
+    # A Tensor weight_decay is the opt-in: the group then carries it as a persistent device
+    # tensor the kernels read, so filling it in place drives a captured step the way a
+    # scheduled LR does. A plain float stays baked at capture.
+    torch.manual_seed(SEED)
+    weights = [torch.nn.Parameter(torch.randn(64, 128, device=DEVICE)),
+               torch.nn.Parameter(torch.randn(128, 64, device=DEVICE))]
+    biases = [torch.nn.Parameter(torch.randn(64, device=DEVICE)),
+              torch.nn.Parameter(torch.randn(128, device=DEVICE))]
+    opt = optimizer_cls([
+        {"params": weights},
+        {"params": biases, "algorithm": "adamw"},
+    ], distributed_mesh=None, lr=0.02, weight_decay=torch.tensor(weight_decay))
+    return weights + biases, opt
+
+
+def _run_wds(params, opt, grad_seq, step_fn, wds):
+    for p in params:
+        p.grad = torch.zeros_like(p)
+    for t, gs in enumerate(grad_seq):
+        for group in opt.param_groups:
+            group["weight_decay"].fill_(wds[t])
+        for p, g in zip(params, gs):
+            p.grad.copy_(g)
+        step_fn()
+    return [p.detach().clone() for p in params]
+
+
+@pytest.mark.parametrize("optimizer_cls", OPTIMIZERS)
+def test_tensor_weight_decay_is_a_persistent_device_tensor(optimizer_cls):
+    _, opt = _build_live_wd(optimizer_cls)
+
+    for group in opt.param_groups:
+        assert isinstance(group["weight_decay"], torch.Tensor)
+        assert group["weight_decay"].device.type == "cuda"
+
+    # Identity is what replay depends on: a float assignment must refill the tensor the
+    # captured graph reads, never swap in a new one.
+    before = [group["weight_decay"] for group in opt.param_groups]
+    for group in opt.param_groups:
+        group["weight_decay"] = 0.05
+    opt._sync_hyperparam_tensors()
+
+    for group, tensor in zip(opt.param_groups, before):
+        assert group["weight_decay"] is tensor
+        assert tensor.item() == pytest.approx(0.05)
+
+
+@pytest.mark.parametrize("optimizer_cls", OPTIMIZERS)
+def test_cudagraph_tracks_scheduled_weight_decay(optimizer_cls):
+    # Schedule-coupled weight decay (Defazio 2506.02285) rewrites weight_decay every step.
+    # Under replay that must track, not freeze at whatever the capture step happened to see.
+    sched = [0.3 - 0.025 * t for t in range(STEPS)]
+    frozen = [sched[WARMUP]] * STEPS
+
+    p0, _ = _build_live_wd(optimizer_cls)
+    grad_seq = _grad_seq(p0)
+
+    pe, oe = _build_live_wd(optimizer_cls)
+    final_eager = _run_wds(pe, oe, grad_seq, oe.step, sched)
+
+    pg, og = _build_live_wd(optimizer_cls)
+    wrap = CudaGraphOptimizer(og, warmup_steps=WARMUP)
+    final_graph = _run_wds(pg, og, grad_seq, wrap.step, sched)
+
+    pc, oc = _build_live_wd(optimizer_cls)
+    wrapc = CudaGraphOptimizer(oc, warmup_steps=WARMUP)
+    final_frozen = _run_wds(pc, oc, grad_seq, wrapc.step, frozen)
+
+    tracks = max((a - b).abs().max().item() for a, b in zip(final_eager, final_graph))
+    nontrivial = max((a - b).abs().max().item() for a, b in zip(final_graph, final_frozen))
+    assert tracks <= 1e-5, (
+        f"{optimizer_cls.__name__}: graph did not track the weight-decay schedule (diff {tracks:.3e})"
+    )
+    assert nontrivial > 1e-3, (
+        f"{optimizer_cls.__name__}: weight decay looks frozen -- scheduled and capture-step-constant "
+        f"runs agree to {nontrivial:.3e}, so the test would pass even if wd were baked"
+    )
+
+
+def test_float_weight_decay_stays_baked_and_is_not_tensorized():
+    # The default path must be untouched: no device tensor, no extra decay pass.
+    _, opt = _build(Dion2)
+
+    for group in opt.param_groups:
+        assert not isinstance(group["weight_decay"], torch.Tensor)
+
+
+def test_capture_refuses_a_parameter_without_a_gradient():
+    params, opt = _build(Dion2)
+    wrap = CudaGraphOptimizer(opt, warmup_steps=1)
+    for p in params:
+        p.grad = torch.zeros_like(p)
+
+    wrap.step()
+    params[0].grad = None
+
+    with pytest.raises(RuntimeError, match="never update them"):
+        wrap.step()
+
+
+def test_capture_allows_a_parameter_that_is_frozen_on_purpose():
+    params, opt = _build(Dion2)
+    wrap = CudaGraphOptimizer(opt, warmup_steps=1)
+    for p in params:
+        p.grad = torch.zeros_like(p)
+
+    wrap.step()
+    params[0].grad = None
+    params[0].requires_grad_(False)
+
+    wrap.step()
+    assert wrap._graph is not None
+
+
+def test_release_drops_the_graph_and_rewarms():
+    params, opt = _build(Dion2)
+    wrap = CudaGraphOptimizer(opt, warmup_steps=1)
+    for p in params:
+        p.grad = torch.zeros_like(p)
+
+    wrap.step()
+    wrap.step()
+    assert wrap._graph is not None
+
+    wrap.release()
+    assert wrap._graph is None
+    assert wrap._step_count == 0
+
+    # Releasing twice is a no-op, and the next steps warm up before capturing again.
+    wrap.release()
+    wrap.step()
+    assert wrap._graph is None
+    wrap.step()
+    assert wrap._graph is not None


### PR DESCRIPTION
## What

Three gaps found while integrating `CudaGraphOptimizer` (#104) into a Lightning + FSDP2 trainer. Each fails silently or hangs rather than erroring, which is the worst shape for an optimizer feature that is on by default downstream.

### 1. `release()` — the graph could not be dropped without side effects

The module already documented that the graph must be dropped before `dist.destroy_process_group()`: on the sharded path it holds the captured megabatch all-to-all, and destroy blocks while those NCCL ops are alive. But it exposed no way to do it — the only `_graph = None` sites were inside `add_param_group` and `load_state_dict`, so an integration had to reach for the private attribute.

Under Lightning the hang is real and un-interruptible: `Strategy.teardown()` only runs `_optimizers_to_device(..., cpu)` and keeps the optimizers alive, and `lightning.fabric.utilities.distributed` registers `destroy_process_group()` via `atexit` **with SIGINT masked**. A finished sharded run trains fine, then wedges at worker exit until something external kills it.

`release()` also restarts the warmup, so a later capture is not taken with buffers that whatever prompted the release may have invalidated.

### 2. Capture refuses a `requires_grad` param with `.grad=None`

The step only touches params that have a gradient, so capture freezes the participating set — a param starved of gradients through the warmup steps is left out of the graph and **silently stops being updated for the rest of the run**. #104 documented this as a caveat with no enforcement.

It is not hypothetical. A VLM config with a text/vision modality cadence (`[{text: N}, {mixed: 1}]`) runs no vision forward on text steps; any `N` past `warmup_steps` freezes the whole vision tower. Expert routing that skips an expert during warmup does the same.

Now a loud error naming the count, with `requires_grad=False` as the escape hatch for params that are genuinely frozen. One host-side pass over the groups, once, at capture.

### 3. Live `weight_decay`, opt-in via a Tensor

`lr` was the only group hyperparameter read live under replay. `weight_decay` reached the kernels through `torch.tensor(group["weight_decay"])` — a fresh host scalar, whose value a CUDA op lifts into the kernel's launch args and bakes at capture.

Schedule-coupled weight decay ([Defazio 2506.02285](https://arxiv.org/abs/2506.02285), AdamC / Muon-C) rescales `weight_decay` with the LR every step. Under capture it froze at the capture-step value; captured during LR warmup, that is a small fraction of the intended decay, for the entire run, with no error. Measured on an H100 against `main`, reproducing the exact expression the kernels use:

```
captured with wd=0.5, lr=1.0     -> x=0.500
after group['weight_decay']=0.0  -> x=0.500   FROZEN
after group['lr'].fill_(0.5)     -> x=0.750   live
```

Passing a Tensor (`weight_decay=torch.tensor(0.01)`) now carries it as a persistent device tensor like the LR, so filling it in place drives a captured step.

**Why opt-in rather than default:** the AdamW scalar path cannot pass a tensor through `torch._fused_adamw_` — `weight_decay` is a `float` in both overloads (`default` and `tensor_lr`), unlike `lr`. So a live weight decay is applied as its own `_foreach_mul_` pass with the kernel handed `wd=0`. Mathematically the same decoupled update, but it rounds `X` once more: measured max|diff| vs. the fused path is 7e-07 in fp32 and 2e-02 (~2 ulp) in bf16. A float `weight_decay` keeps the fused path bit-for-bit as before, so nobody pays for a feature they are not using.

## Implementation note

The LR-tensor machinery generalizes to `(group, name)` rather than gaining a parallel copy: `_ensure_lr_tensor` / `_sync_lr_tensors` become `_ensure_hyperparam_tensor` / `_sync_hyperparam_tensors`, and `_live_hyperparams` decides once per group which names are carried live (before a later reassignment can hide the opt-in). Every other group scalar (`mu`, `beta1`, `epsilon`, …) is still baked at capture, and the module docstring now says so explicitly instead of leaving it to be inferred from the LR discussion.

## Tests

12 new cases in `tests/test_cuda_graph.py`:

- scheduled weight decay tracked under replay for all four optimizers, with a frozen-wd control so the test cannot pass trivially (the same shape as the existing scheduled-LR test);
- weight-decay tensor identity preserved across a `group["weight_decay"] = 0.05` float reassignment;
- the float path staying untensorized;
- capture refused for a grad-less param, allowed for an explicitly frozen one;
- `release()` dropping the graph, being a no-op twice, and re-warming before the next capture.

Full suite on an H100: **283 passed**, with the same 9 pre-existing multi-GPU / empty-shard failures as `main` at dcfc3c8 (verified by running both, failure sets identical).

`test_cuda_graph.py` needed the `torch._dynamo.config.cache_size_limit` bump that `test_optimizers.py`, `test_newton_shulz.py` and `test_dion2_post_ortho_triton.py` already carry. Worth flagging that exhausting it is not a soft fallback here: a recompile attempted under an active capture aborts the capture outright, which is how the limit surfaced.
