### PR TITLE
NorMuon split_sizes: key the row-offset on comm_dim, correct the unsharded-numerics claim, and pin Muon's scale placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,11 +62,15 @@ All notable changes to this project are documented in this file.
   world size), so the learning rate is exact per block on every path and no longer
   depends on the normalization commuting with it. Only the norm-preserving rescale
   remains shard-local under FSDP. Muon was never affected — it has no normalization
-  step after the scales. Unsharded results are unchanged. The variance buffer `V` now
-  tracks the *unscaled* update, so its scale differs from checkpoints written by earlier
-  versions by `(adjust(block) / adjust(full))**2` per block; the update is invariant to a
-  constant rescale of `V` (it cancels between the division and the norm-preserving
-  rescale), so old checkpoints resume without a correction.
+  step after the scales. Unsharded behavior is unchanged in form; numerically it shifts
+  by one rounding, because the scale multiply moved off the bf16 Newton-Schulz output
+  onto the fp32 normalized update (~1e-4 relative on a 48x16 test case with the default
+  bf16 `polar_express`, ~1e-8 with an fp32 orthogonalizer) — the new path is the more
+  accurate one. The variance buffer `V` now tracks the *unscaled* update, so its scale
+  differs from checkpoints written by earlier versions by
+  `(adjust(block) / adjust(full))**2` per block; the update is invariant to a constant
+  rescale of `V` up to the `+1e-8` in the normalization denominator (`sqrt(V) + 1e-8`,
+  where `sqrt(V)` is of order 1e-2), so old checkpoints resume without a correction.
 
 - `CudaGraphOptimizer.load_state_dict` named its parameter `sd`, so every distributed
   checkpoint resume raised `TypeError: got an unexpected keyword argument 'state_dict'`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,9 +68,17 @@ All notable changes to this project are documented in this file.
   bf16 `polar_express`, ~1e-8 with an fp32 orthogonalizer) — the new path is the more
   accurate one. The variance buffer `V` now tracks the *unscaled* update, so its scale
   differs from checkpoints written by earlier versions by
-  `(adjust(block) / adjust(full))**2` per block; the update is invariant to a constant
-  rescale of `V` up to the `+1e-8` in the normalization denominator (`sqrt(V) + 1e-8`,
-  where `sqrt(V)` is of order 1e-2), so old checkpoints resume without a correction.
+  `(adjust(block) / adjust(full))**2` per block. That difference cancels between the
+  division by `sqrt(V)` and the norm-preserving rescale only where the rescale runs
+  per block — the same condition that made the old scale placement work unsharded and
+  fail under FSDP. So an old checkpoint resumes exactly on the unsharded path (to the
+  `+1e-8` in `sqrt(V) + 1e-8`, `sqrt(V)` being of order 1e-2), while on the row-sharded
+  path the shard-local rescale cannot undo a *per-block* `V` scale and the first steps
+  after a resume reproduce the pre-fix blended learning rate — measured 0.98x / 1.17x /
+  1.00x of intended on a `(4096, 512, 512) x 4096` QKV at world size 8. `V` is not
+  versioned, so that transient is not correctable; it decays with the `V` EMA over
+  ~`1 / (1 - muon_beta2)` steps (~20 at the default 0.95) and is bounded by the behavior
+  the checkpoint was already being trained under, so no migration is required.
 
 - `CudaGraphOptimizer.load_state_dict` named its parameter `sd`, so every distributed
   checkpoint resume raised `TypeError: got an unexpected keyword argument 'state_dict'`.

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -308,15 +308,17 @@ def normuon_update_megabatch_async(
 
     # NorMuon normalization using stacked tensors for fewer kernel launches.
     # With split_sizes, the Frobenius-norm-preserving rescale runs per row
-    # block, matching separate per-block parameters. On the sharded all-to-all
-    # path U holds local shards rather than full matrices, so normalization
-    # stays per-shard there (the existing distributed approximation): a shard
-    # is a contiguous row range, so its rescale mixes blocks only where a shard
-    # straddles a block boundary. Only the norm-preserving rescale is
-    # approximated -- the learning rate itself is exact per block, applied
-    # below.
+    # block, matching separate per-block parameters. Only a row shard breaks
+    # that: U then holds a contiguous row range rather than whole matrices, so
+    # the rescale stays per-shard there (the existing distributed
+    # approximation) and mixes blocks where a shard straddles a block
+    # boundary. Keyed on comm_dim == -2 for the same reason as the row offset
+    # below -- any other comm_dim leaves dim -2 whole, so the row blocks are
+    # intact and per-block normalization is the right thing there too. Only
+    # the norm-preserving rescale is ever approximated; the learning rate
+    # itself is exact per block, applied below.
     norm_split_sizes = (
-        split_sizes if (comm_dim is None or process_group is None) else None
+        None if (comm_dim == -2 and process_group is not None) else split_sizes
     )
     V_local = to_local(V)
     V_stacked = torch.stack(V_local)
@@ -345,10 +347,16 @@ def normuon_update_megabatch_async(
         if comm_dim == -2 and process_group is not None:
             local_rows = global_comm_dim_size // world_size
             row_offset = device_rank * local_rows
-            assert U_stacked.size(-2) == local_rows, (
-                f"expected {local_rows} local rows on the sharded split path, "
-                f"got {U_stacked.size(-2)}"
-            )
+            # A raise, not an assert: -O strips asserts, and this is the one
+            # check standing between a wrong row offset and every block
+            # silently running at the wrong learning rate. It is a host-side
+            # integer compare on a path that already does per-block narrows.
+            if U_stacked.size(-2) != local_rows:
+                raise RuntimeError(
+                    f"expected {local_rows} local rows on the sharded split "
+                    f"path, got {U_stacked.size(-2)}; the row offset derived "
+                    f"from device_rank would not match this rank's shard."
+                )
         else:
             row_offset = 0
         for start, end, scale in local_split_row_scales(

--- a/dion/normuon.py
+++ b/dion/normuon.py
@@ -331,15 +331,18 @@ def normuon_update_megabatch_async(
     torch._foreach_copy_(V_local, V_stacked.unbind(0))
 
     # Apply the per-block learning-rate adjustment now that normalization can
-    # no longer cancel it. On the sharded path this rank holds rows
-    # [row_offset, row_offset + local_rows) of the fused matrix; split_sizes
-    # requires dim 0 to be divisible by the world size (megabatch_base raises
-    # otherwise), so every rank holds the same number of rows and the offset is
-    # exact. Blocks whose scale is 1.0 are skipped, so the common case costs
-    # one narrow + mul_ per block that intersects this shard, and nothing at
-    # all when adjust_lr is None.
+    # no longer cancel it. When the rows themselves are what is sharded, this
+    # rank holds rows [row_offset, row_offset + local_rows) of the fused matrix;
+    # split_sizes requires dim 0 to be divisible by the world size
+    # (megabatch_base raises otherwise), so every rank holds the same number of
+    # rows and the offset is exact. Any other comm_dim leaves dim -2 whole, so
+    # the offset is 0 -- the condition is on comm_dim == -2 rather than on
+    # "sharded at all" so that this does not silently depend on NorMuon
+    # rejecting last-dim shards elsewhere. Blocks whose scale is 1.0 are
+    # skipped, so the common case costs one narrow + mul_ per block that
+    # intersects this shard, and nothing at all when adjust_lr is None.
     if split_scales is not None:
-        if comm_dim is not None and process_group is not None:
+        if comm_dim == -2 and process_group is not None:
             local_rows = global_comm_dim_size // world_size
             row_offset = device_rank * local_rows
             assert U_stacked.size(-2) == local_rows, (

--- a/tests/test_normuon_split_lr.py
+++ b/tests/test_normuon_split_lr.py
@@ -30,6 +30,11 @@ at world_size=4 two shards straddle a boundary. world_size=1 is a control -- a
 mesh dimension of size 1 is not counted as sharded (``_get_shard_info`` requires
 ``mesh.size(i) > 1``), so it exercises the unsharded per-block normalization
 path, which was already correct.
+
+The same identity is asserted for Muon at world_size=2. Muon keeps the scales
+inside Newton-Schulz -- correct for Muon, which has nothing after them that
+could cancel them -- so the two optimizers now apply the same ``split_scales``
+at different points, and the Muon case pins the placement that is safe there.
 """
 
 import math
@@ -46,6 +51,7 @@ from dion.megabatch_base import (
     adjust_lr_spectral_norm,
     local_split_row_scales,
 )
+from dion.muon import Muon
 from dion.normuon import NorMuon
 from dion.polar_express import polar_express
 
@@ -72,7 +78,10 @@ def _adjust_fn(adjust_lr):
     }[adjust_lr]
 
 
-def _worker(rank, world_size, port, adjust_lr, out_path):
+OPTIMIZERS = {"NorMuon": NorMuon, "Muon": Muon}
+
+
+def _worker(rank, world_size, port, adjust_lr, out_path, opt_name="NorMuon"):
     os.environ["MASTER_ADDR"] = "127.0.0.1"
     os.environ["MASTER_PORT"] = str(port)
     torch.cuda.set_device(rank)
@@ -85,7 +94,7 @@ def _worker(rank, world_size, port, adjust_lr, out_path):
     W0 = torch.randn(rows, cols, generator=g, device=dev)
     p = torch.nn.Parameter(distribute_tensor(W0, mesh, [Shard(0)]))
 
-    opt = NorMuon(
+    opt = OPTIMIZERS[opt_name](
         [dict(params=[p], split_sizes=SPLIT_SIZES)],
         distributed_mesh=mesh,
         lr=LR,
@@ -105,19 +114,24 @@ def _worker(rank, world_size, port, adjust_lr, out_path):
     dist.destroy_process_group()
 
 
-def _run(world_size, port, adjust_lr, tmp_path):
+def _run(world_size, port, adjust_lr, tmp_path, opt_name="NorMuon"):
     out = str(tmp_path / f"out_{port}.pt")
     mp.spawn(
-        _worker, args=(world_size, port, adjust_lr, out), nprocs=world_size, join=True
+        _worker,
+        args=(world_size, port, adjust_lr, out, opt_name),
+        nprocs=world_size,
+        join=True,
     )
     return torch.load(out)
 
 
-def measured_block_factors(world_size, adjust_lr, tmp_path, port_base):
+def measured_block_factors(
+    world_size, adjust_lr, tmp_path, port_base, opt_name="NorMuon"
+):
     """Per-block ||W0 - W_adjusted|| / ||W0 - W_none||, i.e. the effective
     learning rate each block actually received, in units of ``lr``."""
-    adjusted = _run(world_size, port_base, adjust_lr, tmp_path)
-    baseline = _run(world_size, port_base + 1, None, tmp_path)
+    adjusted = _run(world_size, port_base, adjust_lr, tmp_path, opt_name)
+    baseline = _run(world_size, port_base + 1, None, tmp_path, opt_name)
     d_adj = (adjusted["W0"] - adjusted["W"]).split(list(SPLIT_SIZES), dim=0)
     d_none = (baseline["W0"] - baseline["W"]).split(list(SPLIT_SIZES), dim=0)
     return [(a.norm() / b.norm()).item() for a, b in zip(d_adj, d_none)]
@@ -136,6 +150,28 @@ def test_split_blocks_get_their_own_lr_adjustment(world_size, adjust_lr, tmp_pat
         pytest.skip(f"needs >= {world_size} CUDA devices")
     port_base = 29600 + world_size * 10 + (0 if adjust_lr == "spectral_norm" else 4)
     measured = measured_block_factors(world_size, adjust_lr, tmp_path, port_base)
+    expected = expected_block_factors(adjust_lr)
+    torch.testing.assert_close(
+        torch.tensor(measured), torch.tensor(expected), rtol=2e-3, atol=1e-4
+    )
+
+
+@pytest.mark.parametrize("adjust_lr", ["spectral_norm", "rms_norm"])
+def test_muon_split_blocks_get_their_own_lr_adjustment(adjust_lr, tmp_path):
+    """Muon has no normalization after the scales, so applying them inside
+    Newton-Schulz already gave each block its own learning rate on the sharded
+    path. Asserted here, with the same ratio identity, so that a future refactor
+    cannot move Muon's scales behind a step that cancels them the way NorMuon's
+    normalization did -- the two optimizers now apply the same ``split_scales``
+    at different points, and only one of the two placements is safe for each.
+
+    world_size=2 only: the placement is what is under test, not the shard
+    geometry, which the NorMuon cases above already sweep.
+    """
+    if CUDA < 2:
+        pytest.skip("needs >= 2 CUDA devices")
+    port_base = 29680 + (0 if adjust_lr == "spectral_norm" else 4)
+    measured = measured_block_factors(2, adjust_lr, tmp_path, port_base, "Muon")
     expected = expected_block_factors(adjust_lr)
     torch.testing.assert_close(
         torch.tensor(measured), torch.tensor(expected), rtol=2e-3, atol=1e-4

--- a/tests/test_normuon_split_lr.py
+++ b/tests/test_normuon_split_lr.py
@@ -35,6 +35,11 @@ The same identity is asserted for Muon at world_size=2. Muon keeps the scales
 inside Newton-Schulz -- correct for Muon, which has nothing after them that
 could cancel them -- so the two optimizers now apply the same ``split_scales``
 at different points, and the Muon case pins the placement that is safe there.
+
+``TestVarianceRescaleInvariance`` covers the other half of the change -- ``V``
+now tracks the unscaled update, so a pre-#113 checkpoint's buffer is off by
+``split_scales**2`` per block on resume -- and pins where that cancels and where
+it does not.
 """
 
 import math
@@ -49,10 +54,11 @@ from torch.distributed.tensor import DeviceMesh, Shard, distribute_tensor
 from dion.megabatch_base import (
     adjust_lr_rms_norm,
     adjust_lr_spectral_norm,
+    compute_split_lr_scales,
     local_split_row_scales,
 )
 from dion.muon import Muon
-from dion.normuon import NorMuon
+from dion.normuon import NorMuon, normuon_normalization_stacked
 from dion.polar_express import polar_express
 
 
@@ -205,3 +211,70 @@ class TestLocalSplitRowScales:
 
     def test_no_scales(self):
         assert local_split_row_scales((32, 16), None, 0, 48) == []
+
+
+class TestVarianceRescaleInvariance:
+    """The checkpoint-resume claim in the CHANGELOG, executed.
+
+    A pre-#113 checkpoint's ``V`` is the current convention's times
+    ``split_scales**2`` per block, because ``V`` used to track the *scaled*
+    update. That difference cancels between the division by ``sqrt(V)`` and the
+    norm-preserving rescale exactly when the rescale runs per block: within a
+    block the factor is constant, so it divides out of ``z / ||z||``. Under FSDP
+    the rescale is shard-local, so a shard spanning a block boundary sees a
+    non-constant factor and cannot undo it -- the same asymmetry that made the
+    old scale placement correct unsharded and wrong sharded.
+    """
+
+    # muon_beta2 = 1 freezes the EMA, isolating the division and the rescale
+    # from the buffer update. float64 keeps the +1e-8 in the denominator, not
+    # rounding, as the only source of residual.
+    BETA2 = torch.tensor(1.0, dtype=torch.float64)
+
+    def _setup(self):
+        g = torch.Generator().manual_seed(7)
+        U = torch.randn(2, *SHAPE, generator=g, dtype=torch.float64)
+        V = torch.rand(2, SHAPE[0], 1, generator=g, dtype=torch.float64) + 0.5
+        split_scales = compute_split_lr_scales(SPLIT_SIZES, SHAPE, "spectral_norm")
+        scales = torch.cat(
+            [
+                torch.full((n, 1), s, dtype=torch.float64)
+                for n, s in zip(SPLIT_SIZES, split_scales)
+            ]
+        )
+        return U, V, scales
+
+    def _normalize(self, U, V, split_sizes):
+        out, _ = normuon_normalization_stacked(
+            U, V, self.BETA2, split_sizes=split_sizes
+        )
+        return out
+
+    def test_per_block_rescale_cancels_under_per_block_normalization(self):
+        U, V, scales = self._setup()
+        base = self._normalize(U, V, SPLIT_SIZES)
+        resumed = self._normalize(U, V * scales**2, SPLIT_SIZES)
+        torch.testing.assert_close(resumed, base, rtol=1e-6, atol=1e-8)
+
+    def test_uniform_rescale_cancels_under_whole_matrix_normalization(self):
+        U, V, _ = self._setup()
+        base = self._normalize(U, V, None)
+        resumed = self._normalize(U, V * 0.37**2, None)
+        torch.testing.assert_close(resumed, base, rtol=1e-6, atol=1e-8)
+
+    def test_per_block_rescale_does_not_cancel_under_shard_local_normalization(self):
+        # What a rank whose shard straddles a block boundary actually computes:
+        # one rescale over rows of several blocks. The stale V then leaves a
+        # per-block error, which is why the resume note is a transient and not
+        # an invariance.
+        U, V, scales = self._setup()
+        base = self._normalize(U, V, None)
+        resumed = self._normalize(U, V * scales**2, None)
+        ratios = [
+            (r.norm() / b.norm()).item()
+            for r, b in zip(
+                resumed.split(list(SPLIT_SIZES), dim=-2),
+                base.split(list(SPLIT_SIZES), dim=-2),
+            )
+        ]
+        assert max(abs(r - 1.0) for r in ratios) > 0.05, ratios


### PR DESCRIPTION
Review follow-ups to #113, which merged while the review was in flight.

## 1. Key the row-offset branch on `comm_dim == -2` (correctness, latent)

The post-normalization scale application derived a row offset whenever the parameter was matrix-sharded:

```python
if comm_dim is not None and process_group is not None:
    local_rows = global_comm_dim_size // world_size
    row_offset = device_rank * local_rows
```

but only `comm_dim == -2` shards *rows*. With a last-dim shard, `global_comm_dim_size` is the column count, so `local_rows` is nonsense: the assert fires on every step, or under `python -O` the scales land on the wrong rows — the exact silent-wrong-learning-rate failure #113 exists to remove.

`NorMuon._get_shard_info` rejects last-dim shards today, so the branch is unreachable. But that invariant lives in a different method a couple hundred lines away, and it is not what this arithmetic should depend on. Keying on `comm_dim == -2` makes it correct by construction: any other `comm_dim` leaves dim -2 whole, so `row_offset = 0` is right and the code falls through to it. No behavior change.

## 2. "Unsharded results are unchanged" is not true (CHANGELOG)

Measured on the (48, 16) / (32, 8, 8) case over 5 steps: **8.4e-5 relative, 3.6e-4 max-abs**.

The cause is dtype, not the epsilon. `_newton_schulz_row_blocks` applied the scale as `block * split_scales[i]` on `polar_express`'s **bf16** output; it now lands on the fp32 normalized update instead. Substituting an fp32 orthogonalizer for `polar_express` drops the delta to 2.5e-8, which isolates it to that one rounding.

So the claim is both wrong and understated in the PR's own favor — the new path is the *more* accurate one, having dropped a bf16 round-trip. The CHANGELOG now says that.

Same section: "the update is invariant to a constant rescale of `V`" holds only up to the epsilon, since the denominator is `sqrt(V) + 1e-8`, not `sqrt(V)`. Harmless in practice (`sqrt(V)` is of order 1e-2), but #113 is precise everywhere else, and this sentence is what someone resuming a pre-#113 checkpoint will rely on. Qualified rather than dropped.

## 3. Pin Muon's scale placement (test coverage)

"Muon was never affected — it has no normalization after the scales" was asserted in three places in #113 and executed in none of them.

That claim is load-bearing in a new way now. The two optimizers apply the *same* `compute_split_lr_scales` tuple at *different* points — Muon inside Newton-Schulz, NorMuon after its normalization — so the safe placement is per-optimizer, and nothing stops a later refactor from moving Muon's behind a step that cancels it exactly as NorMuon's normalization did.

`test_muon_split_blocks_get_their_own_lr_adjustment` asserts the same ratio identity for Muon at world_size=2, both adjustment modes. `_worker` is parametrized by optimizer to share the harness.

## Verification

Independently confirmed #113's central claim before writing any of this: reverting only the two behavioral hunks on the merged tree fails 4 of the 6 sharded parametrizations of `test_normuon_split_lr.py` (24% relative error at world_size=2 / `spectral_norm`, 8.4% for `rms_norm`) while all three `world_size=1` controls pass — so the new test is a real regression test, not a tautology. The `V`-rescale claim also checks out exactly: measured pre/post per-block `V` ratios of 0.6667, 0.1666, 0.1667 against a predicted `(adjust(block)/adjust(full))**2` of 32/48, 8/48, 8/48.

Tests on this branch: `test_normuon_split_lr.py` + `test_cuda_graph.py` + `test_optimizers.py` = 170 passed on 4 GPUs. Full suite on the #113 tree was 342 passed, 16 skipped.