### PR TITLE
nordion2: compile the variance scatter separately to fix a PyTorch 2.13 miscompile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,29 @@ All notable changes to this project are documented in this file.
 
 ### Fixed
 
+- `NorDion2` / `Dion3` failed to compile on PyTorch 2.13 as soon as a model had more
+  than one parameter shape group (reported in #115).
+  `nordion2_normalize_selected_stacked` ran the gather of the selected variance rows,
+  the per-row reduction, and the scatter back into the full buffer in one compiled
+  graph; after automatic dynamic-shape generalization 2.13's inductor emitted the
+  scatter epilogue referencing a temp defined only inside the preceding `tl.range`
+  reduction body, and `optimizer.step()` raised `NameError: tmp19 is not defined`
+  (upstream pytorch/pytorch#194490, a 2.12 -> 2.13 regression; both use Triton 3.7.1).
+  Reproducing it takes a shape group holding at least two parameters — dynamo
+  specializes a batch dim of 1, so one-parameter groups stayed on the static path —
+  plus a second distinct row/column shape and a reduction long enough not to compile
+  as a persistent kernel. The scatter is now compiled as its own graph, which makes
+  the invalid fusion unreachable while keeping dynamic shapes; `dynamic=False` also
+  avoids it but recompiles per shape and hits the recompile limit (#23) past eight
+  shape groups. Where the fused form did compile it was also badly slower: its
+  generalized kernel measured ~60x the split one (68 ms vs 1.1 ms per call at N=8,
+  8192x2048 on an H100), so multi-shape models gain throughput here, while a model
+  with a single shape group pays one extra graph entry, ~40 us of host dispatch per
+  call. The split reassociates the fp32 reduction, so `U` differs from the fused
+  kernel by up to 1.9e-6 (`V` is bit-exact) — the same decomposition
+  `test_normalize_selected_stacked_matches_unfused` already compared at
+  `atol=rtol=1e-5`. `Dion2`, `NorMuon` and `Muon` were not affected.
+
 - NorMuon gave `split_sizes` row blocks the wrong learning rate on the FSDP2 sharded
   path (reported in #111). The per-block correction `adjust(block) / adjust(full)` was
   multiplied into each block right after Newton-Schulz, but NorMuon's normalization

--- a/dion/nordion2.py
+++ b/dion/nordion2.py
@@ -371,11 +371,12 @@ def nordion2_update_megabatch_async(
     )
 
     # Update variance neuron buffer for the selected rows and normalize the
-    # orthonormalized update. The gather of the selected variance rows, the
-    # NorMuon normalization (fp32 compute, V stored bf16), and the scatter of
-    # the updated rows back into the full buffer are fused into one compiled
-    # graph so the per-param Python scatter loop and the eager gather/normalize
-    # graph boundary collapse into a single launch per shape group.
+    # orthonormalized update. Stacking replaces the per-param Python loop with
+    # one launch per shape group: the gather of the selected variance rows plus
+    # the NorMuon normalization (fp32 compute, V stored bf16) are one compiled
+    # graph, and the scatter of the updated rows back into the full buffer is a
+    # second one -- deliberately not fused into the first, see
+    # nordion2_normalize_selected_stacked.
     V_local = to_local(V)
     U_stacked = torch.stack(U_ortho)
     V_stacked = torch.stack(V_local)
@@ -462,12 +463,25 @@ def nordion2_normalize_selected_stacked(
     The gather + reduction and the scatter are compiled as two graphs rather than
     one. PyTorch 2.13's inductor miscompiles the single-graph form once automatic
     dynamic shapes kick in: the scatter epilogue is emitted referencing a temp
-    defined only inside the preceding reduction loop body, so the second distinct
-    parameter shape fails to compile with ``NameError: tmp19 is not defined``.
+    defined only inside the preceding reduction loop body, and compilation dies
+    with ``NameError: tmp19 is not defined``. Reproducing it needs a shape group
+    of at least two parameters (dynamo specializes ``N == 1``, so a group holding
+    a single parameter stays on the static path) plus a second distinct
+    row/column shape to generalize on, and a reduction long enough not to be
+    compiled as a persistent kernel.
+
     Splitting the scatter into its own graph makes that fusion unreachable while
     keeping dynamic shapes (so this stays one compilation for all later shapes,
     unlike ``dynamic=False``, which recompiles per shape and hits the recompile
-    limit). See https://github.com/pytorch/pytorch/issues/194490 and #115.
+    limit). It also matters where the fused form does compile: on 2.13 its
+    generalized kernel is ~60x slower than the split one (68 ms vs 1.1 ms per
+    call at N=8, 8192x2048 on an H100), because fusing the scatter into the
+    dynamic reduction costs inductor the tiling it would otherwise pick.
+
+    This is unconditional rather than version-gated (unlike ``_inductor_workaround``
+    in dion2) so the update numerics do not depend on the torch version: the split
+    reassociates the fp32 reduction and is not bit-identical to the fused form.
+    See https://github.com/pytorch/pytorch/issues/194490 and #115.
     """
     idx = indices.unsqueeze(-1)
     U_normed, V_sel_new = _nordion2_gather_and_normalize(U, V_full, idx, muon_beta2)

--- a/dion/nordion2.py
+++ b/dion/nordion2.py
@@ -427,6 +427,25 @@ def nordion2_update_megabatch_async(
 
 
 @torch.compile(fullgraph=True)
+def _nordion2_gather_and_normalize(
+    U: Tensor,
+    V_full: Tensor,
+    idx: Tensor,
+    muon_beta2: Tensor,
+) -> Tuple[Tensor, Tensor]:
+    V_sel = torch.gather(V_full, dim=-2, index=idx).float()
+    return normuon_normalization_stacked(U, V_sel, muon_beta2)
+
+
+@torch.compile(fullgraph=True)
+def _nordion2_scatter_variance(
+    V_full: Tensor,
+    idx: Tensor,
+    V_sel_new: Tensor,
+) -> Tensor:
+    return V_full.scatter(dim=-2, index=idx, src=V_sel_new.to(V_full.dtype))
+
+
 def nordion2_normalize_selected_stacked(
     U: Tensor,  # [N, k, cols]  orthogonalized selected rows
     V_full: Tensor,  # [N, rows, 1]  full per-neuron variance buffer (param dtype)
@@ -435,16 +454,24 @@ def nordion2_normalize_selected_stacked(
 ) -> Tuple[Tensor, Tensor]:
     """
     Gather the selected variance rows, run NorMuon normalization on them, and
-    scatter the updated rows back into the full variance buffer, all in one
-    compiled graph. Compute is done in fp32 (V stored in param dtype); the
-    returned V_full has the same dtype as the input.
+    scatter the updated rows back into the full variance buffer. Compute is done
+    in fp32 (V stored in param dtype); the returned V_full has the same dtype as
+    the input.
     Returns (normalized_U, updated_V_full).
+
+    The gather + reduction and the scatter are compiled as two graphs rather than
+    one. PyTorch 2.13's inductor miscompiles the single-graph form once automatic
+    dynamic shapes kick in: the scatter epilogue is emitted referencing a temp
+    defined only inside the preceding reduction loop body, so the second distinct
+    parameter shape fails to compile with ``NameError: tmp19 is not defined``.
+    Splitting the scatter into its own graph makes that fusion unreachable while
+    keeping dynamic shapes (so this stays one compilation for all later shapes,
+    unlike ``dynamic=False``, which recompiles per shape and hits the recompile
+    limit). See https://github.com/pytorch/pytorch/issues/194490 and #115.
     """
     idx = indices.unsqueeze(-1)
-    V_sel = torch.gather(V_full, dim=-2, index=idx).float()
-    U_normed, V_sel_new = normuon_normalization_stacked(U, V_sel, muon_beta2)
-    V_full = V_full.scatter(dim=-2, index=idx, src=V_sel_new.to(V_full.dtype))
-    return U_normed, V_full
+    U_normed, V_sel_new = _nordion2_gather_and_normalize(U, V_full, idx, muon_beta2)
+    return U_normed, _nordion2_scatter_variance(V_full, idx, V_sel_new)
 
 
 @torch.compile(fullgraph=True)

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -278,37 +278,66 @@ class TestNorDion2:
         # PyTorch 2.13's inductor miscompiled the gather/normalize/scatter graph
         # there, emitting a scatter epilogue that reads a temp defined only
         # inside the reduction loop body ("NameError: tmp19 is not defined").
-        # cols must stay large: a small reduction compiles as a persistent
-        # (non-looped) kernel, which never had the bug, so shrinking these
-        # shapes would silently defuse this test.
+        # Two of these shapes are load-bearing and must not be shrunk, or the
+        # test silently stops covering the bug:
+        #   - cols must stay large, or the reduction compiles as a persistent
+        #     (non-looped) kernel and there is no loop body to leak a temp from;
+        #   - n must stay >= 2, or dynamo specializes the batch dim on 1 and
+        #     never generalizes the graph.
+        # The dynamo config is pinned so a profile cached by an earlier process
+        # (PGO persists across runs under the inductor cache dir) cannot skip
+        # the dynamic-shape path this test exists to cover.
         # See https://github.com/pytorch/pytorch/issues/194490
+        pinned = {"automatic_dynamic_shapes": True}
+        if hasattr(torch._dynamo.config, "automatic_dynamic_local_pgo"):
+            pinned["automatic_dynamic_local_pgo"] = False
+
         beta2 = torch.tensor(0.9)
-        for n, rows, cols in [(2, 128, 4096), (2, 64, 4096), (3, 96, 2048)]:
-            k = rows // 2
-            torch.manual_seed(5)
-            u = torch.randn(n, k, cols, device=DEVICE, dtype=torch.bfloat16)
-            v_full = torch.rand(n, rows, 1, device=DEVICE, dtype=torch.bfloat16)
-            indices = torch.stack(
-                [torch.randperm(rows, device=DEVICE)[:k] for _ in range(n)], dim=0
-            )
-
-            u_out, v_out = nordion2_normalize_selected_stacked(
-                u.clone(), v_full.clone(), indices, beta2
-            )
-
-            idx = indices.unsqueeze(-1)
-            v_sel = torch.gather(v_full, dim=-2, index=idx).float()
-            u_ref, v_sel_new = normuon_normalization_stacked(u.clone(), v_sel, beta2)
-            v_ref = v_full.clone()
-            for i in range(n):
-                v_ref[i].scatter_(
-                    dim=-2, index=idx[i], src=v_sel_new[i].to(v_ref.dtype)
+        with torch._dynamo.config.patch(**pinned):
+            for n, rows, cols in [(2, 128, 4096), (2, 64, 4096), (3, 96, 2048)]:
+                k = rows // 2
+                torch.manual_seed(5)
+                u = torch.randn(n, k, cols, device=DEVICE, dtype=torch.bfloat16)
+                v_full = torch.rand(n, rows, 1, device=DEVICE, dtype=torch.bfloat16)
+                indices = torch.stack(
+                    [torch.randperm(rows, device=DEVICE)[:k] for _ in range(n)], dim=0
                 )
 
-            assert u_out.shape == u.shape
-            assert v_out.shape == v_full.shape
-            torch.testing.assert_close(u_out, u_ref, atol=1e-5, rtol=1e-5)
-            torch.testing.assert_close(v_out, v_ref, atol=1e-5, rtol=1e-5)
+                u_out, v_out = nordion2_normalize_selected_stacked(
+                    u.clone(), v_full.clone(), indices, beta2
+                )
+
+                idx = indices.unsqueeze(-1)
+                v_sel = torch.gather(v_full, dim=-2, index=idx).float()
+                u_ref, v_sel_new = normuon_normalization_stacked(
+                    u.clone(), v_sel, beta2
+                )
+                v_ref = v_full.clone()
+                for i in range(n):
+                    v_ref[i].scatter_(
+                        dim=-2, index=idx[i], src=v_sel_new[i].to(v_ref.dtype)
+                    )
+
+                assert u_out.shape == u.shape
+                assert v_out.shape == v_full.shape
+                torch.testing.assert_close(u_out, u_ref, atol=1e-5, rtol=1e-5)
+                torch.testing.assert_close(v_out, v_ref, atol=1e-5, rtol=1e-5)
+
+    def test_multiple_shape_groups_step(self):
+        from dion import NorDion2
+
+        # End-to-end guard for #115. The unit test above covers the helper;
+        # this covers the path a user actually hits, where the megabatch drives
+        # it once per shape group and step() raised InductorError on the second.
+        # Same load-bearing shape constraints: >= 2 params per group and a
+        # column count large enough that the reduction is not persistent.
+        params = _make_params([(256, 2048)] * 2 + [(128, 2048)] * 2)
+        opt = NorDion2(params, lr=0.01)
+        for p in params:
+            p.grad = torch.randn_like(p)
+        opt.step()
+        for p in params:
+            assert torch.isfinite(p).all()
 
 # ---------------------------------------------------------------------------
 # Dion2

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -270,6 +270,46 @@ class TestNorDion2:
         torch.testing.assert_close(u_fused, u_ref, atol=1e-5, rtol=1e-5)
         torch.testing.assert_close(v_fused, v_ref, atol=1e-5, rtol=1e-5)
 
+    def test_normalize_selected_stacked_multiple_shapes(self):
+        from dion.nordion2 import nordion2_normalize_selected_stacked
+        from dion.normuon import normuon_normalization_stacked
+
+        # A second distinct shape makes dynamo generalize to dynamic shapes.
+        # PyTorch 2.13's inductor miscompiled the gather/normalize/scatter graph
+        # there, emitting a scatter epilogue that reads a temp defined only
+        # inside the reduction loop body ("NameError: tmp19 is not defined").
+        # cols must stay large: a small reduction compiles as a persistent
+        # (non-looped) kernel, which never had the bug, so shrinking these
+        # shapes would silently defuse this test.
+        # See https://github.com/pytorch/pytorch/issues/194490
+        beta2 = torch.tensor(0.9)
+        for n, rows, cols in [(2, 128, 4096), (2, 64, 4096), (3, 96, 2048)]:
+            k = rows // 2
+            torch.manual_seed(5)
+            u = torch.randn(n, k, cols, device=DEVICE, dtype=torch.bfloat16)
+            v_full = torch.rand(n, rows, 1, device=DEVICE, dtype=torch.bfloat16)
+            indices = torch.stack(
+                [torch.randperm(rows, device=DEVICE)[:k] for _ in range(n)], dim=0
+            )
+
+            u_out, v_out = nordion2_normalize_selected_stacked(
+                u.clone(), v_full.clone(), indices, beta2
+            )
+
+            idx = indices.unsqueeze(-1)
+            v_sel = torch.gather(v_full, dim=-2, index=idx).float()
+            u_ref, v_sel_new = normuon_normalization_stacked(u.clone(), v_sel, beta2)
+            v_ref = v_full.clone()
+            for i in range(n):
+                v_ref[i].scatter_(
+                    dim=-2, index=idx[i], src=v_sel_new[i].to(v_ref.dtype)
+                )
+
+            assert u_out.shape == u.shape
+            assert v_out.shape == v_full.shape
+            torch.testing.assert_close(u_out, u_ref, atol=1e-5, rtol=1e-5)
+            torch.testing.assert_close(v_out, v_ref, atol=1e-5, rtol=1e-5)
+
 # ---------------------------------------------------------------------------
 # Dion2
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #115.

## Problem

`nordion2_normalize_selected_stacked` ran gather + per-row reduction + scatter in a
single compiled graph. On PyTorch 2.13, once a second distinct parameter shape triggers
automatic dynamic-shape generalization, inductor emits a Triton scatter epilogue that
references a temporary defined only inside the preceding `tl.range` reduction body:

```
tmp41 = tl.where(tmp38, tmp40, tmp19)
                               ^
NameError: tmp19 is not defined
```

The first shape compiles fine, so this bites on the *second* shape group of any real
model. Upstream: pytorch/pytorch#194490 — a 2.12 → 2.13 inductor regression (both use
Triton 3.7.1), reported by @WindChimeRan.

Reproduced here on torch 2.13.0+cu130 / H100. Neither FSDP nor multi-GPU is required —
calling the function directly with two shapes in one process is enough. The only call
site is `nordion2_update_megabatch_async`, which is why it surfaces on the sharded path.
I probed the sibling compiled entry points (`normuon_normalization_stacked`,
`dion2_post_orthogonalize`) with two shapes and both pass, so the blast radius is this
one function — the gather+reduce+**scatter** combination is what trips it.

## Fix

Split the scatter into its own compiled graph, making the invalid fusion unreachable.
Dynamic shapes are retained.

## Alternatives considered

`@torch.compile(..., dynamic=False)` also avoids the miscompile and is cheaper per call,
but it recompiles per shape. Driving 10 distinct shapes through the function:

| | compilations | outcome |
|---|---|---|
| `dynamic=False` | one per shape | **hard fail at shape #9** — `FailOnRecompileLimitHit` (`recompile_limit`=8) |
| this PR | 3, then free | survives all 10, 8.0 s total |

That is the #23 failure, so `dynamic=False` would trade this crash for another one on any
model with more than 8 distinct shape groups.

I also tried leaving the scatter in eager (one compiled entry instead of two) to avoid the
second graph's dispatch cost. It is worse: 98 µs of host time vs 91 µs, so it is not used.

## Cost

Measured on two stacks. Summed over every shape group a real model produces
(fraction=0.25), per optimizer step, median of 7x50 iterations on an idle GPU:

| model shape mix | H100 / torch 2.13.0 | B200 / torch 2.12.1 |
|---|---|---|
| ~1.5B (d=2048, ffn=8192, 24L, GQA) | 2438 -> 2015 us (**-17%**) | 1438 -> 1422 us (**-1%**) |
| small (d=768, ffn=3072, 12L) | 224 -> 273 us (+22%) | 290 -> 476 us (+64%) |

The mechanism is the same on both: the extra graph entry costs a flat host-dispatch
overhead -- ~38 us on the H100 box, ~65 us on the cluster nodes (measurable as the floor
that every host-bound shape converges to) -- while the GPU kernels get faster, because not
fusing the scatter into the reduction lets inductor pick a better tiling. Which term wins
depends on whether the call is host-bound or GPU-bound, so the faster the accelerator, the
more shapes fall into the host-bound regime and the less the kernel win shows up. On the
largest group (48, 8192, 2048) the kernel win holds on both: 1294 -> 942 us on H100, and
673 -> 549 us on B200.

Caveat on reading the two columns against each other: hardware and torch version both
differ, so the difference between them is not attributable to hardware alone. Each column
is the relevant one for its own audience -- 2.13 is where the fix is *required* (and where
it is a net win on a 1.5B-shaped model), while 2.12.1 is a stack where the fused path still
works and this change is a small cost.

In absolute terms every number here is under 0.2 ms per step against a step whose host
dispatch `dion/cuda_graph.py` puts at "tens of ms", so the practical impact is well under a
percent either way. `CudaGraphOptimizer` is unaffected -- it disables torch.compile.

I looked at branching (by torch version, or by shape) to keep the fused kernel where it is
safe, and decided against it, though it is a closer call on 2.12 than the H100 numbers alone
suggest. The bug boundary and the perf boundary are different axes: the miscompile needs
cols >~2048 (large enough that inductor emits a looped rather than persistent reduction),
while which variant is faster depends on total work. They conflict -- e.g. (12, 768, 3072)
triggers the bug, so it is forced onto the split path even though fused is faster there --
so a shape branch can only pay off in the small-cols corner, and it would make correctness
depend on an undocumented inductor heuristic that shifts with dtype, config and version; if
that boundary moves, the crash returns in production rather than a slow path. A version
branch would buy back real time on 2.12 (up to ~0.19 ms/step on a small model), but upstream
is still unfixed, so it could only mean "<2.13 uses fused", pinning every future version to
the split path anyway; it would make numerics depend on the torch version; and this file
already carries one version guard that silently does not work (`dion2.py:432` compares
`"2.13.0+cu130" < "2.13"`, which is False by the prefix rule). Given the absolute magnitudes,
one path is the better trade.

## Numerics

Not bit-identical to the fused kernel: `V` is bit-exact, `U` differs by up to 1.9e-6 (fp32
reduction ordering). `test_normalize_selected_stacked_matches_unfused` already compares this
exact decomposition against the fused helper at `atol=rtol=1e-5` and documents why the two
are not expected to match bit-for-bit; the measured difference is well inside that. In effect
this promotes that test's reference implementation to be the implementation.

## Test

`test_normalize_selected_stacked_multiple_shapes` drives three distinct shapes through the
function in one process and checks each against the unfused reference. It fails on unfixed
code with `NameError('tmp18 is not defined')` and passes with this change.

`cols` is deliberately large: I measured that a reduction with `cols <= 1024` compiles as a
persistent (non-looped) kernel and never had the bug, so shrinking these shapes would
silently defuse the test. That is called out in a comment.

## Verification

- `tests/test_optimizers.py` + `tests/test_dion3_alias.py`: 101 passed
- `tests/test_normuon_split_lr.py`: 16 passed on this branch and 16 passed on `origin/main`
  (checked because it failed once under two concurrent GPU test runs; it is contention, not
  a regression — a different parametrization failed each time and it passes serially)
