### PR TITLE
Add dion3 as an alias for nordion2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project are documented in this file.
 
 ### Added
 
+- `NorDion2` is now also available as `Dion3` (`from dion import Dion3`, or
+  `from dion.dion3 import Dion3`), and `train.py` accepts `--optimizer dion3`
+  alongside `--optimizer nordion2`. NorDion2 is the third-generation Dion update
+  — Dion2's submatrix selection and error feedback with NorMuon's per-neuron
+  normalization — so it is exposed under the dion3 name too. This is purely
+  additive: `Dion3` is an alias, not a subclass (`Dion3 is NorDion2`), so the
+  two names are interchangeable including for `isinstance`. Parameter groups
+  keep using `algorithm="nordion2"` under either name — that string keys
+  optimizer state and megabatch grouping and is written into
+  `state_dict()["param_groups"]`, so existing checkpoints and param groups load
+  unchanged.
+
 - `CudaGraphOptimizer.release()` drops the captured graph (and restarts the warmup,
   so a later capture is not taken with cold buffers). On the sharded path the graph
   holds the captured megabatch all-to-all, and `dist.destroy_process_group()` blocks

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ We include optimizer implementations in the `dion/` directory of this repo.
 * `muon.py`: High-performance version of Muon. For sharded matrices, all-to-all communication is used to simultaneously unshard and distribute a batch of matrices. For replicated matrices, Muon will distribute work across all devices and all-gather final results.
 * **`dion2.py`**: High-performance implementation of Dion2, using a similar all-to-all communication pattern for distributed orthonormalization. Only an α-fraction of the momentum matrix is communicated and orthonormalized, significantly reducing both communication overhead and computation cost.
 * `normuon.py`: A variant of the Muon optimizer that introduces neuron-wise normalization to improve stability and convergence efficiency, modified to take similar arguments as `muon.py`. See [the paper](https://arxiv.org/abs/2510.05491) for more details.
+* `nordion2.py`: Combines the two above, applying Dion2's submatrix selection and error feedback to the NorMuon update. As the third-generation Dion update, it is also exported under the name `Dion3` (`from dion import Dion3`). This is an alias rather than a subclass, so `Dion3 is NorDion2` and the two names are fully interchangeable; likewise `--optimizer dion3` and `--optimizer nordion2` are equivalent in `train.py`. Parameter groups use `algorithm="nordion2"` under either name.
 
 We also provide some reference implementations:
 

--- a/dion/__init__.py
+++ b/dion/__init__.py
@@ -7,3 +7,4 @@ from .muon_reference import Muon as MuonReference
 from .dion2 import Dion2
 from .normuon import NorMuon
 from .nordion2 import NorDion2
+from .dion3 import Dion3  # alias for NorDion2

--- a/dion/dion3.py
+++ b/dion/dion3.py
@@ -1,0 +1,16 @@
+"""Dion3: an additional public name for the NorDion2 optimizer.
+
+NorDion2 is the third-generation Dion update -- Dion2's submatrix selection and
+error feedback with NorMuon's per-neuron normalization -- so it is also exposed
+as ``Dion3``. This is an alias, not a subclass: ``Dion3 is NorDion2``, so the
+two names are interchangeable everywhere, including ``isinstance`` checks. The
+implementation lives in ``dion/nordion2.py``.
+
+Parameter groups keep using ``algorithm="nordion2"`` under either name. That
+string keys the optimizer state and megabatch grouping (see
+``DistributedOrthoBase.step``) and is written into
+``state_dict()["param_groups"]``, so it stays the internal identifier and
+existing checkpoints load unchanged.
+"""
+
+from .nordion2 import NorDion2 as Dion3

--- a/tests/test_dion3_alias.py
+++ b/tests/test_dion3_alias.py
@@ -1,0 +1,94 @@
+"""Dion3 is an additive alias for NorDion2, not a separate optimizer.
+
+These tests pin the three things that make the alias an alias rather than a
+fork: the class identity (so ``isinstance`` and checkpoints do not care which
+name was used), the internal ``algorithm="nordion2"`` param-group identifier
+(which keys optimizer state and is written into ``state_dict()``), and
+``train.py``'s ``--optimizer`` string accepting both names. The existing
+NorDion2 tests in ``test_optimizers.py`` cover the behavior itself.
+"""
+
+import argparse
+import pytest
+import torch
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+CUDA_AVAILABLE = torch.cuda.is_available()
+
+
+def test_dion3_is_nordion2():
+    """The alias must be the same class object, not a subclass or a copy."""
+    from dion import Dion3, NorDion2
+
+    assert Dion3 is NorDion2
+
+
+def test_dion3_module_and_package_exports_agree():
+    """``dion.dion3`` and ``dion`` must export the same object."""
+    import dion
+    from dion.dion3 import Dion3
+    from dion.nordion2 import NorDion2
+
+    assert Dion3 is NorDion2
+    assert dion.Dion3 is Dion3
+
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA required")
+def test_dion3_runs_and_keeps_nordion2_algorithm():
+    """Constructing via the alias yields a NorDion2 with unchanged state keys.
+
+    ``algorithm`` is a param-group key compared against ``self._algo_name`` in
+    ``DistributedOrthoBase.step`` and saved in ``state_dict()["param_groups"]``,
+    so the alias must not introduce a second identifier.
+    """
+    from dion import Dion3, NorDion2
+
+    torch.manual_seed(42)
+    params = [torch.nn.Parameter(torch.randn(64, 128, device=DEVICE))]
+    opt = Dion3(params, lr=0.01)
+    assert isinstance(opt, NorDion2)
+    assert opt.param_groups[0]["algorithm"] == "nordion2"
+
+    params[0].grad = torch.randn_like(params[0])
+    opt.step()
+    assert opt.state[params[0]].keys() >= {"momentum", "variance_neuron"}
+    assert opt.state_dict()["param_groups"][0]["algorithm"] == "nordion2"
+
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA required")
+@pytest.mark.parametrize("optimizer_name", ["nordion2", "dion3"])
+def test_train_optimizer_string_builds_nordion2(optimizer_name):
+    """``--optimizer dion3`` must select the same optimizer as ``nordion2``.
+
+    Mirrors ``init_optimizer``'s DDP path, which only reads
+    ``ddp_model.process_group``, so a stub stands in for a real DDP wrapper.
+    """
+    pytest.importorskip("wandb", reason="train.py deps need the dion[train] extra")
+    import train
+    from dion import NorDion2
+
+    class _StubModel(torch.nn.Module):
+        """Minimal stand-in exposing the attributes init_optimizer reads."""
+
+        def __init__(self):
+            super().__init__()
+            self.transformer = torch.nn.Module()
+            self.transformer.h = torch.nn.Linear(64, 64, bias=False)
+            self.transformer.wte = torch.nn.Embedding(32, 64)
+            self.lm_head = torch.nn.Linear(64, 32, bias=False)
+
+    hp = train.Hyperparameters(optimizer=optimizer_name, scalar_opt="adamw")
+    cli_args = argparse.Namespace(
+        use_gram_newton_schulz=False, no_triton=True, use_polar_express=True
+    )
+    ddp_model = argparse.Namespace(process_group=None)
+
+    opt = train.init_optimizer(
+        model=_StubModel().to(DEVICE),
+        device_mesh=None,
+        ddp_model=ddp_model,
+        hp=hp,
+        cli_args=cli_args,
+    )
+    assert type(opt) is NorDion2
+    assert opt.param_groups[0]["algorithm"] == "nordion2"

--- a/tests/test_dion3_alias.py
+++ b/tests/test_dion3_alias.py
@@ -10,10 +10,37 @@ NorDion2 tests in ``test_optimizers.py`` cover the behavior itself.
 
 import argparse
 import pytest
+import sys
 import torch
+
+from pathlib import Path
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 CUDA_AVAILABLE = torch.cuda.is_available()
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _import_train():
+    """Import the top-level ``train`` module, or skip if it is unavailable.
+
+    ``train.py`` sits at the repo root and is deliberately not part of the
+    installed package (``setup.py`` packages only ``dion*``), so it is importable
+    only when the repo root is on ``sys.path``. That happens by accident under
+    ``python -m pytest`` from the repo root, but not under a bare ``pytest`` or
+    from any other working directory -- so put the repo root on the path
+    explicitly rather than depending on how the suite was invoked.
+
+    ``importorskip`` then covers train.py's optional imports as a set (``wandb``,
+    ``yaml``, ``tqdm``), which ship with the ``dion[train]`` extra and not with
+    ``dion[dev]``. Guarding on any single one of them would let the others turn a
+    dev-only install into an error instead of a skip.
+    """
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    return pytest.importorskip(
+        "train", reason="train.py and its deps need the dion[train] extra"
+    )
 
 
 def test_dion3_is_nordion2():
@@ -63,8 +90,7 @@ def test_train_optimizer_string_builds_nordion2(optimizer_name):
     Mirrors ``init_optimizer``'s DDP path, which only reads
     ``ddp_model.process_group``, so a stub stands in for a real DDP wrapper.
     """
-    pytest.importorskip("wandb", reason="train.py deps need the dion[train] extra")
-    import train
+    train = _import_train()
     from dion import NorDion2
 
     class _StubModel(torch.nn.Module):

--- a/train.py
+++ b/train.py
@@ -502,11 +502,14 @@ def init_optimizer(
             use_polar_express=cli_args.use_polar_express,
         )
 
-    elif hp.optimizer == "nordion2":
+    elif hp.optimizer in ("nordion2", "dion3"):
+        # Dion3 is an alias for NorDion2, so both names build the same optimizer.
+        # Print out whichever name was requested.
+        opt_name = "Dion3" if hp.optimizer == "dion3" else "NorDion2"
         if device_mesh is not None:
             # Ensure that we have a supported device mesh configuration for NorDion2
             if inner_shard_mesh is not None and inner_shard_mesh.size() > 1:
-                raise ValueError("Tensor parallel is not supported by NorDion2.")
+                raise ValueError(f"Tensor parallel is not supported by {opt_name}.")
             distributed_mesh = (
                 outer_shard_mesh if outer_shard_mesh.size() > 1 else replicate_mesh
             )
@@ -515,9 +518,9 @@ def init_optimizer(
             assert ddp_model is not None
             distributed_mesh = ddp_model.process_group  # using ProcessGroup for DDP
             comm_method = "all-gather"
-        print0(f"NorDion2 LR adjust method: {hp.adjust_lr}")
+        print0(f"{opt_name} LR adjust method: {hp.adjust_lr}")
         print0(f"Triton Newton-Schulz kernels: {not cli_args.no_triton}")
-        print0(f"Distributed NorDion2 using: {comm_method}")
+        print0(f"Distributed {opt_name} using: {comm_method}")
         opt = NorDion2(
             param_groups,
             distributed_mesh=distributed_mesh,


### PR DESCRIPTION
## What

Makes the `nordion2` optimizer available under the name `dion3` as well. NorDion2 is
the third-generation Dion update — Dion2's submatrix selection and error feedback with
NorMuon's per-neuron normalization — so this exposes it under the dion3 name too.

This is an **additive alias**, not a rename: every existing `nordion2` entry point keeps
working identically.

## Scope

**Class alias.** `Dion3` is an alias, not a subclass — `Dion3 is NorDion2` — so the two
names are fully interchangeable, including for `isinstance` checks and for checkpoints.
It is defined once in a thin `dion/dion3.py` (matching the repo's one-module-per-optimizer
layout, so `from dion.dion3 import Dion3` works like `from dion.nordion2 import NorDion2`)
and re-exported from `dion/__init__.py` alongside `NorDion2`:

```python
from dion import Dion3          # or: from dion.dion3 import Dion3
assert Dion3 is NorDion2
```

**`--optimizer` string.** `train.py`'s branch is now
`elif hp.optimizer in ("nordion2", "dion3"):`. The NorDion2 device-mesh validation,
comm-method selection, and constructor call are unchanged; only the user-facing prints
were touched, so they report whichever name was actually passed (`Dion3 LR adjust
method: ...` vs `NorDion2 LR adjust method: ...`). No config files change. `run_name`
already keys on `"dion" in hp.optimizer`, which matches `dion3` without a change.

**Docs.** A `nordion2.py` bullet in the README's optimizer-module list noting the `Dion3`
alias, plus a CHANGELOG entry under `[Unreleased] / Added`.

## Internal identifier decision: keep `algorithm="nordion2"`

Parameter groups keep using `algorithm="nordion2"` under both names. This is deliberate —
the identifier is load-bearing, not cosmetic:

* `DistributedOrthoBase.step` dispatches on `group["algorithm"] == self._algo_name`, and
  `_get_or_initialize_state` / `_create_ortho_tasks` key state and megabatch grouping off
  the same name.
* It lives in `defaults`, so it is written into `state_dict()["param_groups"]` and read
  back on resume.
* Users may pass `algorithm="nordion2"` explicitly when building param groups.

Since dion3 *is* nordion2, changing the identifier would break checkpoint resume and
user-supplied param groups for zero benefit. `dion3` is a public/API alias only.

## Tests

New `tests/test_dion3_alias.py` pins what makes this an alias rather than a fork:

* `Dion3 is NorDion2`, and `dion.Dion3` / `dion.dion3.Dion3` agree.
* Constructing via `Dion3` yields a `NorDion2` whose param group and `state_dict()` still
  carry `algorithm="nordion2"`, and whose state keys are unchanged.
* `init_optimizer` builds a `NorDion2` for both `--optimizer nordion2` and
  `--optimizer dion3` (parametrized).

`train.py` sits at the repo root and is deliberately not part of the installed package
(`setup.py` packages only `dion*`), so the test resolves the repo root from `__file__`
and puts it on `sys.path` rather than relying on `python -m pytest` from the repo root
to have put `''` there — otherwise a bare `pytest`, or a run from another directory,
raises `ModuleNotFoundError`. It then `importorskip`s `train` itself, which covers
train.py's optional imports as a set (`wandb`, `yaml`, `tqdm` — all `dion[train]`, not
`dion[dev]`), so a dev-only install skips rather than errors. Verified under
`python -m pytest` from the repo root, under a bare `pytest`, and from a different
working directory.

`pytest tests/test_optimizers.py` passes (95 passed), as do
`tests/test_dion3_alias.py`, `tests/test_state_prepopulation.py`, and
`tests/test_dion2_selection_scope.py`.
