### PR TITLE
NorMuon: apply split_sizes lr scales after normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,27 @@ All notable changes to this project are documented in this file.
 
 ### Fixed
 
+- NorMuon gave `split_sizes` row blocks the wrong learning rate on the FSDP2 sharded
+  path (reported in #111). The per-block correction `adjust(block) / adjust(full)` was
+  multiplied into each block right after Newton-Schulz, but NorMuon's normalization
+  then divides by `sqrt(V)` — an EMA of that same scaled update, so the factor cancels
+  — and rescales to the Frobenius norm of its input, which reintroduces the factor only
+  where that rescale is per block. Under FSDP the rescale is shard-local, so any shard
+  spanning a block boundary applied one blended factor to all its rows: with a fused
+  QKV weight `(4096, 512, 512) x 4096` and `adjust_lr="spectral_norm"`, the K and V
+  blocks ran at up to ~1.8x their intended learning rate, silently and with no warning,
+  matching the "converges faster, then diverges" report. The scales are now applied
+  after the normalization, per row block of each rank's shard (block boundaries are
+  derivable locally because `split_sizes` already requires dim 0 to be divisible by the
+  world size), so the learning rate is exact per block on every path and no longer
+  depends on the normalization commuting with it. Only the norm-preserving rescale
+  remains shard-local under FSDP. Muon was never affected — it has no normalization
+  step after the scales. Unsharded results are unchanged. The variance buffer `V` now
+  tracks the *unscaled* update, so its scale differs from checkpoints written by earlier
+  versions by `(adjust(block) / adjust(full))**2` per block; the update is invariant to a
+  constant rescale of `V` (it cancels between the division and the norm-preserving
+  rescale), so old checkpoints resume without a correction.
+
 - `CudaGraphOptimizer.load_state_dict` named its parameter `sd`, so every distributed
   checkpoint resume raised `TypeError: got an unexpected keyword argument 'state_dict'`.
   torch's DCP calls it by keyword (`_load_optim_state_dict` does

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ param_groups = [
 
 Each block receives the same update it would as a separate parameter: Newton-Schulz, the learning-rate adjustment (`spectral_norm` / `rms_norm`), and NorMuon's norm-preserving rescale are all computed per block. Blocks of equal size (e.g. K and V) are batched into one Newton-Schulz call. The split happens on the fully assembled matrices after the FSDP all-to-all, so the communication pattern is unchanged from the fused parameter.
 
-Requirements: the parameter must be 2D, `split_sizes` must sum to dim 0, and with FSDP dim 0 must be divisible by the world size (so the assembled matrices contain no padding rows). `split_sizes` is mutually exclusive with `num_heads`. With FSDP, NorMuon's norm-preserving rescale operates on local shards (the existing distributed behavior) rather than per block.
+Requirements: the parameter must be 2D, `split_sizes` must sum to dim 0, and with FSDP dim 0 must be divisible by the world size (so the assembled matrices contain no padding rows). `split_sizes` is mutually exclusive with `num_heads`. With FSDP, NorMuon's norm-preserving rescale operates on local shards (the existing distributed behavior) rather than per block; the per-block learning-rate adjustment is exact on every path, because NorMuon applies it after that rescale.
 
 ## Distributed Training Configuration
 

--- a/dion/megabatch_base.py
+++ b/dion/megabatch_base.py
@@ -961,7 +961,9 @@ def compute_split_lr_scales(
     from the whole (fused) matrix shape. Each block of a split parameter
     should instead see the adjustment its own shape would receive as a
     separate parameter, so each block is rescaled by
-    ``adjust(block_shape) / adjust(full_shape)`` after Newton-Schulz.
+    ``adjust(block_shape) / adjust(full_shape)``. Muon applies the scales
+    inside Newton-Schulz (``split_scales`` here); NorMuon applies them after
+    its normalization instead, via ``local_split_row_scales`` below.
     Returns ``None`` when ``adjust_lr`` is None (no shape-dependent scaling).
     """
     if adjust_lr is None:
@@ -979,6 +981,36 @@ def compute_split_lr_scales(
         adjust_fn(1.0, (rows, num_cols), flatten=False) / full_adjust
         for rows in split_sizes
     )
+
+
+def local_split_row_scales(
+    split_sizes: Tuple[int, ...],
+    split_scales: Optional[Tuple[float, ...]],
+    row_offset: int,
+    num_rows: int,
+) -> List[Tuple[int, int, float]]:
+    """
+    Per-block learning-rate scales restricted to one rank's row shard.
+
+    ``split_scales`` is indexed by row block of the whole (fused) matrix, but a
+    caller that applies the scales after the all-to-all holds only rows
+    ``[row_offset, row_offset + num_rows)``. Returns ``(start, end, scale)``
+    triples in local row coordinates for the blocks intersecting this shard,
+    skipping unit scales. A block may straddle a shard boundary, so a shard can
+    carry a partial block, and a shard can carry rows of several blocks.
+    """
+    if split_scales is None:
+        return []
+    result = []
+    block_start = 0
+    for size, scale in zip(split_sizes, split_scales):
+        block_end = block_start + size
+        start = max(block_start, row_offset)
+        end = min(block_end, row_offset + num_rows)
+        if end > start and scale != 1.0:
+            result.append((start - row_offset, end - row_offset, scale))
+        block_start = block_end
+    return result
 
 
 def adjust_lr_rms_norm(lr, param_shape, flatten):

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -12,6 +12,7 @@ from .megabatch_base import (
     adjust_lr_spectral_norm,
     adjust_lr_rms_norm,
     compute_split_lr_scales,
+    local_split_row_scales,
 )
 from .opt_utils import AsyncTask, as_scalar_tensor, to_local
 from .muon import muon_update_pre_orthogonalize, muon_update_post_orthogonalize
@@ -53,8 +54,10 @@ class NorMuon(DistributedOrthoBase):
     separate Q, K, and V blocks, which may have unequal sizes under GQA).
     Newton-Schulz, the learning-rate adjustment, and the NorMuon norm rescale
     run per block, matching the update that separate per-block parameters
-    would receive, while the model keeps the single wide GEMM. See the README
-    for details.
+    would receive, while the model keeps the single wide GEMM. Under FSDP the
+    norm rescale is still shard-local (the existing distributed approximation),
+    but the learning-rate adjustment is exact per block. See the README for
+    details.
 
     Muon optimizer algorithm by Keller Jordan: https://kellerjordan.github.io/posts/muon/
     FSDP2 Muon uses all-to-all communications: https://www.essential.ai/blog/infra
@@ -272,12 +275,17 @@ def normuon_update_megabatch_async(
         global_comm_dim_size = None
 
     # Orthogonalize via shared megabatch communication. With split_sizes, each
-    # row block is orthogonalized independently and rescaled by split_scales,
-    # which converts the whole-matrix adjusted_lr applied below into the
-    # per-block adjustment that separate parameters would receive. The scales
-    # commute through the normalization below: a uniform per-block scale
-    # propagates self-consistently into the variance buffer and the per-block
-    # Frobenius rescale, so the normalized update is scaled by the same factor.
+    # row block is orthogonalized independently. split_scales -- which converts
+    # the whole-matrix adjusted_lr applied below into the per-block adjustment
+    # that separate parameters would receive -- is deliberately NOT applied
+    # here: the normalization below divides U by sqrt(V) and rescales it back
+    # to the Frobenius norm of its own input, so a per-block factor applied
+    # before it cancels in the division and re-enters only through that norm.
+    # That reproduces the factor only when the rescale is per block, which it
+    # is not on the sharded path, where a shard spanning a block boundary
+    # blends the two blocks' scales into one factor and silently gives both
+    # the wrong learning rate. The scales are applied after normalization
+    # instead, per row block of this rank's shard.
     # Request the stacked [N, *shape] result directly: the normalization below
     # immediately re-stacks the orthogonalized update, so taking the list and
     # re-stacking it would be an unbind-then-restack round-trip (N selects + a
@@ -294,7 +302,7 @@ def normuon_update_megabatch_async(
         epsilon=epsilon,
         global_comm_dim_size=global_comm_dim_size,
         split_sizes=split_sizes,
-        split_scales=split_scales,
+        split_scales=None,
         return_stacked=True,
     )
 
@@ -302,8 +310,11 @@ def normuon_update_megabatch_async(
     # With split_sizes, the Frobenius-norm-preserving rescale runs per row
     # block, matching separate per-block parameters. On the sharded all-to-all
     # path U holds local shards rather than full matrices, so normalization
-    # stays per-shard there (the existing distributed approximation); block
-    # boundaries are not locally available.
+    # stays per-shard there (the existing distributed approximation): a shard
+    # is a contiguous row range, so its rescale mixes blocks only where a shard
+    # straddles a block boundary. Only the norm-preserving rescale is
+    # approximated -- the learning rate itself is exact per block, applied
+    # below.
     norm_split_sizes = (
         split_sizes if (comm_dim is None or process_group is None) else None
     )
@@ -318,6 +329,30 @@ def normuon_update_megabatch_async(
     # numerically identical to the per-element loops; this is purely a
     # host-dispatch reduction (the V writeback alone was ~20% of step CPU time).
     torch._foreach_copy_(V_local, V_stacked.unbind(0))
+
+    # Apply the per-block learning-rate adjustment now that normalization can
+    # no longer cancel it. On the sharded path this rank holds rows
+    # [row_offset, row_offset + local_rows) of the fused matrix; split_sizes
+    # requires dim 0 to be divisible by the world size (megabatch_base raises
+    # otherwise), so every rank holds the same number of rows and the offset is
+    # exact. Blocks whose scale is 1.0 are skipped, so the common case costs
+    # one narrow + mul_ per block that intersects this shard, and nothing at
+    # all when adjust_lr is None.
+    if split_scales is not None:
+        if comm_dim is not None and process_group is not None:
+            local_rows = global_comm_dim_size // world_size
+            row_offset = device_rank * local_rows
+            assert U_stacked.size(-2) == local_rows, (
+                f"expected {local_rows} local rows on the sharded split path, "
+                f"got {U_stacked.size(-2)}"
+            )
+        else:
+            row_offset = 0
+        for start, end, scale in local_split_row_scales(
+            split_sizes, split_scales, row_offset, U_stacked.size(-2)
+        ):
+            U_stacked.narrow(-2, start, end - start).mul_(scale)
+
     U = list(U_stacked.unbind(0))
 
     # Compute scaled learning rate

--- a/tests/test_cuda_graph.py
+++ b/tests/test_cuda_graph.py
@@ -112,6 +112,37 @@ def test_cudagraph_matches_eager(optimizer_cls):
     assert diff <= 1e-5, f"{optimizer_cls.__name__}: capture-vs-eager diff {diff:.3e}"
 
 
+def _build_split(optimizer_cls=NorMuon):
+    torch.manual_seed(SEED)
+    fused = [torch.nn.Parameter(torch.randn(48, 16, device=DEVICE))]
+    opt = optimizer_cls(
+        [{"params": fused, "split_sizes": (32, 8, 8)}],
+        distributed_mesh=None,
+        lr=0.02,
+    )
+    return fused, opt
+
+
+@pytest.mark.parametrize("optimizer_cls", [Muon, NorMuon])
+def test_cudagraph_matches_eager_with_split_sizes(optimizer_cls):
+    """A ``split_sizes`` group stays capturable. The per-block lr scales are
+    shape-derived Python floats -- for NorMuon applied as in-place narrow muls on
+    the update after normalization -- so they bake into the graph, which is
+    correct only because they never change once the shapes are fixed."""
+    p0, _ = _build_split(optimizer_cls)
+    grad_seq = _grad_seq(p0)
+
+    pe, oe = _build_split(optimizer_cls)
+    final_eager = _run(pe, oe, grad_seq, oe.step)
+
+    pg, og = _build_split(optimizer_cls)
+    wrap = CudaGraphOptimizer(og, warmup_steps=WARMUP)
+    final_graph = _run(pg, og, grad_seq, wrap.step)
+
+    diff = max((a - b).abs().max().item() for a, b in zip(final_eager, final_graph))
+    assert diff <= 1e-5, f"{optimizer_cls.__name__}: capture-vs-eager diff {diff:.3e}"
+
+
 @pytest.mark.parametrize("optimizer_cls", OPTIMIZERS)
 def test_cudagraph_tracks_scheduled_lr(optimizer_cls):
     p0, o0 = _build(optimizer_cls)

--- a/tests/test_normuon_split_lr.py
+++ b/tests/test_normuon_split_lr.py
@@ -1,0 +1,171 @@
+"""NorMuon ``split_sizes``: each row block must receive the learning-rate
+adjustment its own shape would get as a separate parameter, on every path.
+
+The per-block correction is ``adjust(block_shape) / adjust(full_shape)``
+(``compute_split_lr_scales``), because the megabatch update derives one
+``adjusted_lr`` from the whole fused shape. Applying that factor *before*
+NorMuon's normalization does not survive it: the normalization divides U by
+sqrt(V) -- and V is an EMA of the scaled U, so the factor cancels -- then
+rescales to the Frobenius norm of its input, which reintroduces the factor only
+when that rescale is per block. On the FSDP2 sharded path the rescale is
+shard-local, so a shard spanning a block boundary blends the blocks' scales
+into a single factor and both blocks get the wrong learning rate.
+
+The assertion here is a ratio between two runs that differ *only* in
+``adjust_lr``. With ``adjust_lr=None`` the update is ``lr * N``; with an
+adjustment it must be ``adjust(block_shape) * N`` for the same N, so per row
+block
+
+    ||W0 - W_adjusted|| / ||W0 - W_none||  ==  adjust(lr, block_shape) / lr
+
+exactly. That isolates the learning rate from the shard-local normalization
+approximation (which is common to both runs and cancels), so it holds on the
+sharded path too, where a full parity-with-separate-parameters test would not.
+The grads are supplied, not backpropagated, so the diverging weights of the two
+runs never feed back into the updates.
+
+Runs on 1, 2 and 4 GPUs via NCCL. The 48-row matrix with blocks (32, 8, 8)
+straddles: at world_size=2 the second shard carries rows of all three blocks,
+at world_size=4 two shards straddle a boundary. world_size=1 is a control -- a
+mesh dimension of size 1 is not counted as sharded (``_get_shard_info`` requires
+``mesh.size(i) > 1``), so it exercises the unsharded per-block normalization
+path, which was already correct.
+"""
+
+import math
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from torch.distributed.tensor import DeviceMesh, Shard, distribute_tensor
+
+from dion.megabatch_base import (
+    adjust_lr_rms_norm,
+    adjust_lr_spectral_norm,
+    local_split_row_scales,
+)
+from dion.normuon import NorMuon
+from dion.polar_express import polar_express
+
+
+CUDA = torch.cuda.device_count() if torch.cuda.is_available() else 0
+
+# Unequal blocks, and cols small enough that rms_norm's max(fan_out, fan_in)
+# does not saturate at fan_in for every block -- otherwise all three scales
+# coincide and the test cannot see a blend.
+SPLIT_SIZES = (32, 8, 8)
+SHAPE = (48, 16)
+LR = 0.1
+N_STEPS = 3
+
+
+def _ns(x, epsilon=1e-7):
+    return polar_express(x, epsilon=epsilon)
+
+
+def _adjust_fn(adjust_lr):
+    return {
+        "spectral_norm": adjust_lr_spectral_norm,
+        "rms_norm": adjust_lr_rms_norm,
+    }[adjust_lr]
+
+
+def _worker(rank, world_size, port, adjust_lr, out_path):
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    mesh = DeviceMesh("cuda", list(range(world_size)))
+    dev = torch.device(f"cuda:{rank}")
+
+    rows, cols = SHAPE
+    g = torch.Generator(device=dev).manual_seed(1234)
+    W0 = torch.randn(rows, cols, generator=g, device=dev)
+    p = torch.nn.Parameter(distribute_tensor(W0, mesh, [Shard(0)]))
+
+    opt = NorMuon(
+        [dict(params=[p], split_sizes=SPLIT_SIZES)],
+        distributed_mesh=mesh,
+        lr=LR,
+        weight_decay=0.0,
+        adjust_lr=adjust_lr,
+        newton_schulz_func=_ns,
+    )
+    for step in range(N_STEPS):
+        gg = torch.Generator(device=dev).manual_seed(100 + step)
+        G = torch.randn(rows, cols, generator=gg, device=dev)
+        p.grad = distribute_tensor(G, mesh, [Shard(0)])
+        opt.step()
+
+    full = p.detach().full_tensor()
+    if rank == 0:
+        torch.save({"W": full.cpu(), "W0": W0.cpu()}, out_path)
+    dist.destroy_process_group()
+
+
+def _run(world_size, port, adjust_lr, tmp_path):
+    out = str(tmp_path / f"out_{port}.pt")
+    mp.spawn(
+        _worker, args=(world_size, port, adjust_lr, out), nprocs=world_size, join=True
+    )
+    return torch.load(out)
+
+
+def measured_block_factors(world_size, adjust_lr, tmp_path, port_base):
+    """Per-block ||W0 - W_adjusted|| / ||W0 - W_none||, i.e. the effective
+    learning rate each block actually received, in units of ``lr``."""
+    adjusted = _run(world_size, port_base, adjust_lr, tmp_path)
+    baseline = _run(world_size, port_base + 1, None, tmp_path)
+    d_adj = (adjusted["W0"] - adjusted["W"]).split(list(SPLIT_SIZES), dim=0)
+    d_none = (baseline["W0"] - baseline["W"]).split(list(SPLIT_SIZES), dim=0)
+    return [(a.norm() / b.norm()).item() for a, b in zip(d_adj, d_none)]
+
+
+def expected_block_factors(adjust_lr):
+    adjust_fn = _adjust_fn(adjust_lr)
+    cols = SHAPE[1]
+    return [adjust_fn(LR, (rows, cols), flatten=False) / LR for rows in SPLIT_SIZES]
+
+
+@pytest.mark.parametrize("world_size", [1, 2, 4])
+@pytest.mark.parametrize("adjust_lr", ["spectral_norm", "rms_norm"])
+def test_split_blocks_get_their_own_lr_adjustment(world_size, adjust_lr, tmp_path):
+    if CUDA < world_size:
+        pytest.skip(f"needs >= {world_size} CUDA devices")
+    port_base = 29600 + world_size * 10 + (0 if adjust_lr == "spectral_norm" else 4)
+    measured = measured_block_factors(world_size, adjust_lr, tmp_path, port_base)
+    expected = expected_block_factors(adjust_lr)
+    torch.testing.assert_close(
+        torch.tensor(measured), torch.tensor(expected), rtol=2e-3, atol=1e-4
+    )
+
+
+class TestLocalSplitRowScales:
+    def test_whole_matrix(self):
+        assert local_split_row_scales((32, 8, 8), (0.8, 0.5, 0.4), 0, 48) == [
+            (0, 32, 0.8),
+            (32, 40, 0.5),
+            (40, 48, 0.4),
+        ]
+
+    def test_shard_straddles_two_boundaries(self):
+        # world_size=2 shard 1: global rows [24, 48) covers the tail of block 0
+        # and all of blocks 1 and 2, in local coordinates [0, 24).
+        assert local_split_row_scales((32, 8, 8), (0.8, 0.5, 0.4), 24, 24) == [
+            (0, 8, 0.8),
+            (8, 16, 0.5),
+            (16, 24, 0.4),
+        ]
+
+    def test_shard_inside_one_block(self):
+        assert local_split_row_scales((32, 8, 8), (0.8, 0.5, 0.4), 12, 12) == [
+            (0, 12, 0.8)
+        ]
+
+    def test_unit_scales_skipped(self):
+        assert local_split_row_scales((32, 16), (1.0, 0.5), 0, 48) == [(32, 48, 0.5)]
+
+    def test_no_scales(self):
+        assert local_split_row_scales((32, 16), None, 0, 48) == []


### PR DESCRIPTION
Addresses #111.

## The bug

With `split_sizes`, each row block should get the learning-rate adjustment its own shape would receive as a separate parameter. The megabatch step derives one `adjusted_lr` from the whole fused shape, so `compute_split_lr_scales` supplies the per-block correction `adjust(block) / adjust(full)`, which was multiplied into each block right after Newton-Schulz.

That placement does not survive NorMuon's normalization. It divides `U` by `sqrt(V)` — and `V` is a zero-initialized EMA of that same scaled update, so it is exactly the scale squared times the unscaled EMA and the factor cancels — then rescales to the Frobenius norm of its own input, which reintroduces the factor only where that rescale is per block. On the FSDP2 sharded path the rescale is shard-local, so any shard spanning a block boundary applied **one blended factor to all of its rows**. Blocks whose scales differ then ran at the wrong learning rate, too high for the small blocks: the "converges faster initially, then diverges" report in #111.

Muon was never affected — it has no normalization after the scales. Dion2/NorDion2 reject `split_sizes`.

## The fix

Apply the scales *after* the normalization, per row block of each rank's shard. `split_sizes` already requires dim 0 to be divisible by the sharding world size, so every rank holds the same number of rows and its global row offset is exactly `device_rank * local_rows`; the new `local_split_row_scales` intersects the global blocks with that range and returns local `(start, end, scale)` slices.

Unit scales are skipped, so the common case is one `narrow` + in-place `mul_` per block intersecting the shard, and nothing at all when `adjust_lr is None` — slightly cheaper than the out-of-place `block * scale` it replaces. No extra communication. The learning rate no longer depends on the normalization commuting with it, on any path.

Under FSDP the norm-preserving rescale remains shard-local, exactly as before; only the learning rate is now exact per block.

## Measured

48x16 fused weight, blocks `(32, 8, 8)`, lr 0.1, 3 steps, real NCCL. Each block's effective learning rate in units of the base lr, measured as the ratio of `||dW||` per block against an otherwise identical `adjust_lr=None` run:

| | intended | before | after |
|---|---|---|---|
| `spectral_norm`, world_size=2 | 1.414, 0.707, 0.707 | 1.258, **0.877, 0.877** (+24%) | exact |
| `spectral_norm`, world_size=4 | 1.414, 0.707, 0.707 | 1.336, **0.874**, 0.707 (+23%) | exact |
| `rms_norm`, world_size=2 | 1.131, 0.800, 0.800 | 1.050, **0.869, 0.869** (+8.6%) | exact |
| `rms_norm`, world_size=4 | 1.131, 0.800, 0.800 | 1.090, **0.867**, 0.800 (+8.4%) | exact |

At world_size=4 the third block is already correct before the fix because its shard holds only blocks 2 and 3, which are the same size and so share a scale — there is nothing to blend. Scaled up, a fused QKV weight `(4096, 512, 512) x 4096` under `spectral_norm` puts the K and V blocks at up to ~1.8x their intended learning rate.

## Tests

`tests/test_normuon_split_lr.py` (new) asserts, on 1, 2 and 4 GPUs and for both adjustment modes, that per row block

```
||W0 - W_adjusted|| / ||W0 - W_none||  ==  adjust(lr, block_shape) / lr
```

Comparing two runs that differ *only* in `adjust_lr` cancels the shard-local normalization approximation, which is common to both, so the identity is exact on the sharded path — where a strict parity-with-separate-parameters assertion would fail for reasons unrelated to the learning rate. **The test fails on main** with a 24% relative error at world_size=2. `world_size=1` is a control: a mesh dimension of size 1 is not counted as sharded (`_get_shard_info` requires `mesh.size(i) > 1`), so it takes the already-correct unsharded path.

Also added: CPU unit tests for `local_split_row_scales` (straddling shards, partial blocks, unit-scale skipping), and a capture-vs-eager CUDA-graph test for a `split_sizes` group in `tests/test_cuda_graph.py` (the scales are shape-derived Python floats baked into the graph).

Existing suite on this branch: 313 passed, 16 skipped — including the single-GPU `TestSplitSizes` parity tests, so unsharded behavior is unchanged.

## Checkpoint note

`V` now tracks the *unscaled* update, so its scale differs from checkpoints written by earlier versions by `(adjust(block) / adjust(full))**2` per block. The update is invariant to a constant rescale of `V` (it cancels between the division and the norm-preserving rescale), so old checkpoints resume without a correction. Noted in the CHANGELOG.

## Not covered

The reporter's own configuration in #111 — a gated MLP split into two *equal* blocks — has identical scales in both blocks, so there is nothing to blend and it was already getting the right learning rate. This PR fixes the defect the issue title names; #111 should stay open pending their version, world size, and param groups.
