### PR TITLE
cuda_graph: name load_state_dict's parameter state_dict so DCP resume works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ All notable changes to this project are documented in this file.
 
 ### Fixed
 
+- `CudaGraphOptimizer.load_state_dict` named its parameter `sd`, so every distributed
+  checkpoint resume raised `TypeError: got an unexpected keyword argument 'state_dict'`.
+  torch's DCP calls it by keyword (`_load_optim_state_dict` does
+  `_state_dict_fn(optim, "load_state_dict")(state_dict=...)`), so a wrapped optimizer
+  could train but never resume under FSDP2. The parameter now matches
+  `torch.optim.Optimizer`, and a test asserts the wrapper's parameter *names* match the
+  base class for every overridden method, since substituting for an Optimizer means
+  callers may use any name the base class documents.
+
 - `adamw_update_foreach` dropped the cautious-weight-decay correction entirely when it
   was given a device-tensor `weight_decay` on the legacy (`step=`) path: the kernel is
   handed `weight_decay=0` there, and the correction was scaled by that float, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,10 @@ All notable changes to this project are documented in this file.
   torch's DCP calls it by keyword (`_load_optim_state_dict` does
   `_state_dict_fn(optim, "load_state_dict")(state_dict=...)`), so a wrapped optimizer
   could train but never resume under FSDP2. The parameter now matches
-  `torch.optim.Optimizer`, and a test asserts the wrapper's parameter *names* match the
-  base class for every overridden method, since substituting for an Optimizer means
-  callers may use any name the base class documents.
+  `torch.optim.Optimizer`, and a test asserts the wrapper's parameter *names and kinds*
+  match the base class for every overridden method (the set is discovered, not listed),
+  since substituting for an Optimizer means callers may use any name the base class
+  documents and may pass it positionally or by keyword.
 
 - `adamw_update_foreach` dropped the cautious-weight-decay correction entirely when it
   was given a device-tensor `weight_decay` on the legacy (`step=`) path: the kernel is

--- a/dion/cuda_graph.py
+++ b/dion/cuda_graph.py
@@ -158,10 +158,14 @@ class CudaGraphOptimizer(torch.optim.Optimizer):
     def state_dict(self):
         return self.optimizer.state_dict()
 
-    def load_state_dict(self, sd):
+    def load_state_dict(self, state_dict):
+        # The parameter name is load-bearing, not cosmetic: torch's distributed checkpointing
+        # calls this as ``load_state_dict(state_dict=...)`` by keyword
+        # (torch/distributed/checkpoint/state_dict.py::_load_optim_state_dict), so any other
+        # name is a TypeError on every DCP resume. Match torch.optim.Optimizer exactly.
         # Loading new state invalidates any captured graph (buffers may move).
         self.release()
-        return self.optimizer.load_state_dict(sd)
+        return self.optimizer.load_state_dict(state_dict)
 
     def zero_grad(self, set_to_none: bool = False):
         # set_to_none=True would swap .grad for a fresh tensor each step, breaking the

--- a/tests/test_cuda_graph.py
+++ b/tests/test_cuda_graph.py
@@ -812,3 +812,31 @@ def test_release_restarts_the_warmup_before_any_capture():
 
     wrap.release()
     assert wrap._step_count == 0
+
+
+def test_load_state_dict_accepts_the_state_dict_keyword():
+    # torch's distributed checkpointing calls this by keyword --
+    # `_state_dict_fn(optim, "load_state_dict")(state_dict=...)` in
+    # torch/distributed/checkpoint/state_dict.py::_load_optim_state_dict -- so a wrapper that
+    # renames the parameter is a TypeError on every DCP resume, which is every sharded run.
+    params, opt = _build(Dion2)
+    _run(params, opt, _grad_seq(params)[:2], opt.step)
+    sd = _roundtrip(opt)
+
+    params, opt = _build(Dion2)
+    wrap = CudaGraphOptimizer(opt, warmup_steps=WARMUP)
+    wrap.load_state_dict(state_dict=sd)
+
+    assert wrap.param_groups[0]["step"] == opt.param_groups[0]["step"]
+
+
+@pytest.mark.parametrize("name", ["load_state_dict", "state_dict", "add_param_group", "zero_grad", "step"])
+def test_optimizer_api_parameter_names_match_torch(name):
+    # Same class of bug as the DCP keyword call above: the wrapper substitutes for a
+    # torch.optim.Optimizer, so callers may use any parameter name the base class documents.
+    import inspect
+
+    base = inspect.signature(getattr(torch.optim.Optimizer, name))
+    wrapper = inspect.signature(getattr(CudaGraphOptimizer, name))
+
+    assert list(wrapper.parameters) == list(base.parameters)

--- a/tests/test_cuda_graph.py
+++ b/tests/test_cuda_graph.py
@@ -11,6 +11,7 @@ check that the wrapper is numerically correct:
   tensor the optimizer reads and the wrapper refreshes before each replay -- rather than
   freezing at the capture-time value.
 """
+import inspect
 import io
 import os
 
@@ -819,24 +820,53 @@ def test_load_state_dict_accepts_the_state_dict_keyword():
     # `_state_dict_fn(optim, "load_state_dict")(state_dict=...)` in
     # torch/distributed/checkpoint/state_dict.py::_load_optim_state_dict -- so a wrapper that
     # renames the parameter is a TypeError on every DCP resume, which is every sharded run.
-    params, opt = _build(Dion2)
-    _run(params, opt, _grad_seq(params)[:2], opt.step)
-    sd = _roundtrip(opt)
+    params, source = _build(Dion2)
+    _run(params, source, _grad_seq(params)[:2], source.step)
+    sd = _roundtrip(source)
+    saved_step = source.param_groups[0]["step"]
 
     params, opt = _build(Dion2)
     wrap = CudaGraphOptimizer(opt, warmup_steps=WARMUP)
+    fresh_step = wrap.param_groups[0]["step"]
     wrap.load_state_dict(state_dict=sd)
 
-    assert wrap.param_groups[0]["step"] == opt.param_groups[0]["step"]
+    # Against the *source* optimizer, not against `opt`: `wrap.param_groups` is
+    # `opt.param_groups` by identity, so asserting those two agree holds whether or not the
+    # keyword call loaded anything. Pinning the fresh value too keeps it that way if a later
+    # checkpoint happens to be taken at step 0.
+    assert saved_step != fresh_step
+    assert wrap.param_groups[0]["step"] == saved_step
 
 
-@pytest.mark.parametrize("name", ["load_state_dict", "state_dict", "add_param_group", "zero_grad", "step"])
-def test_optimizer_api_parameter_names_match_torch(name):
+# Discovered rather than listed: the point of the check below is to catch the *next*
+# signature drift, which may well be in a method overridden after this test was written.
+# ``release`` is not on Optimizer and ``param_groups`` is a property, so both drop out.
+OVERRIDDEN_OPTIMIZER_METHODS = sorted(
+    name
+    for name, attr in vars(CudaGraphOptimizer).items()
+    if callable(attr) and not name.startswith("_") and hasattr(torch.optim.Optimizer, name)
+)
+
+
+def test_the_signature_check_covers_the_overrides():
+    # A parametrize over an empty list collects zero tests and reports success, so a broken
+    # predicate above would silently retire the check. Pin that discovery found something.
+    assert "load_state_dict" in OVERRIDDEN_OPTIMIZER_METHODS, OVERRIDDEN_OPTIMIZER_METHODS
+
+
+@pytest.mark.parametrize("name", OVERRIDDEN_OPTIMIZER_METHODS)
+def test_optimizer_api_signatures_match_torch(name):
     # Same class of bug as the DCP keyword call above: the wrapper substitutes for a
-    # torch.optim.Optimizer, so callers may use any parameter name the base class documents.
-    import inspect
-
+    # torch.optim.Optimizer, so callers may use any parameter name the base class documents,
+    # and may pass it positionally or by keyword. Names alone do not pin that -- a
+    # keyword-only ``load_state_dict(self, *, state_dict)`` or a positional-only
+    # ``zero_grad(self, set_to_none, /)`` keeps every name and still breaks half the callers,
+    # which is the same failure this bug was -- so pin the parameter kinds with them.
+    # Defaults deliberately are not pinned: zero_grad's set_to_none defaults to False here
+    # against torch's True, because replay needs stable .grad buffers.
     base = inspect.signature(getattr(torch.optim.Optimizer, name))
     wrapper = inspect.signature(getattr(CudaGraphOptimizer, name))
 
-    assert list(wrapper.parameters) == list(base.parameters)
+    assert [(p.name, p.kind) for p in wrapper.parameters.values()] == [
+        (p.name, p.kind) for p in base.parameters.values()
+    ]


### PR DESCRIPTION
## What

`CudaGraphOptimizer.load_state_dict` named its parameter `sd`. torch's distributed checkpointing calls the optimizer **by keyword**:

```python
# torch/distributed/checkpoint/state_dict.py::_load_optim_state_dict
_state_dict_fn(optim, "load_state_dict")(state_dict=optim_state_dict)
```

so every DCP resume of a wrapped optimizer died with:

```
TypeError: CudaGraphOptimizer.load_state_dict() got an unexpected keyword argument 'state_dict'
```

A wrapped run could train fine and then never resume — and under FSDP2 that is every production run. `torch.optim.Optimizer.load_state_dict(self, state_dict)` is the signature DCP relies on; the fix is to match it.

## How it was found

A Lightning + FSDP2 resume gate on a 1B config (`nordion2`, `fraction=0.5`): train 0→30, exit the process, resume 30→60. The eager and continuous-capture arms passed; the resumed arm crashed in `_restore_modules_and_callbacks` before step 1.

Not by the existing tests — every one of them calls `load_state_dict` positionally, including the resume tests, which is precisely the shape that hides a keyword-only mismatch.

## Tests

Two, and the second is the one that matters beyond this bug:

- `test_load_state_dict_accepts_the_state_dict_keyword` — calls it the way DCP does.
- `test_optimizer_api_parameter_names_match_torch` — parametrized over every overridden method (`load_state_dict`, `state_dict`, `add_param_group`, `zero_grad`, `step`), asserting the wrapper's parameter *names* match `torch.optim.Optimizer`. The class subclasses Optimizer specifically so frameworks accept it, which means callers may use any parameter name the base class documents; pinning the names stops the next rename from reintroducing this in a different method.

Both fail against the bug (verified by reverting the rename) and pass with it fixed. Full suite on an H100: 80 passed in the touched files, no change elsewhere.
